### PR TITLE
[SUCE-627] meta data in index

### DIFF
--- a/client/elements/sc-page-dictionary.html
+++ b/client/elements/sc-page-dictionary.html
@@ -361,7 +361,9 @@
               document.dispatchEvent(new CustomEvent('sherby-metadata', {
                   detail: {
                       title: `${dictionaryResultsText} ${dictionaryWord}`,
-                      description: description
+                      description: description,
+                      bubbles: true,
+                      composed: true
                   }
               }));
           }

--- a/client/elements/sc-page-dictionary.html
+++ b/client/elements/sc-page-dictionary.html
@@ -355,17 +355,15 @@
           }
 
           _createMetaData(dictionaryWord, localize) {
-              const description = localize('metaDescriptionText').substring(0,120);
-              const twitterDescription = description.substring(0,120);
+              const description = localize('metaDescriptionText');
               const dictionaryResultsText = localize('dictionaryResultsText');
-              return { 
-                'og:title': `${dictionaryResultsText} ${dictionaryWord}`,
-                'og:description': description,
-                'twitter:title': `${dictionaryResultsText} ${dictionaryWord}`,
-                'twitter:description': twitterDescription,
-                title: `${dictionaryResultsText} ${dictionaryWord}`,
-                description: description
-                };
+
+              document.dispatchEvent(new CustomEvent('sherby-metadata', {
+                  detail: {
+                      title: `${dictionaryResultsText} ${dictionaryWord}`,
+                      description: description
+                  }
+              }));
           }
       }
 

--- a/client/elements/sc-page-search.html
+++ b/client/elements/sc-page-search.html
@@ -574,7 +574,9 @@ than ten results in total, a dropdown selection menu appears at the top.
               document.dispatchEvent(new CustomEvent('sherby-metadata', {
                   detail: {
                       title: `${searchResultsText} ${searchWord}`,
-                      description: description
+                      description: description,
+                      bubbles: true,
+                      composed: true
                   }
               }));
           }

--- a/client/elements/sc-page-search.html
+++ b/client/elements/sc-page-search.html
@@ -568,17 +568,15 @@ than ten results in total, a dropdown selection menu appears at the top.
           }
 
           _createMetaData(searchWord, localize) {
-              const description = localize('metaDescriptionText').substring(0,120);
-              const twitterDescription = description.substring(0,120);
+              const description = localize('metaDescriptionText');
               const searchResultsText = localize('searchResultsText');
-              return { 
-                'og:title': `${searchResultsText} ${searchWord}`,
-                'og:description': description,
-                'twitter:title': `${searchResultsText} ${searchWord}`,
-                'twitter:description': twitterDescription,
-                title: `${searchResultsText} ${searchWord}`,
-                description: description
-              };
+
+              document.dispatchEvent(new CustomEvent('sherby-metadata', {
+                  detail: {
+                      title: `${searchResultsText} ${searchWord}`,
+                      description: description
+                  }
+              }));
           }
       }
 

--- a/client/elements/sc-page-selector.html
+++ b/client/elements/sc-page-selector.html
@@ -350,13 +350,12 @@ The page-selector also parses the input-data and loads one of 6 possible page-vi
           }
 
           _createMetaData(localize) {
-              const today = new Date();
-              const keywords = localize('metaKeywords').substring(0,120);
-              return {
-                  keywords: keywords,
-                  cdate: today,
-                  mdate: today
-              };
+              const keywords = localize('metaKeywords');
+              document.dispatchEvent(new CustomEvent('keyword-metadata', {
+                  detail: {
+                      keywords: keywords
+                  }
+              }));
           }
 
           _getPageTitle(title, localize) {

--- a/client/elements/sc-page-selector.html
+++ b/client/elements/sc-page-selector.html
@@ -369,7 +369,9 @@ The page-selector also parses the input-data and loads one of 6 possible page-vi
               const keywords = localize('metaKeywords');
               document.dispatchEvent(new CustomEvent('keyword-metadata', {
                   detail: {
-                      keywords: keywords
+                      keywords: keywords,
+                      bubbles: true,
+                      composed: true
                   }
               }));
           }

--- a/client/elements/sc-page-static.html
+++ b/client/elements/sc-page-static.html
@@ -443,17 +443,14 @@
           }
 
           _createMetaData(pageSelection, localize) {
-              const description = localize('metaDescriptionText').substring(0,120);
-              const twitterDescription = description.substring(0,120);
+              const description = localize('metaDescriptionText');
               const pageName = localize(`${pageSelection}`);
-              return { 
-                'og:title': `SuttaCentral—${pageName.toLowerCase()}`,
-                'og:description': description,
-                'twitter:title': `SuttaCentral—${pageName.toLowerCase()}`,
-                'twitter:description': twitterDescription,
-                title: `SuttaCentral—${pageName.toLowerCase()}`,
-                description: description
-              };
+              document.dispatchEvent(new CustomEvent('sherby-metadata', {
+                  detail: {
+                      title: `SuttaCentral—${pageName.toLowerCase()}`,
+                      description: description
+                  }
+              }));
           }
       }
 

--- a/client/elements/sc-page-static.html
+++ b/client/elements/sc-page-static.html
@@ -448,7 +448,9 @@
               document.dispatchEvent(new CustomEvent('sherby-metadata', {
                   detail: {
                       title: `SuttaCentral—${pageName.toLowerCase()}`,
-                      description: description
+                      description: description,
+                      bubbles: true,
+                      composed: true
                   }
               }));
           }

--- a/client/elements/suttaplex/sc-suttaplex-list.html
+++ b/client/elements/suttaplex/sc-suttaplex-list.html
@@ -246,19 +246,17 @@
               if (!suttaplexReturns) {
                   return;
               }
-              let description = localize('metaDescriptionText').substring(0,120);
+              let description = localize('metaDescriptionText');
               if (suttaplexReturns[0].blurb) {
-                  description = suttaplexReturns[0].blurb.substring(0,120);
+                  description = suttaplexReturns[0].blurb;
               }
-              const twitterDescription = description.substring(0,120);
-              return {
-                'og:title': `${suttaplexReturns[0].original_title}—Suttas and Parallels`,
-                'og:description': description,
-                title: `${suttaplexReturns[0].original_title}—Suttas and Parallels`,
-                description: description,
-                'twitter:title': `${suttaplexReturns[0].original_title}—Suttas and Parallels`,
-                'twitter:description': twitterDescription
-              };
+
+              document.dispatchEvent(new CustomEvent('sherby-metadata', {
+                  detail: {
+                      title: `${suttaplexReturns[0].original_title}—Suttas and Parallels`,
+                      description: description
+                  }
+              }));
           }
       }
 

--- a/client/elements/suttaplex/sc-suttaplex-list.html
+++ b/client/elements/suttaplex/sc-suttaplex-list.html
@@ -254,7 +254,9 @@
               document.dispatchEvent(new CustomEvent('sherby-metadata', {
                   detail: {
                       title: `${suttaplexReturns[0].original_title}—Suttas and Parallels`,
-                      description: description
+                      description: description,
+                      bubbles: true,
+                      composed: true
                   }
               }));
           }

--- a/client/elements/text/sc-text-page-selector.html
+++ b/client/elements/text/sc-text-page-selector.html
@@ -291,7 +291,9 @@
               document.dispatchEvent(new CustomEvent('sherby-metadata', {
                   detail: {
                       title: `${title}—${author}`,
-                      description: description
+                      description: description,
+                      bubbles: true,
+                      composed: true
                   }
               }));
           }

--- a/client/elements/text/sc-text-page-selector.html
+++ b/client/elements/text/sc-text-page-selector.html
@@ -281,21 +281,19 @@
               if (!responseData) {
                   return;
               }
-              let description = localize('metaDescriptionText').substring(0,120);
+              let description = localize('metaDescriptionText');
               if (responseData.suttaplex.blurb) {
-                  description = responseData.suttaplex.blurb.substring(0,120);
+                  description = responseData.suttaplex.blurb;
               }
-              const twitterDescription = description.substring(0,120);
               const title = responseData.translation ? responseData.translation.title : responseData.root_text.title;
               const author = responseData.translation ? responseData.translation.author : responseData.root_text.author;
-              return {
-                'og:title': `${title}—${author}`,
-                'og:description': description,
-                title: `${title}—${author}`,
-                description: description,
-                'twitter:title': `${title}—${author}`,
-                'twitter:description': twitterDescription
-              };
+
+              document.dispatchEvent(new CustomEvent('sherby-metadata', {
+                  detail: {
+                      title: `${title}—${author}`,
+                      description: description
+                  }
+              }));
           }
       }
 

--- a/client/index.html
+++ b/client/index.html
@@ -15,7 +15,10 @@
 
   <!-- Search Engine -->
   <meta name="title" content="SuttaCentral">
+  <meta name="description" content="Early Buddhist texts from the Tipitaka (Tripitaka). Suttas (sutras) with the Buddha's teachings on mindfulness, insight, wisdom, and meditation.">
   <meta name="image" content="https://i.vimeocdn.com/portrait/23756910_500x500.jpg">
+  <meta name="keywords" content="Buddha, Buddhism, Buddhist, sutta, sutra, tipitaka, tripitaka, wisdom, teaching, mindfulness, meditation, scripture, canon, Pali, Sanskrit, Tibetan, Chinese, insight, vipassana">
+
   <!-- Schema.org for Google -->
   <meta itemprop="name" content="SuttaCentral">
   <meta itemprop="description"
@@ -24,11 +27,13 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="SuttaCentral">
+  <meta name="twitter:description" content="Early Buddhist texts from the Tipitaka (Tripitaka). Suttas (sutras) with the Buddha's teachings.">
   <meta name="twitter:player" content="https://player.vimeo.com/video/257038431">
   <meta name="twitter:image:alt" content="SuttaCentral">
 
   <!-- Open Graph general (Facebook, Pinterest & Google+) -->
   <meta property="og:title" content="SuttaCentral">
+  <meta property="og:description" content="Early Buddhist texts from the Tipitaka (Tripitaka). Suttas (sutras) with the Buddha's teachings on mindfulness, insight, wisdom, and meditation.">
   <meta property="og:image"
         content="https://raw.githubusercontent.com/suttacentral/suttacentral/development/client/img/social_image.png">
   <meta property="og:url" content="https://next.suttacentral.net/">
@@ -199,6 +204,25 @@
         document.querySelector('.logo-image-container').appendChild(logoImg);
         removeSiteContent();
     }
+    document.addEventListener("sherby-metadata", function(e) {
+        var metaData = e.detail;
+        if (metaData) {
+            document.head.querySelector("[property='og:title']").content = metaData.title;
+            document.head.querySelector("[property='og:description']").content = metaData.description;
+            document.head.querySelector("[name='title']").content = metaData.title;
+            document.head.querySelector("[name='description']").content = metaData.description;
+            document.head.querySelector("[name='twitter:title']").content = metaData.title;
+            document.head.querySelector("[name='twitter:description']").content = metaData.description.substring(0,120);
+            document.head.querySelector("[itemprop='name']").content = metaData.title;
+            document.head.querySelector("[itemprop='description']").content = metaData.description;
+        }
+    });
+    document.addEventListener("keyword-metadata", function(e) {
+        var metaData = e.detail;
+        if (metaData) {
+            document.head.querySelector("[name='keywords']").content = metaData.keywords;
+        }
+    });
 </script>
 
 <noscript>


### PR DESCRIPTION
This fires an event that changes the meta data in index.html. It works well in Console but when I do "view-page-source' it changes it back to default settings so not sure how twitter/fb will react to this but we can try. If this fails, I have no idea.
Actually, if this works we don't need the Sherby-metadata element so I will take it out but lets test first.