### PR TITLE
Fixed typo in regex and rearranged the headers. 

### DIFF
--- a/nginx/conf.d/prod.nginx.conf
+++ b/nginx/conf.d/prod.nginx.conf
@@ -1,30 +1,6 @@
 # don't send the nginx version number in error pages and Server header
 server_tokens off;
 
-# config to don't allow the browser to render the page inside an frame or iframe
-# and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
-add_header X-Frame-Options SAMEORIGIN;
-
-# Avoid clickjacking
-add_header X-Content-Type-Options nosniff;
-
-# Disable content-type sniffing on some browsers
-add_header X-Frame-Options SAMEORIGIN;
-
-# Enable the Cross-site scripting (XSS) filter
-add_header X-XSS-Protection "1; mode=block";
-
-# with Content Security Policy (CSP) enabled(and a browser that supports it(http://caniuse.com/#feat=contentsecuritypolicy),
-# you can tell the browser that it can only download content from the domains you explicitly allow
-# http://www.html5rocks.com/en/tutorials/security/content-security-policy/
-# https://www.owasp.org/index.php/Content_Security_Policy
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' data: about: 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://www.google-analytics.com https://js.stripe.com; img-src 'self' data: https://legacy.suttacentral.net https://suttacentral.net www.google-analytics.com; connect-src 'self' https://api.stripe.com https://js.stripe.com; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src about: https://www.google.com https://js.stripe.com https://player.vimeo.com; object-src 'none'; media-src 'self' http://player.vimeo.com";
-
-# config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
-# to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
-# also https://hstspreload.org/
-add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
-
 map $http_user_agent $outdated {
     default                                 0;
     "~MSIE [1-9]\."                         1;
@@ -47,11 +23,11 @@ map $http_user_agent $outdated {
 # on user-agent. These numbers should be increased once the site stabalizes.
 map $uri $cache_control {
     default                         "private, max-age=86400";
-    "~\.(?:manifest|appcache)|service-worker.js"  "s-max-age=86400, max-age=0";
-    "~\.(?:jpg|webm|woff|woff2|png)"  "public, s-maxage=31104000, max-age=31104000";
-    "~/api|localization|files/"                  "public, s-maxage=604800, max-age=86400";
+    "~/api|localization|files/"     "public, s-maxage=604800, max-age=86400";
 }
 
+# It's important to note that in Nginx configs add_header will only
+# apply if there is no lower level add_headers
 add_header Cache-Control $cache_control;
 
 server {
@@ -65,25 +41,58 @@ server {
 
     if ($outdated = 0){
         set $serve_dir /opt/sc/static/build/default;
+        
+        # HTTP2 push header for Cloudflare
+        # https://blog.cloudflare.com/http-2-server-push-with-multiple-assets-per-link-header/
+        # this seriously confuses Safari 10 so only set it for modern browsers.
+        set prefetch_link "</elements/sc-drawer-layout.html>; rel=preload; as=document,</web-components-loader.js>; rel=preload; as=script";
     }
+    
     if ($outdated = 1){
         set $serve_dir /opt/sc/static/build/es5-bundled;
+        set prefetch_link "";
     }
 
-    location ~* (\.(?:manifest|appcache|html?|xml|json)|service-worker.js)$ {
-      root $serve_dir;
+    location ~* (\.(?:manifest|appcache)|service-worker.js)$ {
+        add_header Cache-Control "public, s-maxage=7200, max-age=0";
+        root $serve_dir;      
     }
 
     location ~* \.(ico|css|js|gif|svg|webp|woff2|jpe?g|png)$ {
         access_log off;
+        add_header Cache-Control "public, s-maxage=31104000, max-age=31104000";
         root $serve_dir;
     }
 
     location / {
+    
+        # don't allow the browser to render the page inside an frame or iframe
+        # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
+        add_header X-Frame-Options SAMEORIGIN;
 
-        # HTTP2 push header for Cloudflare
-        # https://blog.cloudflare.com/http-2-server-push-with-multiple-assets-per-link-header/
-        add_header Link "</elements/sc-drawer-layout.html>; rel=preload; as=document,</web-components-loader.js>; rel=preload; as=script";
+        # Avoid clickjacking
+        add_header X-Content-Type-Options nosniff;
+
+        # Disable content-type sniffing on some browsers
+        add_header X-Frame-Options SAMEORIGIN;
+
+        # Enable the Cross-site scripting (XSS) filter
+        add_header X-XSS-Protection "1; mode=block";
+
+        # with Content Security Policy (CSP) enabled(and a browser that supports it(http://caniuse.com/#feat=contentsecuritypolicy),
+        # you can tell the browser that it can only download content from the domains you explicitly allow
+        # http://www.html5rocks.com/en/tutorials/security/content-security-policy/
+        # https://www.owasp.org/index.php/Content_Security_Policy
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' data: about: 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://www.google-analytics.com https://js.stripe.com; img-src 'self' data: https://legacy.suttacentral.net https://suttacentral.net www.google-analytics.com; connect-src 'self' https://api.stripe.com https://js.stripe.com; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src about: https://www.google.com https://js.stripe.com https://player.vimeo.com; object-src 'none'; media-src 'self' http://player.vimeo.com";
+
+        # config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
+        # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
+        # also https://hstspreload.org/
+        add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+        
+        add_header Cache-Control $cache_control;
+        
+        add_header Link prefetch_link;
 
         alias $serve_dir;
 


### PR DESCRIPTION
Headers in Nginx ain't easy because only the headers in the lowest block apply. The prefetch header, when applied, caused the other headers to not be applied. Also the prefetch header confuses Safari 10 and the site not work.