### PR TITLE
Largely reverted to earlier version, and then fixed it, the primary fix

### DIFF
--- a/nginx/conf.d/prod.nginx.conf
+++ b/nginx/conf.d/prod.nginx.conf
@@ -23,11 +23,11 @@ map $http_user_agent $outdated {
 # on user-agent. These numbers should be increased once the site stabalizes.
 map $uri $cache_control {
     default                         "private, max-age=86400";
-    "~/api|localization|files/"     "public, s-maxage=604800, max-age=86400";
+    "~\.(?:manifest|appcache)|service-worker.js"  "s-max-age=86400, max-age=0";
+    "~\.(?:jpg|webm|woff|woff2|png)"  "public, s-maxage=31104000, max-age=31104000";
+    "~/api|localization|files/"                  "public, s-maxage=604800, max-age=86400";
 }
 
-# It's important to note that in Nginx configs add_header will only
-# apply if there is no lower level add_headers
 add_header Cache-Control $cache_control;
 
 server {
@@ -41,32 +41,28 @@ server {
 
     if ($outdated = 0){
         set $serve_dir /opt/sc/static/build/default;
-        
-        # HTTP2 push header for Cloudflare
-        # https://blog.cloudflare.com/http-2-server-push-with-multiple-assets-per-link-header/
-        # this seriously confuses Safari 10 so only set it for modern browsers.
-        set prefetch_link "</elements/sc-drawer-layout.html>; rel=preload; as=document,</web-components-loader.js>; rel=preload; as=script";
+        set $prefetch_link "</elements/sc-drawer-layout.html>; rel=preload; as=document,</web-components-loader.js>; rel=preload; as=script";
     }
-    
     if ($outdated = 1){
         set $serve_dir /opt/sc/static/build/es5-bundled;
-        set prefetch_link "";
+        set $prefetch_link "";
     }
 
-    location ~* (\.(?:manifest|appcache)|service-worker.js)$ {
-        add_header Cache-Control "public, s-maxage=7200, max-age=0";
-        root $serve_dir;      
+    location ~* (\.(?:manifest|appcache|html?|xml|json)|service-worker.js)$ {
+      root $serve_dir;
     }
 
     location ~* \.(ico|css|js|gif|svg|webp|woff2|jpe?g|png)$ {
         access_log off;
-        add_header Cache-Control "public, s-maxage=31104000, max-age=31104000";
         root $serve_dir;
     }
 
     location / {
-    
-        # don't allow the browser to render the page inside an frame or iframe
+        # HTTP2 push header for Cloudflare
+        # https://blog.cloudflare.com/http-2-server-push-with-multiple-assets-per-link-header/
+        add_header Link $prefetch_link;
+
+        # config to don't allow the browser to render the page inside an frame or iframe
         # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
         add_header X-Frame-Options SAMEORIGIN;
 
@@ -89,10 +85,6 @@ server {
         # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
         # also https://hstspreload.org/
         add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
-        
-        add_header Cache-Control $cache_control;
-        
-        add_header Link prefetch_link;
 
         alias $serve_dir;
 


### PR DESCRIPTION
being that Content Security Policy is now set on the initial response,
instead of every response EXCEPT the first response which I'm pretty
sure was exactly the wrong behavior.