### PR TITLE
Hopefully fix issue with Runtime error

### DIFF
--- a/server/server/search/texts.py
+++ b/server/server/search/texts.py
@@ -109,14 +109,12 @@ class TextIndexer(ElasticIndexer):
         return boost
 
     def yield_po_texts(self, lang, size, to_add):
-        po_texts = get_db().aql.execute(
+        po_texts = list(get_db().aql.execute(
             PO_TEXTS_BY_LANG,
-            bind_vars={'lang': lang},
-            count=True
-        )
+            bind_vars={'lang': lang}
+        ))
 
-        count = po_texts.count()
-        if not count:
+        if not po_texts:
             return
 
         chunk = []
@@ -160,14 +158,12 @@ class TextIndexer(ElasticIndexer):
             yield chunk
 
     def yield_html_texts(self, lang, size, to_add):
-        html_texts = get_db().aql.execute(
+        html_texts = list(get_db().aql.execute(
             TEXTS_BY_LANG,
-            bind_vars={'lang': lang},
-            count=True
-        )
+            bind_vars={'lang': lang}
+        ))
 
-        count = html_texts.count()
-        if not count:
+        if not html_texts:
             return
 
         chunk = []


### PR DESCRIPTION
This error seems to happen when the arango cursor times out, once
upon a time the texts were actually stored in arangoDB so keeping
the cursor open made sense to reduce memory use.

Now only the paths are stored in arango, so there's no reason to not
fetch all the results immediately and close the cursor.