### PR TITLE
SUCE-1370 3-letter languages not showing

### DIFF
--- a/client/elements/suttaplex/card/sc-suttaplex.js
+++ b/client/elements/suttaplex/card/sc-suttaplex.js
@@ -63,7 +63,7 @@ class SCSuttaplex extends LitLocalized(LitElement) {
       const translations = (this.item || {}).translations || [];
       const lang = this.language;
       this._translationsInUserLanguage = translations.filter(item => item.lang === lang);
-      this.translationsInModernLanguages = translations.filter(item => item.lang.length === 2 && item.lang !== lang);
+      this.translationsInModernLanguages = translations.filter(item => !item.is_root && item.lang !== lang);
       this.rootTexts = translations.filter(item => item.is_root);
       this.hasSegmentedTexts = translations.filter(item => item.segmented).length > 0;
     }


### PR DESCRIPTION
I just noticed this small error why the japanese and other 3-letter language code texts were not showing. Not sure how the procudure is right now.