### PR TITLE
 Apply pseudo-icons for languages in navagation menu and language dropdown menu

### DIFF
--- a/client/elements/addons/localization-mixin.js
+++ b/client/elements/addons/localization-mixin.js
@@ -64,7 +64,7 @@ export const Localized = base => class extends base {
     this.languageLoaded();
   }
 
-  async __loadLanguage(lang) {
+  async __loadLanguage(lang) {    
     if (SUPPORTED_TRANSLATIONS.includes(lang)) {
       const path = `${this.localizedStringsPath}/${lang}.json`;
 
@@ -160,4 +160,8 @@ export const LitLocalized = base => class extends connect(store)(base) {
       return Promise.resolve({});
     }
   }
+
+  LoadFallbackLanguage() {
+    this.__siteLanguageChanged(FALLBACK_LANGUAGE);
+  }    
 };

--- a/client/elements/menus/navigation-menu/sc-navigation-menu-css.js
+++ b/client/elements/menus/navigation-menu/sc-navigation-menu-css.js
@@ -310,5 +310,34 @@ ${litScrollbarStyle}
     text-overflow: ellipsis;
     overflow: hidden;
   }
+
+  [data-iso]::before {
+    content: attr(data-iso);
+      background-color:var(--sc-disabled-text-color);
+      color: var(--sc-tertiary-text-color);
+      font-weight: 800;
+      width: var(--sc-size-md-larger);
+      height: 20px;
+      line-height: 20px;
+      text-transform: uppercase;
+      display: inline-block;
+      text-align: center;
+      font-size:11px;
+      position:absolute;
+      margin-top:1px;
+      margin-left: -40px;
+      --notchSize: 4px;
+      clip-path: 
+      polygon(
+        0% var(--notchSize), 
+        var(--notchSize) 0%, 
+        calc(100% - var(--notchSize)) 0%, 
+        100% var(--notchSize), 
+        100% calc(100% - var(--notchSize)), 
+        calc(100% - var(--notchSize)) 100%, 
+        var(--notchSize) 100%, 
+        0% calc(100% - var(--notchSize))
+      );
+  }  
 </style>`;
 

--- a/client/elements/menus/navigation-menu/sc-navigation-menu.js
+++ b/client/elements/menus/navigation-menu/sc-navigation-menu.js
@@ -267,7 +267,7 @@ class SCNavigationMenu extends LitLocalized(LitElement) {
               <a class="nav-link link-text-ellipsis" title="${childItem.name}"
                 style="${this.calculateSubmenuChildrenStyle(menuLevel)}"
                 href="${this.getSuttaplexUrl(childItem.id)}"
-                data-iso="${this.getLanguageName(childItem.lang_iso)}"></a>>
+                data-iso="${this.getLanguageName(childItem.lang_iso)}">
                 ${this.getPrefixedItemName(childItem.name, childItem.display_num)}
               </a>              
             ` : html`

--- a/client/elements/menus/navigation-menu/sc-navigation-menu.js
+++ b/client/elements/menus/navigation-menu/sc-navigation-menu.js
@@ -5,7 +5,6 @@ import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/paper-spinner/paper-spinner-lite.js';
 import { API_ROOT } from '../../../constants';
 
-import '../../../img/sc-language-icons.js';
 import { LitLocalized } from '../../addons/localization-mixin';
 import { scNavigationMenuCss } from './sc-navigation-menu-css';
 
@@ -131,8 +130,8 @@ class SCNavigationMenu extends LitLocalized(LitElement) {
     return this.unclickableMenuItems.includes(uid) ? '' : `/${uid}`;
   }
 
-  getLanguageIconName(isoCode) {
-    return `sc-language-icons:${isoCode}`;
+  getLanguageName(isoCode) {
+    return `${isoCode}`;
   }
 
   getPrefixedItemName(name, num) {
@@ -146,17 +145,14 @@ class SCNavigationMenu extends LitLocalized(LitElement) {
   render() {
     return html`
       ${scNavigationMenuCss}
-
       <div id="container" class="nav-list-container">
         ${this.loading ? this.spinnerTemplate : ''}
         ${this.hasError() ? this.errorTemplate : ''}
-
         <nav class="sc-nav">
           <div id="sub_navigation_header" class="nav-back-button swap-section up ${this.isChildMenu ? 'active' : ''}" title="${this.localize('goBack')}">
             <paper-icon-button id="back_arrow" icon="sc-iron-icons:arrow-back" @click="${this.closeChildMenu}"></paper-icon-button>
             <a class="nav-back-title" href="${this.headerHref}">${this.headerTitle}</a>
           </div>
-
           <div id="sub_navigation" class="sub-nav-container swap-section right open ${this.isChildMenu ? 'active' : ''}" data-menuid="${this.subMenuId}">
             ${this.isChildMenu && this.childMenuData.length ? this.getChildMenuTemplate(this.childMenuData[0], 0) : ''}
           </div>
@@ -193,14 +189,14 @@ class SCNavigationMenu extends LitLocalized(LitElement) {
             <ul class="nav-secondary">
               ${topLevelItem.children.map(groupingLevelItem => html`
                 <li class="nav-menu-item ${groupingLevelItem.yellow_brick_road ? 'yellow-brick' : ''}">
-                  <span class="nav-link">${groupingLevelItem.name}</span>
-    
+                      
                   ${groupingLevelItem.lang_iso ? html`
-                    <iron-icon class="iso-code-image" title="${groupingLevelItem.lang_name}"
-                      icon="${this.getLanguageIconName(groupingLevelItem.lang_iso)}">
-                    </iron-icon>
-                  ` : ''}
-                  
+                    <span class="nav-link" data-iso="${this.getLanguageName(groupingLevelItem.lang_iso)}">
+                      ${groupingLevelItem.name}
+                    </span>
+                  ` : html`<span class="nav-link">${groupingLevelItem.name}</span>`
+                  }
+
                   ${groupingLevelItem.children.length > 0 ? html`
                     ${this.expandMoreButtonTemplate}
                     ${this.deepMainMenuLevelsTemplate(groupingLevelItem, (topLevelItem.name === 'Sutta'))}
@@ -224,20 +220,24 @@ class SCNavigationMenu extends LitLocalized(LitElement) {
           ${item.children.map(childItem => html`
             <li class="nav-menu-item ${this.selectedItemId === childItem.id || this.parentId === childItem.id ? 'selected' : ''} ${childItem.yellow_brick_road ? 'yellow-brick' : ''}">
               ${listType === 'nav-secondary' ? html`
-                <span class="nav-link">${childItem.name}</span>
-                ${childItem.lang_iso ? html`
-                  <iron-icon class="iso-code-image" title="${childItem.lang_name}"
-                    icon="${this.getLanguageIconName(childItem.lang_iso)}"></iron-icon>
-                ` : ''}
-              ` : html`
-                <a class="nav-link link-text-ellipsis" title="${childItem.name}"
-                   href="${this.getSuttaplexUrl(childItem.id)}">
-                  ${childItem.name}
-                </a>
-                ${childItem.lang_iso ? html`
-                  <iron-icon class="iso-code-image" title="${childItem.lang_name}"
-                    icon="${this.getLanguageIconName(childItem.lang_iso)}"></iron-icon>
-                ` : ''}
+                
+                ${childItem.lang_iso ? html`                  
+                  <span class="nav-link" data-iso="${this.getLanguageName(childItem.lang_iso)}">${childItem.name}</span>
+                ` : html`
+                  <span class="nav-link">${childItem.name}</span>`}
+                ` : html`
+                  ${childItem.lang_iso ? html`                  
+                    <a class="nav-link link-text-ellipsis" title="${childItem.name}"
+                      href="${this.getSuttaplexUrl(childItem.id)}"
+                      data-iso="${this.getLanguageName(childItem.lang_iso)}">
+                      ${childItem.name}
+                    </a>                    
+                  ` : html`
+                    <a class="nav-link link-text-ellipsis" title="${childItem.name}"
+                      href="${this.getSuttaplexUrl(childItem.id)}">
+                      ${childItem.name}
+                    </a>                  
+                  `}                
               `}
               
               ${childItem.children && childItem.children.length > 0 ? html`
@@ -264,17 +264,19 @@ class SCNavigationMenu extends LitLocalized(LitElement) {
             @click="${() => this.selectChildItem(menuItem)}"
           >
             ${childItem.lang_iso ? html`
-              <iron-icon class="iso-code-image"
-                title="${childItem.lang_name}" icon="${this.getLanguageIconName(childItem.lang_iso)}">
-              </iron-icon>
-            ` : ''}
-
-            <a class="nav-link link-text-ellipsis" title="${childItem.name}"
-               style="${this.calculateSubmenuChildrenStyle(menuLevel)}"
-               href="${this.getSuttaplexUrl(childItem.id)}">
-              ${this.getPrefixedItemName(childItem.name, childItem.display_num)}
-            </a>
-
+              <a class="nav-link link-text-ellipsis" title="${childItem.name}"
+                style="${this.calculateSubmenuChildrenStyle(menuLevel)}"
+                href="${this.getSuttaplexUrl(childItem.id)}"
+                data-iso="${this.getLanguageName(childItem.lang_iso)}"></a>>
+                ${this.getPrefixedItemName(childItem.name, childItem.display_num)}
+              </a>              
+            ` : html`
+              <a class="nav-link link-text-ellipsis" title="${childItem.name}"
+                  style="${this.calculateSubmenuChildrenStyle(menuLevel)}"
+                  href="${this.getSuttaplexUrl(childItem.id)}">
+                  ${this.getPrefixedItemName(childItem.name, childItem.display_num)}
+              </a>                          
+            `}            
             ${childItem.children && childItem.children.length > 0 ? html`
               ${this.expandMoreButtonTemplate}
               ${this.getChildMenuTemplate(childItem, menuLevel + 1)}

--- a/client/elements/menus/sc-language-base-menu-css.js
+++ b/client/elements/menus/sc-language-base-menu-css.js
@@ -76,10 +76,10 @@ export const languageBaseMenuCss = html`
         var(--notchSize) 100%, 
         0% calc(100% - var(--notchSize))
       );
-    }
+  }
 
-  #jpn::before, #sld::before, #kln::before{
+  #jpn::after, #sld::after, #kln::after{
     letter-spacing: 0;
-    font-size: 12px
+    font-size: 11px
   }    
 </style>`;

--- a/client/elements/menus/sc-language-base-menu-css.js
+++ b/client/elements/menus/sc-language-base-menu-css.js
@@ -2,56 +2,82 @@ import { html } from '@polymer/lit-element';
 
 export const languageBaseMenuCss = html`
 <style>
-      :host {
-        --primary-color: var(--sc-primary-color);
-        --paper-menu-button-content: {
-          display: block;
-        };
-      }
+  :host {
+    --primary-color: var(--sc-primary-color);
+    --paper-menu-button-content: {
+      display: block;
+    };
+  }
 
-      .language-menu-dropdown {
-        @apply --sc-skolar-font-size-md;
-        background-color: transparent;
-        --paper-input-container-focus-color: var(--sc-primary-accent-color);
-        --paper-dropdown-menu-icon: {
-          color: var(--sc-disabled-text-color);
-        };
-        --paper-dropdown-menu-input: {
-          --paper-input-container-input-color: var(--sc-primary-text-color);
-          --paper-input-container-color: var(--sc-secondary-text-color);
-        };
-        --paper-menu-button-dropdown: {
-          @apply --sc-shadow-elevation-9dp;
-          width: 180px;
-          background-color: var(--sc-secondary-background-color);
-        };
-      }
+  .language-menu-dropdown {
+    @apply --sc-skolar-font-size-md;
+    background-color: transparent;
+    --paper-input-container-focus-color: var(--sc-primary-accent-color);
+    --paper-dropdown-menu-icon: {
+      color: var(--sc-disabled-text-color);
+    };
+    --paper-dropdown-menu-input: {
+      --paper-input-container-input-color: var(--sc-primary-text-color);
+      --paper-input-container-color: var(--sc-secondary-text-color);
+    };
+    --paper-menu-button-dropdown: {
+      @apply --sc-shadow-elevation-9dp;
+      width: 180px;
+      background-color: var(--sc-secondary-background-color);
+    };
+  }
 
-      .language-menu-list {
-        background-color: var(--sc-secondary-background-color);
-      }
+  .language-menu-list {
+    background-color: var(--sc-secondary-background-color);
+  }
+  
+  .language-menu-paper-item {
+    @apply --sc-skolar-font-size-md;
+    color: var(--sc-primary-text-color); 
+    /*19px for the icon, 16px for the margin */
+    --paper-item-icon-width: calc(var(--sc-size-language-icon) + var(--sc-size-md));
+  }
 
-      .iso-code-image {
-        fill: var(--sc-disabled-text-color);
-        margin-top: var(--sc-size-xs);
-        width: var(--sc-size-language-icon);
-        height: var(--sc-size-language-icon);
-      }
+  .language-menu-paper-item:hover {
+    background-color: var(--sc-tertiary-background-color);
+    cursor: pointer;
+  }
 
-      .language-menu-paper-item {
-        @apply --sc-skolar-font-size-md;
-        color: var(--sc-primary-text-color);
-        /*19px for the icon, 16px for the margin */
-        --paper-item-icon-width: calc(var(--sc-size-language-icon) + var(--sc-size-md));
-      }
+  .language-name {
+    padding-top: var(--sc-size-xxs);        
+  }
 
-      .language-menu-paper-item:hover {
-        background-color: var(--sc-tertiary-background-color);
-        cursor: pointer;
-      }
+  .language-menu-paper-item::after {
+    content: attr(id);
+    background-color:var(--sc-disabled-text-color);
+    color: var(--sc-tertiary-text-color);
+    font-weight: 800;
+    width: var(--sc-size-md-larger);        
+    height: 20px;
+    line-height: 20px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    display: inline-block;
+    text-align: center;
+    font-size:14px;
+    position:absolute;
+    margin-top:1px;                
+    --notchSize: 4px;        
+    clip-path: 
+      polygon(
+        0% var(--notchSize), 
+        var(--notchSize) 0%, 
+        calc(100% - var(--notchSize)) 0%, 
+        100% var(--notchSize), 
+        100% calc(100% - var(--notchSize)), 
+        calc(100% - var(--notchSize)) 100%, 
+        var(--notchSize) 100%, 
+        0% calc(100% - var(--notchSize))
+      );
+    }
 
-      .language-name {
-        padding-top: var(--sc-size-xxs);
-      }
-</style>
-`;
+  #jpn::before, #sld::before, #kln::before{
+    letter-spacing: 0;
+    font-size: 12px
+  }    
+</style>`;

--- a/client/elements/menus/sc-language-base-menu-css.js
+++ b/client/elements/menus/sc-language-base-menu-css.js
@@ -46,7 +46,9 @@ export const languageBaseMenuCss = html`
   .language-name {
     padding-top: var(--sc-size-xxs);        
   }
-
+   /* This is an illogical solution, but the results are in line with expectations.
+   It should be “language-menu-paper-item::before”, but it produces unexpected results, 
+   using “language-menu-paper-item::after” instead obtains the expected results. */
   .language-menu-paper-item::after {
     content: attr(id);
     background-color:var(--sc-disabled-text-color);

--- a/client/elements/menus/sc-language-base-menu.js
+++ b/client/elements/menus/sc-language-base-menu.js
@@ -7,7 +7,6 @@ import '@polymer/paper-item/paper-item-body.js';
 import '@polymer/paper-listbox/paper-listbox.js';
 
 import { API_ROOT } from '../../constants.js';
-import '../../img/sc-language-icons.js';
 import { store } from '../../redux-store';
 import { LitLocalized } from '../addons/localization-mixin';
 import { languageBaseMenuCss } from './sc-language-base-menu-css';
@@ -71,9 +70,6 @@ class LanguageBaseMenu extends LitLocalized(LitElement) {
   languageTemplate(language) {
     return html`
       <paper-icon-item class="language-menu-paper-item" id="${language.uid}">
-        <iron-icon class="iso-code-image" title="${language.name}" slot="item-icon" icon="sc-language-icons:${language.iso_code}">
-        </iron-icon>
-
         <paper-item-body>
           <div class="language-name">${language.name}</div>
         </paper-item-body>

--- a/client/elements/sc-static-page-selector.js
+++ b/client/elements/sc-static-page-selector.js
@@ -9,7 +9,7 @@ import { Localized } from "./addons/localization-mixin.js";
 
 class SCStaticPageSelector extends ReduxMixin(Localized(PolymerElement)) {
   static get template() {
-    return html`
+    return html`    
     <style>
       app-toolbar {
         background-color: var(--sc-primary-color);
@@ -37,6 +37,25 @@ class SCStaticPageSelector extends ReduxMixin(Localized(PolymerElement)) {
         margin-bottom: 24px;
         margin-top: 0;
         text-align: center;
+      }
+
+      [lang="ar"],
+      [lang="si"],
+      [lang="fa"],
+      [lang="he"],
+      [lang="hi"],
+      [lang="vi"],
+      [lang="jpn"],
+      [lang="lzh"],
+      [lang="zh"],
+      [lang="mr"],
+      [lang="my"],
+      [lang="ta"],
+      [lang="th"],
+      [lang="xct"],
+      [lang="ko"],
+      [lang="bn"] {
+        font-synthesis: none;
       }
 
       .title {
@@ -151,7 +170,7 @@ class SCStaticPageSelector extends ReduxMixin(Localized(PolymerElement)) {
     </style>
 
     [[_createMetaData(selectedPage, localize)]]
-
+    
     <app-toolbar id="title_toolbar">
       <div class="title" main-title="">
         <span class="title-text">
@@ -162,7 +181,7 @@ class SCStaticPageSelector extends ReduxMixin(Localized(PolymerElement)) {
     </app-toolbar>
     <app-toolbar id="subtitle_toolbar">
       <div class="title" main-title="">
-        <p class="subtitle">{{localize('pageSubtitle')}}</p>
+        <p class="subtitle" lang="{{language}}">{{localize('pageSubtitle')}}</p>
       </div>
     </app-toolbar>
     <app-toolbar id="nav_toolbar" bottom-item="">

--- a/client/elements/static/numbering-page.js
+++ b/client/elements/static/numbering-page.js
@@ -4,8 +4,14 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { staticStyles } from '../styles/static-styles.js';
 import { SCStaticPage } from '../addons/sc-static-page.js';
 
-
 class SCNumberingPage extends SCStaticPage {
+
+  firstUpdated(changedProperties) {
+    if (this.localize('LocalizationEnabled') && this.localize('LocalizationEnabled') === "false"){                  
+      this.LoadFallbackLanguage();
+    }
+  }
+
   render() {
     return html`
     ${staticStyles}

--- a/client/elements/text/sc-segmented-text.js
+++ b/client/elements/text/sc-segmented-text.js
@@ -466,7 +466,7 @@ class SCSegmentedText extends SCTextPage {
   _insertSecondaryTextSegment([key, content]) {
     if (!key.startsWith('_')) {
       const subkey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');      
-      let segment = this.$.segmented_text_content.querySelector(`#${subkey}`);
+      const segment = this.$.segmented_text_content.querySelector(`#${subkey}`);
       const newSegment = document.createElement('sc-seg');
       newSegment.id = key;
       newSegment.classList.add('original-text');
@@ -477,43 +477,55 @@ class SCSegmentedText extends SCTextPage {
       }
       else{                
         this.translatedSutta.strings[key] = "";
-
-        let rootSuttaLastkey = "";
-        for (var keyname in this.rootSutta.strings){     
-          rootSuttaLastkey = keyname;
-        }  
-        
-        let sectionId = `#rootSutta-sc${key.split(':')[1].split('.')[0]}`;
-        let rootSuttaSection = this.$.segmented_text_content.querySelector(sectionId);        
-        if (!rootSuttaSection){          
-          const newSection = document.createElement('p');
-          newSection.id = `rootSutta-sc${key.split(':')[1].split('.')[0]}`;                
-          const articleElement = this.$.segmented_text_content.getElementsByTagName('article')[0];          
-          if (articleElement) articleElement.appendChild(newSection);            
-        }        
-        
-        const newTranslatedSegment = document.createElement('sc-seg');
-        newTranslatedSegment.id = key;
-        newTranslatedSegment.classList.add('translated-text');
-        this._setScriptISOCode(newTranslatedSegment, this.translationLang);     
-
-        if (key !== rootSuttaLastkey){          
-          rootSuttaSection = this.$.segmented_text_content.querySelector(sectionId);        
-          rootSuttaSection.appendChild(newTranslatedSegment);            
-          let segment = this.$.segmented_text_content.querySelector(`#${subkey}`);
-          segment.parentNode.insertBefore(newSegment, segment.nextSibling);       
-        } else {
-          const newEndSectionP = document.createElement('p');        
-          newEndSectionP.classList.add('endsection');
-          const articleElement = this.$.segmented_text_content.getElementsByTagName('article')[0];          
-          if (articleElement) articleElement.appendChild(newEndSectionP);
-
-          const endsection = this.$.segmented_text_content.querySelector('.endsection');
-          endsection.appendChild(newTranslatedSegment);
-          endsection.appendChild(newSegment);          
-        }            
+        this.addRootAndTranslatedSegment(key, subkey, newSegment);            
       }            
     }
+  }
+
+  addRootAndTranslatedSegment(key, subkey, newSegment) {
+    let { rootSuttaSection, sectionId } = this.addRootSuttaSection(key);
+
+    const newTranslatedSegment = document.createElement('sc-seg');
+    newTranslatedSegment.id = key;
+    newTranslatedSegment.classList.add('translated-text');
+    this._setScriptISOCode(newTranslatedSegment, this.translationLang);
+
+    var rootSuttaLastkey = Object.keys(this.rootSutta.strings).sort().pop();
+    if (key !== rootSuttaLastkey) {
+      rootSuttaSection = this.$.segmented_text_content.querySelector(`#${sectionId}`);
+      if (rootSuttaSection) rootSuttaSection.appendChild(newTranslatedSegment);
+      let segment = this.$.segmented_text_content.querySelector(`#${subkey}`);
+      if (segment) segment.parentNode.insertBefore(newSegment, segment.nextSibling);
+    }
+    else {
+      this.addEndSection();
+      const endSection = this.$.segmented_text_content.querySelector('.endsection');
+      if (endSection){
+        endSection.appendChild(newTranslatedSegment);
+        endSection.appendChild(newSegment);
+      }      
+    }
+  }
+
+  addEndSection() {
+    const newEndSection = document.createElement('p');
+    newEndSection.classList.add('endsection');
+    const articleElement = this.$.segmented_text_content.getElementsByTagName('article')[0];
+    if (articleElement)
+      articleElement.appendChild(newEndSection);
+  }
+
+  addRootSuttaSection(key) {
+    let sectionId = `rootSutta-sc${key.split(':')[1].split('.')[0]}`;
+    let rootSuttaSection = this.$.segmented_text_content.querySelector(`#${sectionId}`);
+    if (!rootSuttaSection) {
+      const newSection = document.createElement('p');
+      newSection.id = sectionId;
+      const articleElement = this.$.segmented_text_content.getElementsByTagName('article')[0];
+      if (articleElement)
+        articleElement.appendChild(newSection);
+    }
+    return { rootSuttaSection, sectionId };
   }
 
   // After the paragraph list has been loaded, adds relevant data to the placeholders in the sutta text file.

--- a/client/elements/text/sc-segmented-text.js
+++ b/client/elements/text/sc-segmented-text.js
@@ -278,15 +278,15 @@ class SCSegmentedText extends SCTextPage {
   }
 
   _addTextContent() {
-    this._applyFirefoxShadyDomFix();
+    this._applyFirefoxShadyDomFix();    
     if (this.translatedSutta) {
       this._addPrimaryText(this.translatedSutta.strings);
-      if (this.translatedSutta.lang === 'pli' || this.translatedSutta.lang === 'lzh') {
+      if (this.translatedSutta.lang === 'pli' || this.translatedSutta.lang === 'lzh') {        
         this._putIntoSpans('.translated-text', this.rootSutta.lang);
       }
     } else {
       this._addPrimaryText(this.rootSutta.strings);
-      if (this.rootSutta.lang === 'pli' || this.rootSutta.lang === 'lzh') {
+      if (this.rootSutta.lang === 'pli' || this.rootSutta.lang === 'lzh') {        
         this._putIntoSpans('.translated-text', this.rootSutta.lang);
       }
     }
@@ -321,6 +321,7 @@ class SCSegmentedText extends SCTextPage {
     } else {
       return this.localize('noMetadata');
     }
+    
   }
 
   // if the base html and the pali texts have been fully loaded, the setting from the
@@ -422,12 +423,12 @@ class SCSegmentedText extends SCTextPage {
     );
   }
 
-  _insertPrimaryTextIntoSegments(textStrings, textContainer) {
+  _insertPrimaryTextIntoSegments(textStrings, textContainer) {    
     Object.entries(textStrings).forEach(([key, value]) => {
       if (!key.startsWith('_')) {
         let subkey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');
         const segment = textContainer.querySelector(`#${subkey}`);
-        segment.innerHTML = this._tweakText(value);
+        segment.innerHTML = this._tweakText(value);        
       }
     });
   }
@@ -452,10 +453,10 @@ class SCSegmentedText extends SCTextPage {
   _addSecondaryText() {
     const textContainer = this.$.segmented_text_content;
     if (!this.shadowRoot.querySelector('.original-text')) {
-      const stringsArr = Object.entries(this.rootSutta.strings);
+      const stringsArr = Object.entries(this.rootSutta.strings);            
       stringsArr.forEach(item => {
-        this._insertSecondaryTextSegment(item);
-      });
+        this._insertSecondaryTextSegment(item);                
+      });      
       if (this.rootSutta.lang === 'pli' || this.rootSutta.lang === 'lzh') {
         this._putIntoSpans('.original-text', this.rootSutta.lang);
       }
@@ -465,14 +466,54 @@ class SCSegmentedText extends SCTextPage {
 
   _insertSecondaryTextSegment([key, content]) {
     if (!key.startsWith('_')) {
-      const subkey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');
-      const segment = this.$.segmented_text_content.querySelector(`#${subkey}`);
+      const subkey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');      
+      let segment = this.$.segmented_text_content.querySelector(`#${subkey}`);
       const newSegment = document.createElement('sc-seg');
       newSegment.id = key;
       newSegment.classList.add('original-text');
-      newSegment.innerHTML = this._tweakText(content);
-      this._setScriptISOCode(newSegment, this.rootLang);
-      if (segment) segment.parentNode.insertBefore(newSegment, segment.nextSibling);
+      newSegment.innerHTML = this._tweakText(content);            
+      this._setScriptISOCode(newSegment, this.rootLang);            
+      if (segment){
+        segment.parentNode.insertBefore(newSegment, segment.nextSibling);     
+      }
+      else{                
+        this.translatedSutta.strings[key] = "";
+
+        let rootSuttaLastkey = "";
+        for (var keyname in this.rootSutta.strings){     
+          rootSuttaLastkey = keyname;
+        }  
+        
+        let sectionId = `#rootSutta-sc${key.split(':')[1].split('.')[0]}`;
+        let rootSuttaSection = this.$.segmented_text_content.querySelector(sectionId);        
+        if (!rootSuttaSection){          
+          const newSection = document.createElement('p');
+          newSection.id = `rootSutta-sc${key.split(':')[1].split('.')[0]}`;                
+          const articleElement = this.$.segmented_text_content.getElementsByTagName('article')[0];          
+          if (articleElement) articleElement.appendChild(newSection);            
+        }        
+        
+        const newTranslatedSegment = document.createElement('sc-seg');
+        newTranslatedSegment.id = key;
+        newTranslatedSegment.classList.add('translated-text');
+        this._setScriptISOCode(newTranslatedSegment, this.translationLang);     
+
+        if (key !== rootSuttaLastkey){          
+          rootSuttaSection = this.$.segmented_text_content.querySelector(sectionId);        
+          rootSuttaSection.appendChild(newTranslatedSegment);            
+          let segment = this.$.segmented_text_content.querySelector(`#${subkey}`);
+          segment.parentNode.insertBefore(newSegment, segment.nextSibling);       
+        } else {
+          const newEndSectionP = document.createElement('p');        
+          newEndSectionP.classList.add('endsection');
+          const articleElement = this.$.segmented_text_content.getElementsByTagName('article')[0];          
+          if (articleElement) articleElement.appendChild(newEndSectionP);
+
+          const endsection = this.$.segmented_text_content.querySelector('.endsection');
+          endsection.appendChild(newTranslatedSegment);
+          endsection.appendChild(newSegment);          
+        }            
+      }            
     }
   }
 
@@ -943,8 +984,8 @@ class SCSegmentedText extends SCTextPage {
   }
 
   _startGeneratingSpans(selector, unit) {
-    let segments = this.shadowRoot.querySelectorAll(selector);
-    segments = Array.from(segments);
+    let segments = this.shadowRoot.querySelectorAll(selector);    
+    segments = Array.from(segments);    
     let empty = true;
     while (segments.length > 0) {
       const segment = segments.shift();
@@ -966,7 +1007,7 @@ class SCSegmentedText extends SCTextPage {
   }
 
   _putSegmentIntoSpans(segment, unit, that) {
-    const text = segment.innerHTML;
+    const text = segment.innerHTML;        
     let div = document.createElement('div');
     div.innerHTML = text;
     that._recurseDomChildren(div, true, unit);

--- a/client/elements/text/sc-segmented-text.js
+++ b/client/elements/text/sc-segmented-text.js
@@ -278,15 +278,15 @@ class SCSegmentedText extends SCTextPage {
   }
 
   _addTextContent() {
-    this._applyFirefoxShadyDomFix();    
+    this._applyFirefoxShadyDomFix();
     if (this.translatedSutta) {
       this._addPrimaryText(this.translatedSutta.strings);
-      if (this.translatedSutta.lang === 'pli' || this.translatedSutta.lang === 'lzh') {        
+      if (this.translatedSutta.lang === 'pli' || this.translatedSutta.lang === 'lzh') {
         this._putIntoSpans('.translated-text', this.rootSutta.lang);
       }
     } else {
       this._addPrimaryText(this.rootSutta.strings);
-      if (this.rootSutta.lang === 'pli' || this.rootSutta.lang === 'lzh') {        
+      if (this.rootSutta.lang === 'pli' || this.rootSutta.lang === 'lzh') {
         this._putIntoSpans('.translated-text', this.rootSutta.lang);
       }
     }
@@ -321,7 +321,6 @@ class SCSegmentedText extends SCTextPage {
     } else {
       return this.localize('noMetadata');
     }
-    
   }
 
   // if the base html and the pali texts have been fully loaded, the setting from the
@@ -423,12 +422,12 @@ class SCSegmentedText extends SCTextPage {
     );
   }
 
-  _insertPrimaryTextIntoSegments(textStrings, textContainer) {    
+  _insertPrimaryTextIntoSegments(textStrings, textContainer) {
     Object.entries(textStrings).forEach(([key, value]) => {
       if (!key.startsWith('_')) {
         let subkey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');
         const segment = textContainer.querySelector(`#${subkey}`);
-        segment.innerHTML = this._tweakText(value);        
+        segment.innerHTML = this._tweakText(value);
       }
     });
   }
@@ -455,8 +454,8 @@ class SCSegmentedText extends SCTextPage {
     if (!this.shadowRoot.querySelector('.original-text')) {
       const stringsArr = Object.entries(this.rootSutta.strings);            
       stringsArr.forEach(item => {
-        this._insertSecondaryTextSegment(item);                
-      });      
+        this._insertSecondaryTextSegment(item);
+      });
       if (this.rootSutta.lang === 'pli' || this.rootSutta.lang === 'lzh') {
         this._putIntoSpans('.original-text', this.rootSutta.lang);
       }
@@ -984,8 +983,8 @@ class SCSegmentedText extends SCTextPage {
   }
 
   _startGeneratingSpans(selector, unit) {
-    let segments = this.shadowRoot.querySelectorAll(selector);    
-    segments = Array.from(segments);    
+    let segments = this.shadowRoot.querySelectorAll(selector);
+    segments = Array.from(segments);
     let empty = true;
     while (segments.length > 0) {
       const segment = segments.shift();
@@ -1007,7 +1006,7 @@ class SCSegmentedText extends SCTextPage {
   }
 
   _putSegmentIntoSpans(segment, unit, that) {
-    const text = segment.innerHTML;        
+    const text = segment.innerHTML;
     let div = document.createElement('div');
     div.innerHTML = text;
     that._recurseDomChildren(div, true, unit);

--- a/client/localization/elements/sc-static-page-selector/zh.json
+++ b/client/localization/elements/sc-static-page-selector/zh.json
@@ -15,7 +15,7 @@
         "DISCOURSES": "论述",
         "VINAYA": "僧律",
         "ABHIDHAMMA": "论",
-        "NUMBERING": "遍号",
+        "NUMBERING": "编号",
         "ABBREVIATIONS": "缩写",
         "METHODOLOGY": "方法",
         "ACKNOWLEDGMENTS": "致谢",

--- a/client/localization/elements/static_numbering-page/zh.json
+++ b/client/localization/elements/static_numbering-page/zh.json
@@ -54,6 +54,7 @@
         "a441f933e0026f55ccff38b534f98a53": "",
         "b05db772991d93146fef3d61fd1fee46": "",
         "6299f74950379388e645c9f29be6b3a3": "",
-        "8f70644fc24846742da5830bb2f87163": ""
+        "8f70644fc24846742da5830bb2f87163": "",
+        "LocalizationEnabled": "false"
     }
 }


### PR DESCRIPTION
I don't know that when a pull request is not completed, the newly submitted code will be added to the pull requests…… so this pull requests will have the following updates:

   1. Apply pseudo-icons for languages in navagation menu and language dropdown #1368 #1373 #1375
   2. fixed "font-synthesis is not working in FF for Chinese l10n" #1262
   3. fixed "Missing Pali text in segmented translations". #1236 
   4. fixed "Numbering page cannot be displayed correctly for Chinese l10n, and the" 遍号 "should be the" 编号 ". #1409 

Next time, I will submit only one update per pull requests.