### PR TITLE
Rewrite site components in LitElement (5): sc-scrollbar-styles.js, sc…

### DIFF
--- a/client/elements/menus/navigation-menu/sc-navigation-menu-css.js
+++ b/client/elements/menus/navigation-menu/sc-navigation-menu-css.js
@@ -1,10 +1,8 @@
 import { html } from 'lit-element';
 import { scrollbarStyle } from '../../styles/sc-scrollbar-style.js';
 
-const litScrollbarStyle = html([scrollbarStyle.innerHTML]);
-
 export const scNavigationMenuCss =  html`
-${litScrollbarStyle}
+${scrollbarStyle}
 
 <style>
   .sc-nav {

--- a/client/elements/sc-page-dictionary.js
+++ b/client/elements/sc-page-dictionary.js
@@ -10,11 +10,12 @@ import { dictStyles } from './styles/sc-dict-styles.js';
 import { scrollbarStyle } from './styles/sc-scrollbar-style.js';
 
 const polymer_dictStyles = html([dictStyles.strings.join('')]);
-class SCPageDictionary extends ReduxMixin(Localized(PolymerElement)) {
+const polymer_scrollbarStyle = html([scrollbarStyle.strings.join('')]);
+class SCPageDictionary extends ReduxMixin(Localized(PolymerElement)) {  
   static get template() {
     return html`
     ${polymer_dictStyles}
-    ${scrollbarStyle}
+    ${polymer_scrollbarStyle}    
     <style>
       .dictionary-results-container, .related-terms {
         padding: var(--sc-size-xxl) 0;

--- a/client/elements/styles/sc-scrollbar-style.js
+++ b/client/elements/styles/sc-scrollbar-style.js
@@ -1,4 +1,4 @@
-import { html } from '@polymer/polymer/polymer-element.js';
+import { html } from 'lit-element';
 
 export const scrollbarStyle = html`
 <style>

--- a/client/elements/styles/sc-suttaplex-styles.js
+++ b/client/elements/styles/sc-suttaplex-styles.js
@@ -1,4 +1,4 @@
-import { html } from '@polymer/polymer/polymer-element.js';
+import { html } from 'lit-element';
 
 export const suttaplexStyles = html`
 <style>

--- a/client/elements/styles/sc-text-heading-styles.js
+++ b/client/elements/styles/sc-text-heading-styles.js
@@ -1,4 +1,4 @@
-import { html } from '@polymer/polymer/polymer-element.js';
+import { html } from 'lit-element';
 
 export const textHeadingStyles = html`
 <style>

--- a/client/elements/styles/sc-text-paragraph-num-styles.js
+++ b/client/elements/styles/sc-text-paragraph-num-styles.js
@@ -1,4 +1,4 @@
-import { html } from '@polymer/polymer/polymer-element.js';
+import { html } from 'lit-element';
 
 export const textParagraphNumStyles = html`
 <style>

--- a/client/elements/styles/sc-text-styles.js
+++ b/client/elements/styles/sc-text-styles.js
@@ -1,4 +1,4 @@
-import { html } from '@polymer/polymer/polymer-element.js';
+import { html } from 'lit-element';
 
 export const textStyles = html`
 <style>

--- a/client/elements/text/sc-segmented-text.js
+++ b/client/elements/text/sc-segmented-text.js
@@ -16,13 +16,16 @@ import '../lookups/sc-lzh2en.js';
 import { Transliterator } from './transliterator.js';
 
 const polymer_lookupStyles = html([lookupStyles.strings.join('')]);
+const polymer_textHeadingStyles = html([textHeadingStyles.strings.join('')]);
+const polymer_textStyles = html([textStyles.strings.join('')]);
+const polymer_textParagraphNumStyles = html([textParagraphNumStyles.strings.join('')]);
 
 class SCSegmentedText extends SCTextPage {
   static get template() {
     return html`
-    ${textStyles}
-    ${textHeadingStyles}
-    ${textParagraphNumStyles}
+    ${polymer_textStyles}
+    ${polymer_textHeadingStyles}
+    ${polymer_textParagraphNumStyles}
     ${polymer_lookupStyles}
     <style>
       :host {

--- a/client/elements/text/sc-simple-text.js
+++ b/client/elements/text/sc-simple-text.js
@@ -13,13 +13,16 @@ import { lookupStyles } from '../lookups/sc-lookup-styles.js';
 import { Transliterator } from './transliterator.js';
 
 const polymer_lookupStyles = html([lookupStyles.strings.join('')]);
+const polymer_textHeadingStyles = html([textHeadingStyles.strings.join('')]);
+const polymer_textStyles = html([textStyles.strings.join('')]);
+const polymer_textParagraphNumStyles = html([textParagraphNumStyles.strings.join('')]);
 
 class SCSimpleText extends SCTextPage {
   static get template() {
     return html`
-    ${textStyles}
-    ${textHeadingStyles}
-    ${textParagraphNumStyles}
+    ${polymer_textStyles}
+    ${polymer_textHeadingStyles}
+    ${polymer_textParagraphNumStyles}
     ${polymer_lookupStyles}
     <style>
       :host {

--- a/client/elements/text/sc-text-options.js
+++ b/client/elements/text/sc-text-options.js
@@ -12,11 +12,12 @@ import { suttaplexStyles } from '../styles/sc-suttaplex-styles.js';
 /*
 Pulls in one relevant suttaplex-card inside a collapse-item to display on top of each sutta text.
 */
+const polymer_suttaplexStyles= html([suttaplexStyles.strings.join('')]);
 
 class SCTextOptions extends ReduxMixin(Localized(PolymerElement)) {
   static get template() {
     return html`
-    ${suttaplexStyles}
+    ${polymer_suttaplexStyles}    
     <style>
       @media print {
         :host {

--- a/client/elements/text/sc-text-page-selector.js
+++ b/client/elements/text/sc-text-page-selector.js
@@ -17,11 +17,12 @@ import { API_ROOT } from '../../constants.js';
   This element makes a server request for a sutta text, dispatches it to the redux store and subsequently shows
   either the simple sutta text view or the segmented view.
 */
+const polymer_textHeadingStyles = html([textHeadingStyles.strings.join('')]);
 
 class SCTextPageSelector extends ReduxMixin(Localized(PolymerElement)) {
   static get template() {
     return html`
-    ${textHeadingStyles}
+    ${polymer_textHeadingStyles}
     <style>
       .loading-indicator {
         @apply --sc-skolar-font-size-s;


### PR DESCRIPTION
Rewrote the shared style written in polymer to lit-element.

Affected files:
1. client/elements/styles/sc-scrollbar-style.js
2. client/elements/styles/sc-suttaplex-styles.js
3. client/elements/styles/sc-text-heading-styles.js
4. client/elements/styles/sc-text-paragraph-num-styles.js
5. client/elements/styles/sc-text-styles.js
6. client/elements/sc-page-dictionary.js
7. client/elements/menus/navigation-menu/sc-navigation-menu-css.js
8. client/elements/text/sc-segmented-text.js
9. client/elements/text/sc-simple-text.js
10. client/elements/text/sc-text-options.js
11. client/elements/text/sc-text-page-selector.js