### PR TITLE
fix: Taisho parallels table has missing column letters #1477

### DIFF
--- a/client/utils/suttaplex.js
+++ b/client/utils/suttaplex.js
@@ -8,7 +8,8 @@ export function transformId(rootId, expansionData, idOrName = 0) {
       const idNumbers = rootId.substring(5);
       return `G-3 Dhp ${idNumbers}`;
     }
-    const idPart = getParagraphRange(rootId).replace('--', '–').replace('#', ': ').replace(/[a-z]+/g,'');
+    //const idPart = getParagraphRange(rootId).replace('--', '–').replace('#', ': ').replace(/[a-z]+/g,'');
+    const idPart = getParagraphRange(rootId).replace('--', '–').replace('#', ': ');
     let scAcronym = '';
     const rootPart = rootId.split('#')[0];
     const uidParts = rootPart.split('-');


### PR DESCRIPTION
"Column letter more be restored to parallel root IDs for Chinese texts."