### PR TITLE
fix:  Some Pali text cannot be displayed

### DIFF
--- a/client/elements/text/sc-segmented-text.js
+++ b/client/elements/text/sc-segmented-text.js
@@ -1297,12 +1297,22 @@ class SCSegmentedText extends SCTextPage {
     let sutta = this.translatedSutta ? this.translatedSutta : this.rootSutta;
     const dummyElement = document.createElement('template');
     dummyElement.innerHTML = this.markup.trim();
-    return Array.from(
+    let arrayTOC = Array.from(
       dummyElement.content.querySelectorAll('h2')
     ).map(elem => {
       const id = elem.firstElementChild.id;
-      return { link: id, name: this._stripLeadingOrdering(sutta.strings[id]) };
-    })
+      if (sutta.strings[id]) {
+        return { link: id, name: this._stripLeadingOrdering(sutta.strings[id]) };
+      }
+    });
+
+    /**
+    * Because some Pali text does not have a proper structure to generate TOC,
+    * the array generated here will have undefined array elements.
+    * this command deletes the undefined array elements
+    */
+    arrayTOC = arrayTOC.filter(Boolean);
+    return arrayTOC;
   }
 
   _stripLeadingOrdering(name) {


### PR DESCRIPTION
 Some Pali text does not have a proper structure to generate TOC, so there will be errors when generating TOC.

Solution: filter the generated array to eliminate unexpected values.