### PR TITLE
Update python-arangodb from 4.4.0 to 5.0.0

### DIFF
--- a/server/env/.base.env
+++ b/server/env/.base.env
@@ -1,5 +1,4 @@
-ARANGO_HOST=sc-arangodb
-ARANGO_PORT=8529
+ARANGO_HOSTS=http://sc-arangodb:8529
 ARANGO_ROOT_PASSWORD=test
 ARANGO_USER=root
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -42,7 +42,7 @@ pytest==3.8.0
 pytest-flask==0.12.0
 pytest-sugar==0.9.1
 pyppeteer==0.0.24
-python-arango==4.4.0
+python-arango==5.0.0
 python-dateutil==2.7.3
 pytz==2018.5
 PyYAML==5.1

--- a/server/server/common/arangodb.py
+++ b/server/server/common/arangodb.py
@@ -75,7 +75,7 @@ class ArangoDB:
     def connect(self) -> ArangoClient:
         """Connect to the ArangoDB"""
         config = current_app.config['ARANGO_CLIENT']
-        return ArangoClient(host=config['host'], port=config['port'])
+        return ArangoClient(hosts=config['hosts'])
 
     @property
     def client(self) -> ArangoClient:

--- a/server/server/config.py
+++ b/server/server/config.py
@@ -19,8 +19,7 @@ class Config:
         pass
 
     ARANGO_CLIENT = {
-        'host': os.getenv('ARANGO_HOST'),
-        'port': int(os.getenv('ARANGO_PORT')),
+        'hosts': os.getenv('ARANGO_HOSTS'),
         'username': os.getenv('ARANGO_USER', None),
         'password': os.getenv('ARANGO_ROOT_PASSWORD', None),
     }

--- a/server/server/migrations/migrations/add_dictionary_search_view_024.py
+++ b/server/server/migrations/migrations/add_dictionary_search_view_024.py
@@ -8,14 +8,14 @@ class SecondMigration(Migration):
 
     def create_view(self):
         db = get_db()
-
-        db.create_view(
+        db.create_arangosearch_view(
             'v_dict',
-            view_type='arangosearch',
             properties={
                 'links': {
                     'dictionary_full': {
-                        'fields': {'word_ascii': {'analyzers': ['identity']}}
+                        'fields': {
+                            'word_ascii': {'analyzers': ['identity']}
+                        }
                     }
                 }
             },

--- a/server/server/migrations/migrations/add_text_search_view_025.py
+++ b/server/server/migrations/migrations/add_text_search_view_025.py
@@ -8,9 +8,8 @@ class SecondMigration(Migration):
 
     def create_view(self):
         db = get_db()
-        db.create_view(
+        db.create_arangosearch_view(
             'v_text',
-            view_type='arangosearch',
             properties={
                 'links': {
                     'html_text': {

--- a/server/server/wait_for_arango.py
+++ b/server/server/wait_for_arango.py
@@ -6,7 +6,7 @@ from arango.exceptions import ServerConnectionError
 
 
 def connect():
-    client = ArangoClient(host=os.getenv('ARANGO_HOST'), port=os.getenv('ARANGO_PORT'))
+    client = ArangoClient(hosts=os.getenv('ARANGO_HOSTS'))
 
     # arango client >= 4 thows only when verify is set to True
     client.db(


### PR DESCRIPTION
See https://github.com/suttacentral/suttacentral/issues/1548

`make install-requirements` should theoretically be sufficient to get the change to show up, but since the code change touches migration code, `make install-requirements delete-database migrate load-data` may be necessary.

After this change:
- With language set to, eg, Afrikaans, menu should show green circle on "Sutta".
- On staging.suttacentral.net/languages, languages other than Pali and English should show up.
