### PR TITLE
Bump ArangoDB 3.5.0 => 3.5.2; Disable hack for silent view corruption bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - sc-arangodb
 
   sc-arangodb:
-    image: arangodb/arangodb:3.5.0
+    image: arangodb/arangodb:3.5.2
     container_name: 'sc-arangodb'
     env_file:
       - server/env/.base.env

--- a/server/server/common/arangodb.py
+++ b/server/server/common/arangodb.py
@@ -103,7 +103,7 @@ class ArangoDB:
             else:
                 params['name'] = current_app.config['ARANGO_DB']
             db = g._database = self.client.db(**params)
-            update_views_hack(db)
+            # update_views_hack(db)
         return db
 
     @staticmethod


### PR DESCRIPTION
See https://github.com/suttacentral/suttacentral/issues/1548

After this 
- With language set to, eg, Afrikaans, menu should show green circle on "Sutta".
- On staging.suttacentral.net/languages, languages other than Pali and English should show up.

If at any point this no longer happens, relevant queries should be modified so that they do not use the ArangoSearch View called `v_text`.