### PR TITLE
Use bilara-segmented-text instead of old text page

### DIFF
--- a/client/elements/styles/sc-layout-bilara-styles.js
+++ b/client/elements/styles/sc-layout-bilara-styles.js
@@ -1,593 +1,515 @@
 import { html,css } from 'lit-element';
 
 export const commonStyles = css`
-
-  main
-{
+  main {
     display: flex;
-
     margin: 4em 2em;
-
     justify-content: center;
-}
-
-`;
+  }`;
 
 export const plainStyles = html`
   <style>
+    article {
+      max-width: 720px;
+    }
 
-  article
-{
-    max-width: 720px;
-}
+    .root {
+      display: none;
+    }
 
-.reference,
-.root
-{
-    display: none;
-}
+    /* Set styles for tooltip marker. First we hide the actual content. These settings ensure the beginning, i.e. the :before content, is visible and the rest is hidden. Height is important to maintain even line-height. */
+    .comment,
+    .variant {
+      overflow: hidden;
 
-/* Set styles for tooltip marker. First we hide the actual content. These settings ensure the beginning, i.e. the :before content, is visible and the rest is hidden. Height is important to maintain even line-height. */
-.comment,
-.variant
-{
-    overflow: hidden;
+      width: 1ex;
+      height: 1em;
+      padding: 0 6px 0 0;
 
-    width: 1ex;
-    height: 1em;
-    padding: 0 6px 0 0;
+      white-space: nowrap;
 
-    white-space: nowrap;
+      border: none;
+      background-color: inherit;
+    }
 
-    border: none;
-    background-color: inherit;
-}
+  /* Show the tooltip. Note that using this technique it is not possible to use transition on the display.*/
+    .comment[data-tooltip]:hover::after,
+    .variant[data-tooltip]:hover::after {
+      display: block;
+    }
+  </style>
+`;
 
-/* Show the tooltip. Note that using this technique it is not possible to use transition on the display.*/
-.comment[data-tooltip]:hover::after,
-.variant[data-tooltip]:hover::after
-{
-    display: block;
-}
+export const plainPaliStyles = html`
+  <style>
+    section, article {
+      max-width: 720px;
+    }
 
+    .comment,
+    .variant {
+      overflow: hidden;
+
+      width: 1ex;
+      height: 1em;
+      padding: 0 6px 0 0;
+
+      white-space: nowrap;
+
+      border: none;
+      background-color: inherit;
+    }
+
+    .comment[data-tooltip]:hover::after,
+    .variant[data-tooltip]:hover::after {
+      display: block;
+    }
   </style>
 `;
 
 export const plainPlusStyles = html`
   <style>
-
-.root
-{
-    display: none;
-}
-
-/* Let min width be handled by media queries, max width according to the nested grid width.*/
-.segment
-{
-    display: grid;
-
-    grid-template-columns: 100px minmax(0, auto);
-    grid-column-gap: var(--sc-size-lg);
-}
-
-.reference
-{
-    grid-column: 1;
-    grid-row: 1 / span 3;
-}
-
-.translation
-{
-    grid-column: 2;
-}
-
-.translation
-{
-    position: relative;
-
-    display: grid;
-
-    grid-template-columns: minmax(240px, 720px) minmax(120px, 480px);
-    grid-column-gap: var(--sc-size-lg);
-}
-
-.text
-{
-    grid-column: 1;
-}
-
-.comment
-{
-    position: absolute;
-
-    padding: var(--sc-size-sm) var(--sc-size-md);
-
-    box-shadow: var(--sc-shadow-elevation-1dp);
-
-    grid-column: 2;
-    grid-row: 1;
-}
-
-/* remove <br> tags to avoid unsightly spaces in verses. */
-br
-{
-    content: '';
-}
-
-@media only screen and (max-width: 600px)
-{
-    .segment,
-    .reference,
-    .translation,
-    .root
-    {
-        display: block;
+    .root {
+      display: none;
     }
 
-    .variant,
-    .comment
-    {
+    /* Let min width be handled by media queries, max width according to the nested grid width.*/
+    .segment {
+      display: grid;
+
+      grid-template-columns: 100px minmax(0, auto);
+      grid-column-gap: var(--sc-size-lg);
+    }
+
+    .reference {
+      grid-column: 1;
+      grid-row: 1 / span 3;
+    }
+
+    .translation {
+      grid-column: 2;
+    }
+
+    .translation {
+      position: relative;
+
+      display: grid;
+
+      grid-template-columns: minmax(240px, 720px) minmax(120px, 480px);
+      grid-column-gap: var(--sc-size-lg);
+    }
+
+    .text {
+      grid-column: 1;
+    }
+
+    .comment {
+      position: absolute;
+
+      padding: var(--sc-size-sm) var(--sc-size-md);
+
+      box-shadow: var(--sc-shadow-elevation-1dp);
+
+      grid-column: 2;
+      grid-row: 1;
+    }
+
+    /* remove <br> tags to avoid unsightly spaces in verses. */
+    br {
+      content: '';
+    }
+
+    @media only screen and (max-width: 600px) {
+      .segment,
+      .reference,
+      .translation,
+      .root {
+        display: block;
+      }
+
+      .variant,
+      .comment {
         position: relative;
 
         display: table;
 
         margin-top: var(--sc-size-sm);
+      }
     }
-}
-
   </style>
 `;
 
 export const sideBySideStyles = html`
-  <style>
- 
-.segment
-{
-    display: grid;
+  <style> 
+    .segment {
+      display: grid;
 
-    grid-template-columns: minmax(240px, 720px) minmax(240px, 720px);
-    grid-column-gap: var(--sc-size-lg);
-}
+      grid-template-columns: minmax(240px, 720px) minmax(240px, 720px);
+      grid-column-gap: var(--sc-size-lg);
+    }
 
-.reference
-{
-    display: none;
-}
+    .translation {
+      grid-column: 1;
+    }
 
-.translation
-{
-    grid-column: 1;
-}
+    .root {
+      grid-column: 2;
+    }
 
-.root
-{
-    grid-column: 2;
-}
+    br {
+      content: '';
+    }
 
-br
-{
-    content: '';
-}
-
-/* Center the tooltip in the respective column */
-.translation,
-.root
-{
-    position: relative;
-}
-
-/* Set styles for tooltip marker. First we hide the actual content of the .comment tag. These settings ensure the beginning of .comment, i.e. the :before content, is visible and the rest is hidden. Height is important to maintain even line-height. */
-.comment,
-.variant
-{
-    overflow: hidden;
-
-    width: 1ex;
-    height: 1em;
-    padding: 0 6px 0 0;
-
-    white-space: nowrap;
-
-    border: none;
-    background-color: inherit;
-}
-
-/* Show the tooltip. Note that using this technique it is not possible to use transition on the display.*/
-.comment[data-tooltip]:hover::after,
-.variant[data-tooltip]:hover::after
-{
-    display: block;
-}
-
-@media only screen and (max-width: 600px)
-{
-    .segment,
+    /* Center the tooltip in the respective column */
     .translation,
-    .root
-    {
+    .root {
+      position: relative;
+    }
+
+    /* Set styles for tooltip marker. First we hide the actual content of the .comment tag. These settings ensure the beginning of .comment, i.e. the :before content, is visible and the rest is hidden. Height is important to maintain even line-height. */
+    .comment,
+    .variant {
+      overflow: hidden;
+
+      width: 1ex;
+      height: 1em;
+      padding: 0 6px 0 0;
+
+      white-space: nowrap;
+
+      border: none;
+      background-color: inherit;
+    }
+
+    /* Show the tooltip. Note that using this technique it is not possible to use transition on the display.*/
+    .comment[data-tooltip]:hover::after,
+    .variant[data-tooltip]:hover::after {
+      display: block;
+    }
+
+    @media only screen and (max-width: 600px) {
+      .segment,
+      .translation,
+      .root {
         position: relative;
 
         display: block;
-    }
-    .root .text
-    {
-        color: var(--sc-secondary-text-color);
-    }
-}
+      }
 
+      .root .text {
+        color: var(--sc-secondary-text-color);
+      }
+    }
   </style>
 `;
 
 export const sideBySidePlusStyles = html`
   <style>
+    .segment {
+      position: relative;
 
-.segment
-{
-    position: relative;
+      display: grid;
 
-    display: grid;
+      grid-template-columns: 100px  minmax(0, auto) minmax(0, auto);
+      grid-column-gap: var(--sc-size-lg);
+    }
 
-    grid-template-columns: 100px  minmax(0, auto) minmax(0, auto);
-    grid-column-gap: var(--sc-size-lg);
-}
+    .reference {
+      grid-column: 1;
+      grid-row: 1 / span 3;
+    }
 
-.reference
-{
-    grid-column: 1;
-    grid-row: 1 / span 3;
-}
+    .translation {
+      grid-column: 2;
+    }
 
-.translation
-{
-    grid-column: 2;
-}
+    .root {
+      grid-column: 3;
+    }
 
-.root
-{
-    grid-column: 3;
-}
-
-.translation,
-.root
-{
-    position: relative;
-
-    display: grid;
-
-    grid-template-columns: minmax(240px, 720px) minmax(120px, 300px);
-    grid-column-gap: var(--sc-size-lg);
-}
-
-.text
-{
-    grid-column: 1;
-}
-
-.comment,
-.variant
-{
-    position: absolute;
-
-    padding: var(--sc-size-sm) var(--sc-size-md);
-
-    box-shadow: var(--sc-shadow-elevation-1dp);
-
-    grid-column: 2;
-    grid-row: 1;
-}
-
-br
-{
-    content: '';
-}
-
-blockquote
-{
-    margin: 0;
-}
-
-@media only screen and (max-width: 1280px)
-{
     .translation,
-    .root,
-    .variant,
-    .comment
-    {
+    .root {
+      position: relative;
+
+      display: grid;
+
+      grid-template-columns: minmax(240px, 720px) minmax(120px, 300px);
+      grid-column-gap: var(--sc-size-lg);
+    }
+
+    .text {
+      grid-column: 1;
+    }
+
+    .comment,
+    .variant {
+      position: absolute;
+
+      padding: var(--sc-size-sm) var(--sc-size-md);
+
+      box-shadow: var(--sc-shadow-elevation-1dp);
+
+      grid-column: 2;
+      grid-row: 1;
+    }
+
+    br {
+      content: '';
+    }
+
+    blockquote {
+      margin: 0;
+    }
+
+    @media only screen and (max-width: 1280px) {
+      .translation,
+      .root,
+      .variant,
+      .comment {
         position: relative;
 
         display: table;
 
         margin-top: var(--sc-size-sm);
-    }
+      }
 
-    .segment
-    {
+      .segment {
         grid-template-columns: minmax(240px, 720px) minmax(240px, 720px);
-    }
+      }
 
-    .reference
-    {
+      .reference {
         grid-column: 1 / span 2;
-    }
+      }
 
-    .translation
-    {
+      .translation {
         grid-column: 1;
-    }
+      }
 
-    .root
-    {
+      .root {
         grid-column: 2;
+      }
     }
-}
 
-@media only screen and (max-width: 600px)
-{
-    .segment,
-    .reference,
-    .translation,
-    .root
-    {
+    @media only screen and (max-width: 600px) {
+      .segment,
+      .reference,
+      .translation,
+      .root {
         display: block;
-    }
+      }
 
-    .variant,
-    .comment
-    {
+      .variant,
+      .comment {
         position: relative;
 
         display: table;
 
         margin-top: var(--sc-size-sm);
-    }
+      }
 
-    .root .text
-    {
+      .root .text {
         color: var(--sc-secondary-text-color);
+      }
     }
-}
-
   </style>
 `;
 
 export const lineByLineStyles = html`
   <style>
+    .segment {
+      display: grid;
 
-.segment
-{
-    display: grid;
-
-    grid-template-columns: minmax(200px, 720px);
-}
-
-.reference
-{
-    display: none;
-}
-
-.translation
-{
-    grid-column: 1;
-}
-
-.root
-{
-    grid-column: 1;
-}
-
-.root .text
-{
-    color: var(--sc-secondary-text-color);
-}
-
-br
-{
-    content: '';
-}
-
-.comment,
-.variant
-{
-    overflow: hidden;
-
-    width: 1ex;
-    height: 1em;
-    padding: 0 6px 0 0;
-
-    white-space: nowrap;
-
-    border: none;
-    background-color: inherit;
-}
-
-/* Show the tooltip. Note that using this technique it is not possible to use transition on the display.*/
-.comment[data-tooltip]:hover::after,
-.variant[data-tooltip]:hover::after
-{
-    display: block;
-}
-
-    </style>
-  `;
-
-  export const lineByLinePlusStyles = html`
-    <style>
-
-    .segment
-{
-    display: grid;
-
-    grid-template-columns: 100px minmax(0, auto);
-    grid-column-gap: var(--sc-size-lg);
-}
-
-.reference
-{
-    grid-column: 1;
-    grid-row: 1 / span 3;
-}
-
-.translation
-{
-    grid-column: 2;
-}
-
-.root
-{
-    grid-column: 2;
-}
-
-.root .text
-{
-    color: var(--sc-secondary-text-color);
-}
-
-.translation,
-.root
-{
-    position: relative;
-
-    display: grid;
-
-    grid-template-columns: minmax(240px, 720px) minmax(120px, 480px);
-    grid-column-gap: var(--sc-size-lg);
-}
-
-.text
-{
-    grid-column: 1;
-}
-
-.comment,
-.variant
-{
-    position: absolute;
-
-    padding: var(--sc-size-sm) var(--sc-size-md);
-
-    box-shadow: var(--sc-shadow-elevation-1dp);
-
-    grid-column: 2;
-    grid-row: 1;
-}
-
-br
-{
-    content: '';
-}
-
-blockquote
-{
-    margin: 0;
-}
-
-blockquote .text
-{
-    margin-left: 2em;
-}
-
-@media only screen and (max-width: 840px)
-{
-    .segment,
-    .reference,
-    .translation,
-    .root
-    {
-        display: block;
+      grid-template-columns: minmax(200px, 720px);
     }
 
-    .variant,
-    .comment
-    {
+    .reference {
+      display: none;
+    }
+
+    .translation {
+      grid-column: 1;
+    }
+
+    .root {
+      grid-column: 1;
+    }
+
+    .root .text {
+      color: var(--sc-secondary-text-color);
+    }
+
+    br {
+      content: '';
+    }
+
+    .comment,
+    .variant {
+      overflow: hidden;
+
+      width: 1ex;
+      height: 1em;
+      padding: 0 6px 0 0;
+
+      white-space: nowrap;
+
+      border: none;
+      background-color: inherit;
+    }
+
+    /* Show the tooltip. Note that using this technique it is not possible to use transition on the display.*/
+    .comment[data-tooltip]:hover::after,
+    .variant[data-tooltip]:hover::after {
+      display: block;
+    }
+  </style>
+`;
+
+export const lineByLinePlusStyles = html`
+  <style>
+    .segment {
+      display: grid;
+
+      grid-template-columns: 100px minmax(0, auto);
+      grid-column-gap: var(--sc-size-lg);
+    }
+
+    .reference {
+      grid-column: 1;
+      grid-row: 1 / span 3;
+    }
+
+    .translation {
+      grid-column: 2;
+    }
+
+    .root {
+      grid-column: 2;
+    }
+
+    .root .text {
+      color: var(--sc-secondary-text-color);
+    }
+
+    .translation,
+    .root {
+      position: relative;
+
+      display: grid;
+
+      grid-template-columns: minmax(240px, 720px) minmax(120px, 480px);
+      grid-column-gap: var(--sc-size-lg);
+    }
+
+    .text {
+      grid-column: 1;
+    }
+
+    .comment,
+    .variant {
+      position: absolute;
+
+      padding: var(--sc-size-sm) var(--sc-size-md);
+
+      box-shadow: var(--sc-shadow-elevation-1dp);
+
+      grid-column: 2;
+      grid-row: 1;
+    }
+
+    br {
+      content: '';
+    }
+
+    blockquote {
+      margin: 0;
+    }
+
+    blockquote .text {
+      margin-left: 2em;
+    }
+
+    @media only screen and (max-width: 840px) {
+      .segment,
+      .reference,
+      .translation,
+      .root {
+          display: block;
+      }
+
+      .variant,
+      .comment {
         position: relative;
 
         display: table;
 
         margin-top: var(--sc-size-sm);
+      }
     }
-}
-
   </style>
 `;
 
 export const hideReferenceStyles = html`
   <style>
-
-.reference
-{
-    display: none;
-}
-
+    .reference {
+      display: none;
+    }
   </style>
 `;
 
 export const hidePTSReferenceStyles = html`
   <style>
+    .reference {
+      display: inherit;
+    }
 
-.reference
-{
-    display: inherit;
-}
-a.pts
-{
-    display: none;
-}
-a.sc
-{
-    display: inherit;
-}
+    a.pts {
+      display: none;
+    }
 
+    a.sc {
+      display: inherit;
+    }
   </style>
 `;
 
 export const showAllReferenceStyles = html`
   <style>
-
-.reference
-{
-    display: inherit;
-}
-
+    .reference {
+      display: inherit;
+    }
   </style>
 `;
 
 export const hideAsterisk = html`
   <style>
-
-.comment,
-.variant
-{
-    display: none;
-}
-.comment:before,
-.variant:before
-{
-    content: none;
-}
-
+    .comment,
+    .variant {
+      display: none;
+    }
+    
+    .comment:before,
+    .variant:before {
+      content: none;
+    }
   </style>
 `;
 
 export const showAsterisk = html`
   <style>
+    .comment:before,
+    .variant:before {
+      line-height: 1;
 
-.comment:before,
-.variant:before
-{
-    line-height: 1;
+      content: '*';
+      vertical-align: super;
+    }
 
-    content: '*';
-    vertical-align: super;
-}
-.comment:before
-{
-    color: var(--sc-primary-accent-color);
-}
+    .comment:before {
+      color: var(--sc-primary-accent-color);
+    }
 
-.variant:before
-{
-    color: var(--sc-secondary-accent-color);
-}
-
+    .variant:before {
+      color: var(--sc-secondary-accent-color);
+    }
   </style>
 `;

--- a/client/elements/text/sc-bilara-segmented-text.js
+++ b/client/elements/text/sc-bilara-segmented-text.js
@@ -15,6 +15,7 @@ import { typographyBilaraStyles } from '../styles/sc-typography-bilara-styles.js
 import {
   commonStyles,
   plainStyles,
+  plainPaliStyles,
   plainPlusStyles,
   sideBySideStyles,
   sideBySidePlusStyles,
@@ -38,12 +39,6 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       showParagraphs: { type: Boolean },
       paragraphs: { type: Array },
       paragraphTitles: { type: Object },
-      rootAuthor: { type: String },
-      rootLang: { type: String },
-      rootTitle: { type: String },
-      translationAuthor: { type: String },
-      translationLang: { type: String },
-      translatedTitle: { type: String },
       suttaReference: { type: Object },
       suttaComment: { type: Object },
       suttaVariant: { type: Object },
@@ -64,7 +59,6 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       segmentedIDsAdded: { type: Boolean },
       hasScriptBeenChanged: { type: Boolean },
       localizedStringsPath: { type: String },
-      currentSutta: { type: Object },
       currentStyles: { type: Object },
       referencesDisplayStyles: { type: Object },
       notesDisplayStyles: { type: Object },
@@ -99,7 +93,6 @@ class SCBilaraSegmentedText extends SCLitTextPage {
     this.segmentedIDsAdded = false;
     this.hasScriptBeenChanged = false;
     this.localizedStringsPath = '/localization/elements/sc-text';
-    this.currentSutta = {};
     this.translationTextSelector = '.translation .text';
     this.rootTextSelector = '.root .text';
     this.commentSpanRectInfo = new Map();
@@ -118,7 +111,8 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       ['none_sidebyside', sideBySideStyles],
       ['asterisk_sidebyside', sideBySideStyles],
       ['none_linebyline', lineByLineStyles],
-      ['asterisk_linebyline', lineByLineStyles]
+      ['asterisk_linebyline', lineByLineStyles],
+      ['pali', plainPaliStyles],
     ]);
     this.mapReferenceDisplayStyles = new Map([
       ['none', hideReferenceStyles],
@@ -182,7 +176,6 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       this._showHighlightingChanged();
     }, 100);
     //this.navItems = this._prepareNavigation();
-    this.currentSutta = this.translatedSutta ? this.translatedSutta : this.rootSutta;
 
     setTimeout(() => {
       //this._recalculateCommentSpanHeight();
@@ -373,6 +366,9 @@ class SCBilaraSegmentedText extends SCLitTextPage {
 
   _changeTextView() {
     let viewCompose = `${this.chosenNoteDisplayType}_${this.chosenTextView}`;
+    if (!this.bilaraTranslatedSutta && this.bilaraRootSutta) {
+      viewCompose = 'pali';
+    }
     this.currentStyles = this.mapStyles.get(viewCompose) ? this.mapStyles.get(viewCompose) : plainStyles;
     this.referencesDisplayStyles = this.mapReferenceDisplayStyles.get(this.chosenReferenceDisplayType);
     this.notesDisplayStyles = this.mapNoteDisplayStyles.get(this.chosenNoteDisplayType);
@@ -401,7 +397,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   }
 
   _prepareNavigation() {
-    let sutta = this.translatedSutta ? this.translatedSutta : this.rootSutta;
+    let sutta = this.bilaraTranslatedSutta ? this.bilaraTranslatedSutta : this.bilaraRootSutta;
     if (!sutta) {
       return;
     }
@@ -451,8 +447,8 @@ class SCBilaraSegmentedText extends SCLitTextPage {
     this._deleteRootSuttaMarkup();
     this._addRootSuttaMarkup();
     mapSutta.forEach((value, key) => {
-      let escapeKey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');
-      let suttaId = key.split(':')[0].replace(/\./g, '\\\.');
+      let escapeKey = key.replace(/:/ug, '\\\:').replace(/\./ug, '\\\.');
+      let suttaId = key.split(':')[0].replace(/\./ug, '\\\.');
       let suttaArticle = this.shadowRoot.querySelector(`#${suttaId}`);
       this._addRootTextToSpan(suttasSection, escapeKey, value);
       this._addRootTextToSpan(suttaArticle, escapeKey, value);
@@ -496,8 +492,8 @@ class SCBilaraSegmentedText extends SCLitTextPage {
     }
     const suttasSection = this.shadowRoot.querySelector('section.range');
     mapSutta.forEach((value, key) => {
-      let escapeKey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');
-      let suttaId = key.split(':')[0].replace(/\./g, '\\\.');
+      let escapeKey = key.replace(/:/ug, '\\\:').replace(/\./ug, '\\\.');
+      let suttaId = key.split(':')[0].replace(/\./ug, '\\\.');
       let suttaArticle = this.shadowRoot.querySelector(`#${suttaId}`);
       this._addRootSuttaMarkupToSpan(suttasSection, escapeKey);
       this._addRootSuttaMarkupToSpan(suttaArticle, escapeKey);
@@ -527,8 +523,8 @@ class SCBilaraSegmentedText extends SCLitTextPage {
     }
     const suttasSection = this.shadowRoot.querySelector('section.range');
     mapSutta.forEach((value, key) => {
-      let escapeKey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');
-      let suttaId = key.split(':')[0].replace(/\./g, '\\\.');
+      let escapeKey = key.replace(/:/ug, '\\\:').replace(/\./ug, '\\\.').replace(/\^/ug, '\\\^');
+      let suttaId = key.split(':')[0].replace(/\./ug, '\\\.');
       let suttaArticle = this.shadowRoot.querySelector(`#${suttaId}`);
       this._addTranslationSuttaMarkupToSpan(suttasSection, escapeKey);
       this._addTranslationSuttaMarkupToSpan(suttaArticle, escapeKey);
@@ -563,8 +559,8 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       return;
     }
     mapSutta.forEach((value, key) => {
-      let escapeKey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');
-      let suttaId = key.split(':')[0].replace(/\./g, '\\\.');
+      let escapeKey = key.replace(/:/ug, '\\\:').replace(/\./ug, '\\\.');
+      let suttaId = key.split(':')[0].replace(/\./ug, '\\\.');
       let suttaArticle = this.shadowRoot.querySelector(`#${suttaId}`);
       if (suttaArticle) {
         const segmentElement = suttaArticle.querySelector(`#${escapeKey}`);
@@ -608,8 +604,8 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       return;
     }
     mapComment.forEach((value, key) => {
-      let escapeKey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');
-      let suttaId = key.split(':')[0].replace(/\./g, '\\\.');
+      let escapeKey = key.replace(/:/ug, '\\\:').replace(/\./ug, '\\\.');
+      let suttaId = key.split(':')[0].replace(/\./ug, '\\\.');
       let suttaArticle = this.shadowRoot.querySelector(`#${suttaId}`);
       if (suttaArticle) {
         const translationSpan = suttaArticle.querySelector(`#${escapeKey} .translation`);
@@ -639,8 +635,8 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       return;
     }
     mapVariant.forEach((value, key) => {
-      let escapeKey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');
-      let suttaId = key.split(':')[0].replace(/\./g, '\\\.');
+      let escapeKey = key.replace(/:/ug, '\\\:').replace(/\./ug, '\\\.');
+      let suttaId = key.split(':')[0].replace(/\./ug, '\\\.');
       let suttaArticle = this.shadowRoot.querySelector(`#${suttaId}`);
       if (suttaArticle) {
         const rootSpan = suttaArticle.querySelector(`#${escapeKey} .root`);
@@ -693,8 +689,8 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       return;
     }
     mapRef.forEach((value, key) => {
-      let escapeKey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');
-      let suttaId = key.split(':')[0].replace(/\./g, '\\\.');
+      let escapeKey = key.replace(/:/ug, '\\\:').replace(/\./ug, '\\\.');
+      let suttaId = key.split(':')[0].replace(/\./ug, '\\\.');
       let suttaArticle = this.shadowRoot.querySelector(`#${suttaId}`);
       if (suttaArticle) {
         const refElement = suttaArticle.querySelector(`#${escapeKey} .reference`);
@@ -749,8 +745,8 @@ class SCBilaraSegmentedText extends SCLitTextPage {
     this._addTranslationSuttaMarkup();
     const suttasSection = this.shadowRoot.querySelector('section.range');
     mapSutta.forEach((value, key) => {
-      let escapeKey = key.replace(/:/g, '\\\:').replace(/\./g, '\\\.');
-      let suttaId = key.split(':')[0].replace(/\./g, '\\\.');
+      let escapeKey = key.replace(/:/ug, '\\\:').replace(/\./ug, '\\\.').replace(/\^/ug, '\\\^');
+      let suttaId = key.split(':')[0].replace(/\./ug, '\\\.');
       let suttaArticle = this.shadowRoot.querySelector(`#${suttaId}`);
       this._addTranslationTextToSpan(suttasSection, escapeKey, value);
       this._addTranslationTextToSpan(suttaArticle, escapeKey, value);
@@ -927,7 +923,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       this._segmentedTextContentElement().classList.add('latin-script');
       // set the latin text segment iso codes, if not set already
       if (!this._segmentedTextContentElement().querySelector(`.original-text[lang='pli-Latn']`)) {
-        segments.forEach((item) => this._setScriptISOCode(item, this.rootLang));
+        segments.forEach((item) => this._setScriptISOCode(item, this.rootSutta.lang));
       }
       this.hasScriptBeenChanged = false;
     } else if (scriptNames.includes(this.paliScript)) { // if the script name is valid:
@@ -935,7 +931,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       this.hasScriptBeenChanged = true;
     }
     if (!this.translatedSutta) { // if we're in a segmented root text, set the top text div lang attribute:
-      this._setScriptISOCode(this._segmentedTextContentElement(), this.rootLang);
+      this._setScriptISOCode(this._segmentedTextContentElement(), this.rootSutta.lang);
     } else {
       this._segmentedTextContentElement().removeAttribute('lang');
     }
@@ -974,7 +970,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
 
   _setScriptOfSegments(segments, scriptFunctionName, t) {
     Array.from(segments).forEach(item => {
-      this._setScriptISOCode(item, this.rootLang);
+      this._setScriptISOCode(item, this.rootSutta.lang);
       let words = item.querySelectorAll('.word');
       Array.from(words).forEach(word => {
         word.dataset.latin_text = word.innerHTML;

--- a/client/elements/text/sc-text-page-selector.js
+++ b/client/elements/text/sc-text-page-selector.js
@@ -1,7 +1,6 @@
 import { LitElement, html } from 'lit-element';
 import '@polymer/iron-icon/iron-icon.js';
 
-import './sc-segmented-text.js';
 import './sc-bilara-segmented-text.js';
 import './sc-simple-text.js';
 import './sc-stepper.js';
@@ -45,7 +44,6 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
         </div>
         ${this.displaySimpleTextTemplate}
         ${this.displaySegmentedTextTemplate}
-        ${this.displayBilaraSegmentedTextTemplate}
         ${this.displayError}
       </div>
       ${this.displayStepper}
@@ -90,24 +88,6 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
       return '';
     }
     return !this._shouldHideSegmentedText() ? html`
-      <sc-segmented-text
-        id="segmented_text"
-        .rootSutta=${this.rootSutta}
-        .markup="${this.markup}"
-        .translatedSutta=${this.translatedSutta}
-        .rootLang="${this.responseData.root_text.lang}"
-        .isLoading=${this.isLoading}
-        .error=${this.lastError}
-        ?hidden=${this._shouldHideSegmentedText()}>
-      </sc-segmented-text>
-    ` : '';
-  }
-
-  get displayBilaraSegmentedTextTemplate() {
-    if (!this.responseData || !this.responseData.root_text) {
-      return '';
-    }
-    return this._shouldDisplayBilaraSegmentedText() ? html`
       <sc-bilara-segmented-text
         id="segmented_text"
         .rootSutta=${this.rootSutta}
@@ -118,10 +98,8 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
         .suttaComment=${this.suttaComment}
         .suttaReference=${this.suttaReference}
         .suttaVariant=${this.suttaVariant}
-        .rootLang="${this.responseData.root_text.lang}"
         .isLoading=${this.isLoading}
-        .error=${this.lastError}
-        ?hidden=${!this._shouldDisplayBilaraSegmentedText()}>
+        .error=${this.lastError}>
       </sc-bilara-segmented-text>
     ` : '';
   }
@@ -262,9 +240,7 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
       this.previous.name = this._transformId(this.previous.uid, this.expansionReturns);
     }
 
-    if (this._shouldDisplayBilaraSegmentedText()) {
-      this._getBilaraText();
-    }
+    this._getBilaraText();
   }
 
   _getSuttaTextUrl() {
@@ -376,14 +352,7 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
   }
 
   _shouldHideSegmentedText() {
-    return (!this.isSegmentedText || this.isLoading || this._shouldDisplayBilaraSegmentedText());
-  }
-
-  _shouldDisplayBilaraSegmentedText() {
-    if (!this.translatedSutta) {
-      return false;
-    }
-    return (this.isSegmentedText && !this.isLoading && this.translatedSutta.author_uid === 'sujato');
+    return (!this.isSegmentedText || this.isLoading);
   }
 
   _shouldDisplayStepper() {


### PR DESCRIPTION
1. Use sc-bilara-segmented-text.js instead of sc-segmented-text.js.
2. Root text and translated text were all shown by sc-bilara-segmented-text.js.