### PR TITLE
remove flex-basis from search results

### DIFF
--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -97,7 +97,6 @@ class SCPageSearch extends LitLocalized(LitElement) {
 
         .padded-container {
           display: flex;
-          flex-basis: 0.000000001px;
           flex-direction: column;
           padding: 0 var(--sc-size-md);
         }


### PR DESCRIPTION
This just removes the line 

```
          flex-basis: 0.000000001px;
```

in sc-page-search.js. This is bad CSS and was causing problems.
