### PR TITLE
Let the site title is only displayed on the home page.

### DIFF
--- a/client/elements/navigation/sc-linden-leaves.js
+++ b/client/elements/navigation/sc-linden-leaves.js
@@ -12,114 +12,101 @@ class SCLindenLeaves extends LitLocalized(LitElement) {
 
   static get styles() {
     return css`
-:host
-{
-    display: block;
-}
+      :host {
+        display: block;
+      }
 
-nav
-{
-    display: flex;
-    overflow-x: auto;
-    flex-direction: row;
+      nav {
+        display: flex;
+        overflow-x: auto;
+        flex-direction: row;
 
-    box-sizing: border-box;
-    padding: 0 2%;
+        box-sizing: border-box;
+        padding: 0 2%;
 
-    white-space: nowrap;
+        white-space: nowrap;
 
-    background-color: rgb(75, 74, 74);
+        background-color: rgb(75, 74, 74);
 
-    justify-content: space-between;
-}
+        justify-content: space-between;
+      }
 
-nav ul
-{
-    display: flex;
+      nav ul {
+        display: flex;
 
-    width: 100%;
-    margin: 0;
-    padding: 0;
-}
+        width: 100%;
+        margin: 0;
+        padding: 0;
+      }
 
-nav li
-{
-    font-size: .8em;
-    font-weight: 500;
+      nav li {
+        font-size: 0.8em;
+        font-weight: 500;
 
-    margin: 0 0 0 8px;
+        margin: 0 0 0 8px;
 
-    list-style-type: none;
-}
+        list-style-type: none;
 
-nav li a
-{
-    display: inline-block;
+        position: relative;
+      }
 
-    padding: 14px 4px 10px 0px;
+      nav li a {
+        display: inline-block;
 
-    color: white;
+        padding: 14px 4px 10px 0px;
 
-    text-decoration: none;
+        color: white;
 
-    opacity: 0.8;
-}
+        text-decoration: none;
 
-nav li a:hover
-{
-    cursor: pointer;
+        opacity: 0.8;
+      }
 
-    border-bottom: 4px solid var(--sc-primary-color-light);
-}
+      nav li a:hover {
+        cursor: pointer;
 
-nav li:last-child
-{
-    font-weight: 800;
+        border-bottom: 4px solid var(--sc-primary-color-light);
+      }
 
-    border-bottom: 4px solid var(--sc-primary-color-light);
+      nav li:last-child {
+        font-weight: 800;
 
-}
+        border-bottom: 4px solid var(--sc-primary-color-light);
+      }
 
-nav li:last-child a:hover
-{
-    cursor: default;
+      nav li:last-child a:hover {
+        cursor: default;
 
-    color: white;
-    border-bottom: none;
-}
+        color: white;
+        border-bottom: none;
+      }
 
-nav li:last-child a
-{
-    cursor: default;
+      nav li:last-child a {
+        cursor: default;
 
-    opacity: 1
-}
+        opacity: 1;
+      }
 
-nav li:after
-{
-    font-weight: 400;
+      nav li:after {
+        font-weight: 400;
 
-    margin-left: 8px;
+        margin-left: 8px;
 
-    content: '❭';
+        content: "❭";
 
-    color: white;
+        color: white;
 
-    opacity: 0.8;
-}
+        opacity: 0.8;
+      }
 
-nav li:last-of-type:after
-{
-    margin-left: 0;
+      nav li:last-of-type:after {
+        margin-left: 0;
+        content: "";
+      }
 
-    content: '';
-}
-
-nav li:first-of-type
-{
-    margin-left: 0;
-}
-
+      nav li:first-of-type {
+        margin-left: 0;
+      }
     `;
   }
 

--- a/client/elements/navigation/sc-navigation.js
+++ b/client/elements/navigation/sc-navigation.js
@@ -382,7 +382,7 @@ class SCNavigation extends LitLocalized(LitElement) {
     }
 
     let displayVaggasMenu = this.vaggasData[0] && this.vaggasData[0].children &&
-      this.vaggasData[0].children.some(child => ['div', 'division', 'subdivision'].includes(child.type)) ? true : false; 
+      this.vaggasData[0].children.some(child => ['div', 'division', 'subdivision'].includes(child.type)); 
 
     let currentUrl = `/${childId}`;
     if (displayVaggasMenu) {
@@ -479,7 +479,7 @@ class SCNavigation extends LitLocalized(LitElement) {
     }
 
     this.displayVaggaChildren = this.vaggaChildren && 
-      this.vaggaChildren.some(child => ['div', 'division', 'subdivision'].includes(child.type)) ? true : false; 
+      this.vaggaChildren.some(child => ['div', 'division', 'subdivision'].includes(child.type)); 
 
     let currentUrl = `/${childId}`;
     if (this.displayVaggaChildren) {
@@ -551,7 +551,7 @@ class SCNavigation extends LitLocalized(LitElement) {
     }
 
     this.displayVaggaChildrenChildren = this.vaggaChildrenChildren && 
-      this.vaggaChildrenChildren[0].children.some(child => ['div', 'division', 'subdivision'].includes(child.type)) ? true : false; 
+      this.vaggaChildrenChildren[0].children.some(child => ['div', 'division', 'subdivision'].includes(child.type));
 
     this.displayVaggaChildren = false;
     let currentUrl = `/${childId}`;
@@ -626,7 +626,7 @@ class SCNavigation extends LitLocalized(LitElement) {
     }
 
     this.displaySakaChildren = this.sakaChildren && 
-      this.sakaChildren.some(child => ['div', 'division', 'subdivision'].includes(child.type)) ? true : false; 
+      this.sakaChildren.some(child => ['div', 'division', 'subdivision'].includes(child.type));
 
     this.displayVaggaChildrenChildren = !this.displaySakaChildren;
 

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -336,7 +336,7 @@ class SCPageSelector extends ReduxMixin(Localized(PolymerElement)) {
     this.parentNode.querySelector('#titlebar').style.display = displayStyle;
 
     this._setViewModeButtonDisplayState();
-    this.dispatch('changeDisplaySCSiteTitleState', this.shouldShowStaticPage);
+    this.dispatch('changeDisplaySCSiteTitleState', this.route.path === '/' ? true : false);
   }
 
   // Lazy loading for site elements


### PR DESCRIPTION
1. let the site title is only displayed on the home page.
2. limit the ripple boundaries of the breadcrumbs.
3. sc-navigation.js code clean up(Delete redundant `true: false`)