### PR TITLE
Open more PWA enabled browsers to use SC offline function.

### DIFF
--- a/client/elements/static/offline-page.js
+++ b/client/elements/static/offline-page.js
@@ -784,15 +784,16 @@ class SCOfflinePage extends ReduxMixin(Localized(PolymerElement)) {
       tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
       return false;
     }
-    if (M[1] === 'Chrome') {
-      tem = ua.match(/\b(OPR|Edge)\/(\d+)/);
-      if (tem != null) return false;
-    }
+
     M = M[2] ? [M[1], M[2]] : [navigator.appName, navigator.appVersion, '-?'];
     if ((tem = ua.match(/version\/(\d+)/i)) != null) M.splice(1, 1, tem[1]);
 
     // Check if it is supported browser
-    return M[0].toLowerCase() === 'chrome' && parseInt(M[1]) >= 65;
+    return (M[0].toLowerCase() === 'chrome' && parseInt(M[1]) >= 65) || 
+              (M[0].toLowerCase() === 'firefox' && parseInt(M[1]) >= 79) ||
+                (M[0].toLowerCase() === 'safari' && parseInt(M[1]) >= 11.3) ||
+                  (M[0].toLowerCase() === 'opera' && parseInt(M[1]) >= 65) ||
+                    (M[0].toLowerCase() === 'edge' && parseInt(M[1]) >= 79);
   }
 
   _canBeAddedToHomeScreen() {


### PR DESCRIPTION
Open more PWA enabled browsers to use SC offline function.

At present, PWA is supported by the specific versions of Firefox, edge, IOS Safari and opera browsers.