### PR TITLE
small style tweaks for breadcrumbs

### DIFF
--- a/client/elements/navigation/sc-linden-leaves.js
+++ b/client/elements/navigation/sc-linden-leaves.js
@@ -42,11 +42,7 @@ class SCLindenLeaves extends LitLocalized(LitElement) {
         font-size: 0.8em;
         font-weight: 500;
 
-        margin: 0 0 0 8px;
-
         list-style-type: none;
-
-        position: relative;
 
         display: flex;
         align-items: center;
@@ -55,13 +51,16 @@ class SCLindenLeaves extends LitLocalized(LitElement) {
       nav li a {
         display: inline-block;
 
-        padding: 14px 4px 10px 0px;
+        padding: 14px 8px 10px 8px;
 
         color: white;
 
         text-decoration: none;
 
         opacity: 0.8;
+
+        border-bottom: 4px solid rgba(0,0,0,0);
+        position: relative;
       }
 
       nav li a:hover {
@@ -94,11 +93,11 @@ class SCLindenLeaves extends LitLocalized(LitElement) {
       }
 
       mwc-icon {
-        color: var(--sc-secondary-text-color);
+        color: var(--sc-disabled-text-color);
       }
 
       .lastLiPadding {
-        padding: 14px 4px 10px 0px;
+        padding: 14px 8px 10px 8px;
       }
     `;
   }


### PR DESCRIPTION
This fixes some small style regressions introduced when using the mwc-icons.

- Stop items from changing position on hover (this is a crude way to do it, I am sure there are better  ways!)
- Ensure correct padding for ripple effect.
- Use `var(--sc-disabled-text-color)` for icons. This is the standard color for icons, not secondary-text-color. It should really be renamed `sc-icon-color` but oh well, nothing is perfect!