### PR TITLE
Make top and bottom margins of content more consistent

### DIFF
--- a/client/elements/navigation/sc-linden-leaves.js
+++ b/client/elements/navigation/sc-linden-leaves.js
@@ -19,6 +19,7 @@ class SCLindenLeaves extends LitLocalized(LitElement) {
         display: flex;
         overflow-x: auto;
         flex-direction: row;
+        height: 46px;
 
         box-sizing: border-box;
         padding: 0 calc(2% - 8px);

--- a/client/elements/navigation/sc-navigation-styles.js
+++ b/client/elements/navigation/sc-navigation-styles.js
@@ -4,14 +4,12 @@ export const navigationNormaModelStyles = html`
   <style>
     main {
       max-width: 720px;
-      margin: var(--sc-size-md-larger) auto;
+      margin: 0 auto 64px;
     }
 
     .main-nav {
       display: flex;
       flex-direction: row;
-
-      margin-top: 4em;
 
       justify-content: center;
       flex-wrap: nowrap;

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -35,15 +35,8 @@ class SCPageSelector extends ReduxMixin(Localized(PolymerElement)) {
         height: 100%;
       }
 
-      .container {
-        position: relative;
-        min-height: calc(100vh - 108px);
-      }
-
-      sc-text-page-selector {
-        display: flex;
-        flex: 1;
-        flex-direction: column;
+      .container{
+        margin-top: 64px;
       }
 
       .link-anchor {

--- a/client/elements/static/home-page.js
+++ b/client/elements/static/home-page.js
@@ -21,7 +21,7 @@ class SCHomePage extends SCStaticPage {
 
       main {
         max-width: 1600px;
-        margin: 0 auto 8em;
+        margin: 0 auto;
         padding: 0 2%;
       }
 

--- a/client/elements/styles/sc-layout-bilara-styles.js
+++ b/client/elements/styles/sc-layout-bilara-styles.js
@@ -3,7 +3,6 @@ import { html,css } from 'lit-element';
 export const commonStyles = css`
   main {
     display: flex;
-    margin: 4em 1em;
     justify-content: center;
   }
   

--- a/client/elements/styles/sc-layout-simple-styles.js
+++ b/client/elements/styles/sc-layout-simple-styles.js
@@ -1,13 +1,6 @@
 import { css } from 'lit-element';
 
 export const layoutSimpleStyles = css`
-  main {
-    display: flex;
-
-    margin: 4.2em 2.4em;
-
-    justify-content: center;
-  }
 
   section,
   article {

--- a/client/elements/styles/sc-page-selector-styles.js
+++ b/client/elements/styles/sc-page-selector-styles.js
@@ -8,12 +8,6 @@ export const SCPageSelectorStyles = html`
       height: 100%;
     }
 
-    sc-text-page-selector {
-      display: flex;
-      flex: 1;
-      flex-direction: column;
-    }
-
     /* Only static pages use transparent backgrounds, other pages use the original backgrounds. */
     .toolbar-header,
     #sc_action_items {

--- a/client/elements/styles/sc-static-page-selector-styles.js
+++ b/client/elements/styles/sc-static-page-selector-styles.js
@@ -134,8 +134,7 @@ export const SCPageStaticSelectorOriginStyles = html`
     }
 
     #pages {
-      /* Subtract height of top bar */
-      min-height: calc(100vh - 145px - var(--sc-size-xxl) - var(--sc-size-xl));
+      margin-bottom: 64px;
       position: relative;
     }
   </style>

--- a/client/elements/styles/sc-typography-common-styles.js
+++ b/client/elements/styles/sc-typography-common-styles.js
@@ -17,7 +17,6 @@ export const typographyCommonStyles = css`
   main {
     display: flex;
     justify-content: center;
-    margin: 4em 1em;
   }
 
 /* text block elements */

--- a/client/elements/suttaplex/sc-suttaplex-list.css.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.css.js
@@ -7,14 +7,12 @@ export const suttaplexListCss = html`<style>
 
   .division-content {
     color: var(--sc-primary-text-color);
-    /* Subtract margins and top bar height */
-    height: calc(100vh - var(--sc-size-md-larger) * 2 - var(--sc-size-xxl));
     position: relative;
     padding: 0;
     }
 
   .main {
-    margin: var(--sc-size-md-larger) auto;
+    margin: 0 auto 64px;
     max-width: 720px;
   }
 

--- a/client/elements/text/sc-stepper.js
+++ b/client/elements/text/sc-stepper.js
@@ -7,6 +7,7 @@ class SCStepper extends LitElement {
   render() {
     return html`
     <style>
+
       @media print {
         :host {
           display: none;
@@ -16,7 +17,7 @@ class SCStepper extends LitElement {
       .bar {
         display: flex;
         width: 100%;
-        height: calc(var(--sc-size-xxl) * 1.5);
+        height: 96px;
         background-color: var(--sc-secondary-text-color);
         overflow: hidden
       }

--- a/client/elements/text/sc-text-page-selector.js
+++ b/client/elements/text/sc-text-page-selector.js
@@ -34,7 +34,8 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
         }
 
         .wrapper {
-          flex: 1;
+        min-height: calc(100vh - 334px);
+        margin-bottom: 64px;
         }
 
         .sutta-list {

--- a/client/index.html
+++ b/client/index.html
@@ -62,7 +62,7 @@
     }
     
     html, body {
-      min-height: 100vh;
+      height: 100%;
     }
 
     body {


### PR DESCRIPTION
This fix adjusts the handling of the top and bottom margins in the various contexts:

- static pages
- nav pages
- suttaplex list
- text pages
- search results

I'm still not happy with the way the foot is placed in the text pages, as it relies on the adding up the height of all other elements, if any of them change it will break. We should use a flexbox method like here, but I can't get it to work.

https://developer.mozilla.org/en-US/docs/Web/CSS/Layout_cookbook/Sticky_footers

