### PR TITLE
Sujato header

### DIFF
--- a/client/elements/menus/sc-action-items.js
+++ b/client/elements/menus/sc-action-items.js
@@ -21,7 +21,7 @@ class SCActionItems extends LitLocalized(LitElement) {
       #tools_menu {
         display: flex;
         justify-content: space-between;
-        align-items: center;
+        align-items: baseline;
       }
 
       .invisible {
@@ -39,7 +39,7 @@ class SCActionItems extends LitLocalized(LitElement) {
       #btnDarkTheme:after,
       #btnViewCompact:after,
       #btnViewComfy:after {
-        font-size: var(--sc-skolar-font-size-xxs);;
+        font-size: var(--sc-skolar-font-size-xxs);
 
         position: absolute;
         bottom: -4px;

--- a/client/elements/menus/sc-action-items.js
+++ b/client/elements/menus/sc-action-items.js
@@ -31,14 +31,16 @@ class SCActionItems extends LitLocalized(LitElement) {
       #btnLightTheme,
       #btnDarkTheme,
       #btnViewCompact,
-      #btnViewComfy {
+      #btnViewComfy,
+      #btnTools {
         position: relative;
       }
 
       #btnLightTheme:after,
       #btnDarkTheme:after,
       #btnViewCompact:after,
-      #btnViewComfy:after {
+      #btnViewComfy:after,
+      #btnTools:after {
         font-size: var(--sc-skolar-font-size-xxs);
 
         position: absolute;
@@ -63,6 +65,10 @@ class SCActionItems extends LitLocalized(LitElement) {
 
       #btnViewComfy:after {
         content: 'spacing';
+      }
+      
+      #btnTools:after{
+        content: 'views'
       }
     </style>
 
@@ -117,10 +123,10 @@ class SCActionItems extends LitLocalized(LitElement) {
       </mwc-icon-button>
       
       <mwc-icon-button 
-        icon="settings" 
+        icon="visibility" 
         class="white-icon toolButtons" 
         id="btnTools" 
-        title="Text options" 
+        title="View options" 
         @click="${this._onBtnToolsClick}" 
         slot="actionItems" 
         ?hidden="${this.displayToolButton}">

--- a/client/elements/navigation/sc-linden-leaves.js
+++ b/client/elements/navigation/sc-linden-leaves.js
@@ -44,6 +44,7 @@ class SCLindenLeaves extends LitLocalized(LitElement) {
       nav li {
         font-size: var(--sc-skolar-font-size-xs);
         font-weight: 500;
+        color: white;
         
         display: flex;
 

--- a/client/elements/styles/sc-site-layout-styles.js
+++ b/client/elements/styles/sc-site-layout-styles.js
@@ -23,12 +23,6 @@ export const SCSiteLayoutStyles = css`
     }
   }
 
-  @media screen and (max-width: 480px) {
-    #subTitle {
-      font-size: 1.05rem !important;
-    }
-  }
-
   .dialog-header {
     font-family: var(--sc-sans-font);
     font-size: var(--sc-skolar-font-size-static-subtitle);
@@ -107,6 +101,7 @@ export const SCSiteLayoutStyles = css`
     text-overflow: ellipsis;
 
     overflow: hidden;
+    font-size: clamp(2rem, 8vw, 3rem);
   }
 
   #mainTitle {
@@ -116,7 +111,7 @@ export const SCSiteLayoutStyles = css`
   }
 
   .homeTitle #mainTitle {
-    font-size: 3rem;
+    
     line-height: 1;
     font-family: var(--sc-serif-font);
     font-variant-caps: small-caps;
@@ -125,7 +120,7 @@ export const SCSiteLayoutStyles = css`
 
   #subTitle {
     font-style: italic;
-    font-size: 1.5rem;
+    font-size: 0.5em;
   
   }
 
@@ -153,12 +148,6 @@ export const SCSiteLayoutStyles = css`
     text-overflow: ellipsis;
   }
 
-  @media screen and (max-width: 600px) {
-    #generalTitle {
-      font-size: var(--sc-skolar-font-size-md);
-    }
-  }
-
   @media print {
     #universal_toolbar,
     #title {
@@ -167,25 +156,10 @@ export const SCSiteLayoutStyles = css`
   }
 
   .title-logo-icon {
-    height: 60px;
-    width: 60px;
-/* these hacky margins compensate for the padding in the svg icon */
-    margin: 4px 4px -4px -4px;
-  }
-
-  @media (max-width: 600px) {
-    h1 {
-      font-size: var(--sc-skolar-font-size-xxl);
-      padding-top: 0.2em;
-    }
-    .title-logo-icon {
-      height: 40px;
-      width: 40px;
-    }
-    .subtitle {
-      font-size: var(--sc-skolar-font-size-md);
-      margin-bottom: 0.5em;
-    }
+    height: 1.25em;
+    width: 1.25em;
+/* these hacky margins compensate for the padding in the svg icon. Use em to scale with clamp*/
+    margin: 0.1em 0.1em -0.1em -0.1em;
   }
 
   #static_pages_nav_menu {

--- a/client/elements/styles/sc-site-layout-styles.js
+++ b/client/elements/styles/sc-site-layout-styles.js
@@ -92,31 +92,17 @@ export const SCSiteLayoutStyles = css`
     margin: var(--sc-size-sm);
   }
 
-  #title {
-    font-family: "skolar pe";
-    margin-right: auto;
-    background-color: var(--sc-primary-color);
-  }
-
   .homeTitle {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
 
     box-sizing: border-box;
-    height: 3em;
+    height: 144px;
     margin: auto;
-    margin-right: auto;
 
     transition: all 0.1s;
 
-    font-size: 3em;
-    line-height: 0.9;
-    font-family: "skolar pe";
-    font-variant-caps: small-caps;
-
-    text-align: center;
     white-space: nowrap;
     text-overflow: ellipsis;
 
@@ -126,21 +112,26 @@ export const SCSiteLayoutStyles = css`
   #mainTitle {
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-end;
+  }
+
+  .homeTitle #mainTitle {
+    font-size: 3em;
+    line-height: 1;
+    font-family: var(--sc-serif-font);
+    font-variant-caps: small-caps;
+    letter-spacing: var(--sc-caps-letter-spacing);
   }
 
   #subTitle {
-    text-align: center;
     font-style: italic;
     font-size: 1.5rem;
-    display: flex;
-    justify-content: center;
-    margin-left: 1em;
-    font-variant-caps: normal;
+  
   }
 
   #universal_toolbar {
-    color: white;
+    background-color: var(--sc-primary-color);
+    color: var(--sc-tertiary-text-color);
     position: sticky;
     top: 0;
     box-shadow: var(--sc-shadow-elevation-2dp);
@@ -149,21 +140,17 @@ export const SCSiteLayoutStyles = css`
 
   #context_toolbar {
     display: flex;
-    background-color: var(--sc-primary-color);
+    justify-content: space-between;
     padding: 0 2%;
   }
 
   .generalTitle {
-    font-weight: normal;
     display: flex;
     align-items: center;
-    font-family: var(--sc-sans-font);
     font-size: calc(20px * var(--sc-skolar-font-scale));
-    color: var(--sc-tertiary-text-color);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    width: calc(80%);
   }
 
   @media screen and (max-width: 600px) {
@@ -180,11 +167,10 @@ export const SCSiteLayoutStyles = css`
   }
 
   .title-logo-icon {
-    vertical-align: bottom;
-    height: var(--sc-size-xxl);
-    width: var(--sc-size-xxl);
-    margin-bottom: 6px;
-    margin-right: -2px;
+    height: 60px;
+    width: 60px;
+/* these hacky margins compensate for the padding in the svg icon */
+    margin: 4px 4px -4px -4px;
   }
 
   @media (max-width: 600px) {

--- a/client/elements/styles/sc-site-layout-styles.js
+++ b/client/elements/styles/sc-site-layout-styles.js
@@ -116,7 +116,7 @@ export const SCSiteLayoutStyles = css`
   }
 
   .homeTitle #mainTitle {
-    font-size: 3em;
+    font-size: 3rem;
     line-height: 1;
     font-family: var(--sc-serif-font);
     font-variant-caps: small-caps;


### PR DESCRIPTION
This makes some small changes to the styles for the header.

- apply background color to whole toolbar to avoid possible gaps in background
- likewise, let font-family be applied globally i.e. `:root {    font-family: var(--sc-sans-font);}`, only change it if using a different font.
- remove unused CSS
- make sure flex styles are applied properly

Also, I have changed to use the "visibility" icon for text settings, with the label "views".
