### PR TITLE
Sujato container

### DIFF
--- a/client/elements/addons/sc-bottom-sheet.js
+++ b/client/elements/addons/sc-bottom-sheet.js
@@ -38,6 +38,7 @@ export class SCBottomSheet extends LitElement {
       display: none;
       background-color: var(--sc-secondary-background-color);
       bottom: 0px;
+      margin: 0 calc(-1 * var(--sc-container-margin)) -64px;
       animation: bottomSheetShow 200ms 1 ease-in normal forwards;
     }
 

--- a/client/elements/addons/sc-bottom-sheet.js
+++ b/client/elements/addons/sc-bottom-sheet.js
@@ -106,6 +106,10 @@ details[open]
     right: 10vw;
 
     width: 80vw;
+
+    box-shadow: var(--sc-shadow-elevation-8dp);
+
+    border-radius: 4px
 }
 
 summary

--- a/client/elements/addons/sc-bottom-sheet.js
+++ b/client/elements/addons/sc-bottom-sheet.js
@@ -25,191 +25,227 @@ export class SCBottomSheet extends LitElement {
 
   static get styles() {
     return css`
-      @media print {
-        :host {
-          display: none;
-        }
-      }
 
-    :host {
-      /* display: block; */
-      z-index: 9999;
-      position: sticky;
-      display: none;
-      background-color: var(--sc-secondary-background-color);
-      bottom: 0px;
-      margin: 0 calc(-1 * var(--sc-container-margin)) -64px;
-      animation: bottomSheetShow 200ms 1 ease-in normal forwards;
-    }
 
-    #wrapper {
-      box-shadow: 1px 1px .5px .5px rgba(0, 0, 0, 0.14);
-      font-family: "skolar sans pe";
-      height: 200px
-    }
+body,
+main,
+article,
+header,
+footer
+{
+  display: flex;
+}
 
-    body,
-    main,
-    article,
-    header,
-    footer {
-      display: flex;
-    }
+header
+{
+  position: relative;;
 
-    header {
-      padding: 0px var(--sc-size-md);
-      justify-content: space-between;
-      align-items: center;
-      background-color: var(--sc-secondary-text-color);
-      color: var(--sc-primary-background-color);
-      height: 32px;
-      position: relative
-    }
+  height: 32px;
+  padding: 0 var(--sc-size-md);
 
-    header div {
-      display: flex;
-      flex-direction: row;
-    }
+  color: var(--sc-primary-background-color);
+  background-color: var(--sc-secondary-text-color);
 
-    details {
-      padding: 4px;
-      background-color: var(--sc-secondary-text-color);
-      color: var(--sc-primary-background-color);
-      font-size: 14px;
-      z-index: 1;
-    }
+  justify-content: space-between;
+  align-items: center;
+}
 
-    details ul {
-      margin-right: 1em
-    }
+header div
+{
+  display: flex;
+  flex-direction: row;
+}
 
-    details a {
-      color: inherit;
-      text-decoration: underline;
-      text-decoration-color: var(--sc-primary-color);
-      text-decoration-skip-ink: auto;
-    }
+details
+{
+  font-size: 14px;
 
-    details[open] {
-      position: absolute;
-      top: -300px;
-      width: 80vw;
-      right: 10vw
-    }
+  z-index: 1;
 
-    summary {
-      white-space: nowrap;
-    }
+  padding: 4px;
 
-    header button {
-      width: 100%;
-      background: none;
-      border: none;
-    }
+  color: var(--sc-primary-background-color);
+  background-color: var(--sc-secondary-text-color);
+}
 
-    #btnClose {
-      cursor: pointer;
-      color: inherit;
-    }
+details ul
+{
+  margin-right: 1em;
+}
 
-    dfn {
-      background-color: var(--sc-primary-color-light);
-      color: var(--sc-paper-tooltip-color);
-      padding: 0 var(--sc-size-sm);
-      margin-left: calc((100vw - 960px) / 2);
-    }
+details a
+{
+  text-decoration: underline;
 
-    main {
-      justify-content: center;
-    }
+  color: inherit;
 
-    article {
-      height: 120px;
-      overflow-x: hidden;
-      overflow-y: auto;
-      padding: 12px 16px 0;
-      box-sizing: border-box;
-      width: 960px
-    }
+  text-decoration-color: var(--sc-primary-color);
+}
 
-    dl {
-      margin: 0 0 16px 0;
-      display: table;
-      /*hack to get the padding-bottom working*/
-      font-size: 16px;
-    }
+details[open]
+{
+  position: absolute;
+  top: -300px;
+  right: 10vw;;
 
-    dt {
-      display: inline-block;
-      background-color: var(--sc-primary-color-light);
-    }
+  width: 80vw;
+}
 
-    dd {
-      margin: var(--sc-size-sm) 0 0 0
-    }
+summary
+{
+  white-space: nowrap;
+}
 
-    dd a {
-      color: inherit;
-      text-decoration: underline;
-      text-decoration-color: var(--sc-primary-color);
-      text-decoration-skip-ink: auto;
-      font-weight: bold
-    }
+header button
+{
+  width: 100%;
 
-    footer {
-      border-top: 1px solid rgba(0, 0, 0, 0.12);
-      height: 48px;
-      background-color: var(--sc-secondary-background-color);
-      box-sizing: border-box;
-    }
+  border: none;
+  background: none;
+}
 
-    footer div {
-      width: 50%;
-      text-align: center;
-      position: relative
-    }
+#btnClose
+{
+  cursor: pointer;
 
-    #next {
-      border-left: 1px solid var(--sc-border-color);
-    }
+  color: inherit;
+}
 
-    footer div button {
-      font-size: 2em;
-      width: 100%;
-      height: 100%;
-      background: none;
-      border: none;
-      cursor: pointer;
-      /* vertical-align: top; */
-      padding-bottom: 10px;
-      color: var(--sc-disabled-text-color)
-    }
+dfn
+{
+  margin-left: calc((100vw - 960px) / 2);
+  padding: 0 var(--sc-size-sm);
 
-    #btnNext {
-      border-left: 1px solid rgba(0, 0, 0, 0.14);
-    }
+  color: var(--sc-paper-tooltip-color);
+  background-color: var(--sc-primary-color-light);
+}
 
-    morph-ripple {
-      --ripple-color: var(--sc-primary-color);
-    }
+main
+{
+  justify-content: center;
+}
 
-    @keyframes bottomSheetShow {
-      from {
-        bottom: -200px;
-      }
-      to {
-        bottom: 0px;
-      }
-    }
+article
+{
+  overflow-x: hidden;
+  overflow-y: auto;
 
-    @keyframes bottomSheetHide {
-      from {
-        bottom: 0px;
-      }
-      to {
-        bottom: -200px;
-      }
-    }`;
+  box-sizing: border-box;
+  width: 960px;;
+  height: 120px;
+  padding: 12px 16px 0;
+}
+
+dl
+{
+  /*hack to get the padding-bottom working*/
+  font-size: 16px;
+
+  display: table;
+
+  margin: 0 0 16px 0;
+}
+
+dt
+{
+  display: inline-block;
+
+  background-color: var(--sc-primary-color-light);
+}
+
+dd
+{
+  margin: var(--sc-size-sm) 0 0 0;
+}
+
+dd a
+{
+  font-weight: bold;;
+
+  text-decoration: underline;
+
+  color: inherit;
+
+  text-decoration-color: var(--sc-primary-color);
+}
+
+footer
+{
+  box-sizing: border-box;
+  height: 48px;
+
+  border-top: 1px solid rgba(0, 0, 0, .12);
+  background-color: var(--sc-secondary-background-color);
+}
+
+footer div
+{
+  position: relative;;
+
+  width: 50%;
+
+  text-align: center;
+}
+
+#next
+{
+  border-left: 1px solid var(--sc-border-color);
+}
+
+footer div button
+{
+  font-size: 2em;
+
+  width: 100%;
+  height: 100%;
+  /* vertical-align: top; */
+  padding-bottom: 10px;
+
+  cursor: pointer;
+
+  color: var(--sc-disabled-text-color);;
+  border: none;
+  background: none;
+}
+
+#btnNext
+{
+  border-left: 1px solid rgba(0, 0, 0, .14);
+}
+
+morph-ripple 
+{
+    --ripple-color: var(--sc-primary-color);
+}
+
+
+@keyframes bottomSheetShow
+{
+  from
+  {
+    bottom: -200px;
+  }
+
+  to
+  {
+    bottom: 0;
+  }
+}
+
+@keyframes bottomSheetHide
+{
+  from
+  {
+    bottom: 0;
+  }
+
+  to
+  {
+    bottom: -200px;
+  }
+}
+
+`;
   }
 
   render() {

--- a/client/elements/addons/sc-bottom-sheet.js
+++ b/client/elements/addons/sc-bottom-sheet.js
@@ -1,6 +1,9 @@
 import { LitElement, html, css } from 'lit-element';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 
+import '@material/mwc-icon';
+import '@material/mwc-icon-button';
+
 import '@moduware/morph-ripple';
 
 export class SCBottomSheet extends LitElement {
@@ -26,6 +29,20 @@ export class SCBottomSheet extends LitElement {
   static get styles() {
     return css`
 
+:host
+{
+    font-family: var(--sc-sans-font);
+
+    position: fixed;
+    z-index: 100;
+    bottom: 0;
+
+    width: 100%;
+    margin: 0 calc(-1 * var(--sc-container-margin));
+
+    background-color: var(--sc-secondary-background-color);
+    box-shadow: var(--sc-shadow-elevation-2dp);
+}
 
 body,
 main,
@@ -33,216 +50,217 @@ article,
 header,
 footer
 {
-  display: flex;
+    display: flex;
 }
 
 header
 {
-  position: relative;;
+    position: relative;
 
-  height: 32px;
-  padding: 0 var(--sc-size-md);
+    height: 32px;
+    padding: 0 var(--sc-size-md);
 
-  color: var(--sc-primary-background-color);
-  background-color: var(--sc-secondary-text-color);
+    color: var(--sc-primary-background-color);
+    background-color: var(--sc-secondary-text-color);
 
-  justify-content: space-between;
-  align-items: center;
+    justify-content: space-between;
+    align-items: center;;
 }
 
 header div
 {
-  display: flex;
-  flex-direction: row;
+    display: flex;
+    flex-direction: row;
 }
 
 details
 {
-  font-size: 14px;
+    font-size: 14px;
 
-  z-index: 1;
+    z-index: 1;
 
-  padding: 4px;
+    padding: 4px;
 
-  color: var(--sc-primary-background-color);
-  background-color: var(--sc-secondary-text-color);
+    color: var(--sc-primary-background-color);
+    background-color: var(--sc-secondary-text-color);
 }
 
 details ul
 {
-  margin-right: 1em;
+    margin-right: 1em;
 }
 
 details a
 {
-  text-decoration: underline;
+    text-decoration: underline;
 
-  color: inherit;
+    color: inherit;
 
-  text-decoration-color: var(--sc-primary-color);
+    text-decoration-color: var(--sc-primary-color);
 }
 
 details[open]
 {
-  position: absolute;
-  top: -300px;
-  right: 10vw;;
+    position: absolute;
+    top: -300px;
+    right: 10vw;
 
-  width: 80vw;
+    width: 80vw;
 }
 
 summary
 {
-  white-space: nowrap;
+    white-space: nowrap;
 }
 
 header button
 {
-  width: 100%;
+    width: 100%;
 
-  border: none;
-  background: none;
+    border: none;
+    background: none;
 }
 
 #btnClose
 {
-  cursor: pointer;
+    padding: 8px 16px;
 
-  color: inherit;
+    cursor: pointer;
+
+    color: inherit;
 }
 
 dfn
 {
-  margin-left: calc((100vw - 960px) / 2);
-  padding: 0 var(--sc-size-sm);
+    margin-left: calc((100vw - 960px) / 2);
+    padding: 0 var(--sc-size-sm);
 
-  color: var(--sc-paper-tooltip-color);
-  background-color: var(--sc-primary-color-light);
+    color: var(--sc-paper-tooltip-color);
+    background-color: var(--sc-primary-color-light);
 }
 
 main
 {
-  justify-content: center;
+    justify-content: center;
 }
 
 article
 {
-  overflow-x: hidden;
-  overflow-y: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
 
-  box-sizing: border-box;
-  width: 960px;;
-  height: 120px;
-  padding: 12px 16px 0;
+    box-sizing: border-box;
+    width: 960px;
+    height: 120px;
+    padding: 12px 16px 0;;
 }
 
 dl
 {
-  /*hack to get the padding-bottom working*/
-  font-size: 16px;
+    /*hack to get the padding-bottom working*/
+    font-size: 16px;
 
-  display: table;
+    display: table;
 
-  margin: 0 0 16px 0;
+    margin: 0 0 16px 0;
 }
 
 dt
 {
-  display: inline-block;
+    display: inline-block;
 
-  background-color: var(--sc-primary-color-light);
+    background-color: var(--sc-primary-color-light);
 }
 
 dd
 {
-  margin: var(--sc-size-sm) 0 0 0;
+    margin: var(--sc-size-sm) 0 0 0;
 }
 
 dd a
 {
-  font-weight: bold;;
+    font-weight: bold;
 
-  text-decoration: underline;
+    text-decoration: underline;
 
-  color: inherit;
+    color: inherit;
 
-  text-decoration-color: var(--sc-primary-color);
+    text-decoration-color: var(--sc-primary-color);;
 }
 
 footer
 {
-  box-sizing: border-box;
-  height: 48px;
+    box-sizing: border-box;
+    height: 48px;
 
-  border-top: 1px solid rgba(0, 0, 0, .12);
-  background-color: var(--sc-secondary-background-color);
+    border-top: 1px solid rgba(0, 0, 0, .12);
+    background-color: var(--sc-secondary-background-color);
 }
 
 footer div
 {
-  position: relative;;
+    position: relative;
 
-  width: 50%;
+    width: 50%;
 
-  text-align: center;
+    text-align: center;;
 }
 
 #next
 {
-  border-left: 1px solid var(--sc-border-color);
+    border-left: 1px solid var(--sc-border-color);
 }
 
 footer div button
 {
-  font-size: 2em;
+    font-size: 2em;
 
-  width: 100%;
-  height: 100%;
-  /* vertical-align: top; */
-  padding-bottom: 10px;
+    width: 100%;
+    height: 100%;
+    /* vertical-align: top; */
+    padding-bottom: 10px;
 
-  cursor: pointer;
+    cursor: pointer;
 
-  color: var(--sc-disabled-text-color);;
-  border: none;
-  background: none;
+    color: var(--sc-disabled-text-color);
+    border: none;
+    background: none;;
 }
 
 #btnNext
 {
-  border-left: 1px solid rgba(0, 0, 0, .14);
+    border-left: 1px solid rgba(0, 0, 0, .14);
 }
 
-morph-ripple 
+  morph-ripple 
 {
     --ripple-color: var(--sc-primary-color);
 }
 
-
 @keyframes bottomSheetShow
 {
-  from
-  {
-    bottom: -200px;
-  }
+    from
+    {
+        bottom: -200px;
+    }
 
-  to
-  {
-    bottom: 0;
-  }
+    to
+    {
+        bottom: 0;
+    }
 }
 
 @keyframes bottomSheetHide
 {
-  from
-  {
-    bottom: 0;
-  }
+    from
+    {
+        bottom: 0;
+    }
 
-  to
-  {
-    bottom: -200px;
-  }
+    to
+    {
+        bottom: -200px;
+    }
 }
 
 `;
@@ -269,7 +287,8 @@ morph-ripple
                     </li>
                 </ul>
               </details>
-              <button id="btnClose" @click=${this.hide}>&#8675;</button>
+              <button id="btnClose" @click=${this.hide}>✕</button>
+
             </div>
         </header>
         <main>

--- a/client/elements/addons/sc-nav-contents.js
+++ b/client/elements/addons/sc-nav-contents.js
@@ -10,20 +10,20 @@ const styles = html`
   border-radius: 2px;
 }
 
+ol
+{
+  margin: 0 0 0 1em;
+  padding: 0 0 0 1rem;
+}
+
 li
 {
-  font-family: var(--sc-sans-font);
+  font-family: var(--sc-serif-font);
   font-size: var(--sc-skolar-font-size-md);
   font-weight: 400;
 
   margin: .5em 0;
   padding: .25em 0 .25em clamp(0rem, 3vw, 1rem);
-}
-
-ol
-{
-  margin: 0;
-  padding: 0 0 0 1rem;
 }
 
 li::marker
@@ -45,7 +45,6 @@ a:hover
 {
   color: var(--sc-primary-color);
 }
-
 
 </style>`;
 

--- a/client/elements/addons/sc-nav-contents.js
+++ b/client/elements/addons/sc-nav-contents.js
@@ -2,43 +2,51 @@ import { LitElement, html } from 'lit-element';
 
 const styles = html`
 <style>
-  .contents {
-    margin: 0 auto !important;
-    padding: 0 var(--sc-size-md);
-    max-width: 720px;
-    display: block;
-    border-radius: 2px;
-    border-left: 4px solid #F6C200;
-  }
+  .contents
+{
+  margin: 0 auto !important;
 
-  li {
-    font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-md);
-    font-weight: 400;
-    line-height: 24px;
-    margin: 0.5em 0;
-    padding: var(--sc-size-xs) 0;
-  }
+  border-left: 4px solid var(--sc-primary-color-light);
+  border-radius: 2px;
+}
 
-  ol {
-    margin: 1em 0 0 0;
-  }
+li
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-md);
+  font-weight: 400;
 
-  a {
-        color: inherit;
-        text-decoration: underline;
-        text-decoration-color: var(--sc-primary-color);
-        text-decoration-skip-ink: auto;
-    text-decoration: none;
-  }
+  margin: .5em 0;
+  padding: .25em 0 .25em clamp(0rem, 3vw, 1rem);
+}
 
-  a:hover  {
-    color: var(--sc-primary-color);
-  }
+ol
+{
+  margin: 0;
+  padding: 0 0 0 1rem;
+}
 
-  a:visited {
-    text-decoration-color: var(--sc-primary-color-dark);
-  }
+li::marker
+{
+  font-family: var(--sc-sans-font);
+  font-weight: bold;
+
+  color: var(--sc-secondary-text-color);
+}
+
+a
+{
+  text-decoration: none;
+
+  color: inherit;
+}
+
+a:hover
+{
+  color: var(--sc-primary-color);
+}
+
+
 </style>`;
 
 export class SCNavContents extends LitElement {
@@ -54,13 +62,11 @@ export class SCNavContents extends LitElement {
   render() {
     return html`
       ${styles}
-      <div class="wrapper">
         <nav class="contents">
           <ol>
             ${this.items ? this.items.map(item => html`<li><a href="${'#' + item.link}">${item.name}</a></li>`) : ''}
           </ol>
         </nav>
-      </div>
     `
   }
 }

--- a/client/elements/addons/sc-toasts.js
+++ b/client/elements/addons/sc-toasts.js
@@ -14,14 +14,6 @@ class SCToasts extends LitElement {
 
       .toast {
         text-align: center;
-        margin-left: calc(50vw);
-      }
-
-      /* 841px: width at which the persistent sidebar appears*/
-      @media screen and (min-width: 841px) {
-        .toast {
-          margin-left: calc(50vw + var(--app-drawer-width) / 2);
-        }
       }
 
       .success-toast {

--- a/client/elements/navigation/sc-linden-leaves.js
+++ b/client/elements/navigation/sc-linden-leaves.js
@@ -16,10 +16,15 @@ class SCLindenLeaves extends LitLocalized(LitElement) {
     return css`
       :host {
         display: block;
+
+        height: 48px;
+
+        background-color: rgb(75, 74, 74);
       }
 
       nav {
         display: flex;
+        height: 48px;
         overflow-x: auto;
         overflow-y: hidden;
         flex-direction: row;
@@ -55,10 +60,13 @@ class SCLindenLeaves extends LitLocalized(LitElement) {
 
       nav li a {
         position: relative;
+        display: flex;
+        align-items: center;
 
-        display: inline-block;
+        padding: 0 8px;
 
-        padding: 14px 8px 10px 8px;
+        height: 100%;
+        box-sizing: border-box;
 
         text-decoration: none;
 
@@ -78,7 +86,10 @@ class SCLindenLeaves extends LitLocalized(LitElement) {
       nav li:last-child {
         font-weight: 800;
 
-        padding: 14px 8px 10px 8px;
+        padding: 0 8px;
+
+        height: 100%;
+        box-sizing: border-box;
 
         border-bottom: 4px solid var(--sc-primary-color-light);
       }

--- a/client/elements/navigation/sc-linden-leaves.js
+++ b/client/elements/navigation/sc-linden-leaves.js
@@ -14,110 +14,123 @@ import { icons } from '../../img/sc-icons';
 class SCLindenLeaves extends LitLocalized(LitElement) {
   static get styles() {
     return css`
-      :host {
-        display: block;
+    :host
+{
+  display: block;
 
-        height: 48px;
+  height: 48px;
 
-        background-color: rgb(75, 74, 74);
-      }
+  background-color: rgb(75, 74, 74);
+}
 
-      nav {
-        display: flex;
-        height: 48px;
-        overflow-x: auto;
-        overflow-y: hidden;
-        flex-direction: row;
-        box-sizing: border-box;
-        padding: 0 calc(2% - 8px);
+nav
+{
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  flex-direction: row;
 
-        white-space: nowrap;
+  box-sizing: border-box;
+  height: 48px;
+  padding: 0 calc(2% - 8px);
 
-        background-color: rgb(75, 74, 74);
+  white-space: nowrap;
 
-        justify-content: space-between;
-      }
+  background-color: rgb(75, 74, 74);
 
-      nav ul {
-        display: flex;
+  justify-content: space-between;
+}
 
-        width: 100%;
-        margin: 0;
-        padding: 0;
-      }
+nav ul
+{
+  display: flex;
 
-      nav li {
-        font-size: var(--sc-skolar-font-size-xs);
-        font-weight: 500;
-        color: white;
-        
-        display: flex;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
 
-        list-style-type: none;
+nav li
+{
+  font-size: var(--sc-skolar-font-size-xs);
+  font-weight: 500;
 
-        align-items: center;
-      }
+  display: flex;
 
-      nav li a {
-        position: relative;
-        display: flex;
-        align-items: center;
+  list-style-type: none;
 
-        padding: 0 8px;
+  color: white;
 
-        height: 100%;
-        box-sizing: border-box;
+  align-items: center;
+}
 
-        text-decoration: none;
+nav li a
+{
+  position: relative;
 
-        opacity: .8;
-        color: white;
-        border-bottom: 4px solid rgba(0,0,0,0);
-      }
+  display: flex;
 
-      nav li a:hover {
-        cursor: pointer;
+  box-sizing: border-box;
+  height: 100%;
+  padding: 0 8px;
 
-        border-bottom: 4px solid var(--sc-primary-color-light);
+  text-decoration: none;
 
-        opacity: 1;
-      }
+  opacity: .8;
+  color: white;
+  border-bottom: 4px solid rgba(0,0,0,0);
 
-      nav li:last-child {
-        font-weight: 800;
+  align-items: center;
+}
 
-        padding: 0 8px;
+nav li a:hover
+{
+  cursor: pointer;
 
-        height: 100%;
-        box-sizing: border-box;
+  opacity: 1;
+  border-bottom: 4px solid var(--sc-primary-color-light);
+}
 
-        border-bottom: 4px solid var(--sc-primary-color-light);
-      }
+nav li:last-child
+{
+  font-weight: 800;
 
-      nav li:last-child a:hover {
-        cursor: default;
+  box-sizing: border-box;
+  height: 100%;
+  padding: 0 8px;
 
-        color: white;
-        border-bottom: none;
-      }
+  border-bottom: 4px solid var(--sc-primary-color-light);
+}
 
-      nav li:last-child a {
-        cursor: default;
+nav li:last-child a:hover
+{
+  cursor: default;
 
-        opacity: 1;
-      }
+  color: white;
+  border-bottom: none;
+}
 
-      nav li:first-of-type {
-        margin-left: 0;
-      }
+nav li:last-child a
+{
+  cursor: default;
 
-      mwc-icon {
-        color: var(--sc-disabled-text-color);
-      }
+  opacity: 1;
+}
 
-      morph-ripple {
-        --ripple-color: var(--sc-primary-color);
-      }
+nav li:first-of-type
+{
+  margin-left: 0;
+}
+
+mwc-icon
+{
+  color: var(--sc-disabled-text-color);
+}
+
+morph-ripple 
+{
+   --ripple-color: var(--sc-primary-color);
+}
     `;
   }
 

--- a/client/elements/sc-page-dictionary.js
+++ b/client/elements/sc-page-dictionary.js
@@ -12,7 +12,7 @@ class SCPageDictionary extends LitLocalized(LitElement) {
     ${dictStyles}
     <style>
       .dictionary-results-container {
-        padding: var(--sc-size-xxl) 0;
+        
       }
 
       .dictionary-results-main {

--- a/client/elements/sc-page-dictionary.js
+++ b/client/elements/sc-page-dictionary.js
@@ -11,6 +11,10 @@ class SCPageDictionary extends LitLocalized(LitElement) {
     return html`
     ${dictStyles}
     <style>
+.dictionary-results-container
+{
+  margin: 0 0 var(--sc-size-xxl) 0;
+    }
 .dictionary-results-main
 {
   max-width: 720px;
@@ -71,7 +75,7 @@ h1
 
 .dictionary-entries
 {
-  padding: var(--sc-size-xl) 0 var(--sc-size-md);
+  margin: var(--sc-size-xl) 0 var(--sc-size-md);
 }
 
 .related-terms li
@@ -108,13 +112,10 @@ h1
 .dictionary-source
 {
   font-family: var(--sc-sans-font);
-  font-family: var(--sc-serif-font);
   font-size: var(--sc-skolar-font-size-s);
-  font-weight: 400;
   font-weight: bold;
-  line-height: 20px;
 
-  margin: var(--sc-size-sm) 0 var(--sc-size-md);
+  margin: var(--sc-size-md) 0;
 
   color: var(--sc-secondary-text-color);
 }
@@ -126,9 +127,7 @@ h1
 
 .selected-terms-item > a
 {
-  font-weight: bold;;
-
-  color: var(--sc-primary-color);
+  font-weight: bold;
 }
 
 .selected-terms-item > a:hover
@@ -137,6 +136,14 @@ h1
   text-decoration: none;
 }
 
+.dictionary-results-term,
+.selected-terms-item > a,
+.selected-terms-item > a:hover,
+dfn
+{
+  background-color: var(--sc-primary-color-light-transparent);
+  color: var(--sc-primary-color-darkest);
+}
     </style>
 
     <div class="dictionary-results-container">

--- a/client/elements/sc-page-dictionary.js
+++ b/client/elements/sc-page-dictionary.js
@@ -1,9 +1,7 @@
 import { LitElement, html, css } from 'lit-element';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
-import '@polymer/app-layout/app-drawer/app-drawer.js';
 import { API_ROOT } from '../constants.js';
 import { dictStyles } from './styles/sc-dict-styles.js';
-import { scrollbarStyle } from './styles/sc-scrollbar-style.js';
 import { icons } from '../img/sc-icons';
 
 import { LitLocalized } from './addons/localization-mixin'
@@ -11,10 +9,9 @@ import { LitLocalized } from './addons/localization-mixin'
 class SCPageDictionary extends LitLocalized(LitElement) {
   render() {
     return html`
-    ${scrollbarStyle}
     ${dictStyles}
     <style>
-      .dictionary-results-container, .related-terms {
+      .dictionary-results-container {
         padding: var(--sc-size-xxl) 0;
       }
 
@@ -52,29 +49,22 @@ class SCPageDictionary extends LitLocalized(LitElement) {
         color: var(--sc-primary-accent-color);
       }
 
-      .terms-button {
-        color: var(--sc-disabled-text-color);
-      }
-
       .related-terms {
-        margin: 0 var(--sc-size-md) var(--sc-size-xl) 0;
-        text-align: left;
+
         }
 
       .related-terms ul {
-        margin: var(--sc-size-sm) 0 0 0;
+        margin: 0;
         display: block;
         list-style: none;
         padding: 0;
       }
 
       .related-terms h3 {
+        margin: 1em 0 0 0;
         font-family: var(--sc-sans-font);
         font-size: var(--sc-skolar-font-size-s);
-        font-weight: 400;
-        line-height: 20px;
         color: var(--sc-secondary-text-color);
-        margin: var(--sc-size-md-larger) 0 0 var(--sc-size-md);
         font-weight: bold;
       }
 
@@ -83,22 +73,29 @@ class SCPageDictionary extends LitLocalized(LitElement) {
       }
 
       .related-terms li {
-        font-family: var(--sc-sans-font);
-        font-size: var(--sc-skolar-font-size-s);
-        font-weight: 400;
-        line-height: 20px;
+        padding: 0;
+    margin: 0.5rem 1rem 0 0;
+    display: inline-block;
+    
+
       }
 
       .related-terms a {
-        color: var(--sc-primary-accent-color);
-        padding: var(--sc-size-xs) 0 var(--sc-size-xs) var(--sc-size-md);
-        margin: var(--sc-size-xs) 0;
+        color: var(--sc-primary-accent-color);        
         text-decoration: none;
         display: inline-block;
+        border-radius: 4px;
+        border-bottom: 4px solid rgba(0,0,0,0);
       }
 
-      .related-terms em {
-        color: var(--sc-primary-text-color);
+      .related-terms a:hover{
+        
+        text-decoration: underline;
+        color: var(--sc-primary-color);
+      }
+
+      .related-terms i {
+        color: var(--sc-secondary-text-color);
       }
 
       .dictionary-source {
@@ -123,12 +120,13 @@ class SCPageDictionary extends LitLocalized(LitElement) {
         }
       }
 
-      .selected-terms-item {
-        background: linear-gradient(to right, var(--sc-primary-color) var(--sc-size-xs), transparent var(--sc-size-xs));
-      }
-
       .selected-terms-item > a {
           color: var(--sc-primary-color);
+          font-weight: bold
+      }
+      .selected-terms-item > a:hover{
+        text-decoration: none;
+        cursor: default;
       }
     </style>
 
@@ -136,16 +134,13 @@ class SCPageDictionary extends LitLocalized(LitElement) {
       <main class="dictionary-results-main">
         <div class="dictionary-results-head">
           <h1><span class="dictionary-results-description">${this.localize('definitionsFor')}</span> <span class="dictionary-results-term">${this.dictionaryWord}</span></h1>
-          <span class="terms-button">
-            <mwc-icon-button id="menu_icon" @click=${this._toggleDrawer}>${icons['menu']}</mwc-icon-button>
-          </span>
         </div>
         <div class="dictionary-entries">
           ${this.dictionaryEntriesTemplate}
         </div>
 
-        <app-drawer id="drawer" align="right" class="sc-scrollbar" swipe-open="">
-          <div class="related-terms sc-scrollbar">
+   
+          <div class="related-terms">
             <h3>${this.localize('adjacentTerms')}</h3>
             <ul class="near-terms">
               ${this.dictionaryAdjacentTemplate}
@@ -155,7 +150,7 @@ class SCPageDictionary extends LitLocalized(LitElement) {
               ${this.dictionarySimilarTemplate}
             </ul>
           </div>
-        </app-drawer>
+   
 
       </main>
     </div>
@@ -329,9 +324,9 @@ class SCPageDictionary extends LitLocalized(LitElement) {
       if (glossaryReturns) {
         for (let glossWord in inputArray[0]) {
           let glossLookup = inputArray[0][glossWord];
-          glossText = `<a href="/define/${glossLookup}">${glossLookup}</a>`;
+          glossText = `<a href="/define/${glossLookup}">${glossLookup}`;
           if (glossaryReturns[0][glossLookup]) {
-            glossText += `<em> (${glossaryReturns[0][glossLookup]})</em>`
+            glossText += `<i> (${glossaryReturns[0][glossLookup]})</i></a>`
           }
           glossaryObject = { "glossWord": glossLookup, "glossText": glossText };
           glossary.push(glossaryObject);

--- a/client/elements/sc-page-dictionary.js
+++ b/client/elements/sc-page-dictionary.js
@@ -11,123 +11,132 @@ class SCPageDictionary extends LitLocalized(LitElement) {
     return html`
     ${dictStyles}
     <style>
-      .dictionary-results-container {
-        
-      }
+.dictionary-results-main
+{
+  max-width: 720px;
+  margin: 0 auto;
+}
 
-      .dictionary-results-main {
-        max-width: 720px;
-        margin: 0 auto;
-      }
+.dictionary-results-head
+{
+  display: flex;
 
-      @media (max-width: 740px) {
-        .dictionary-results-main {
-          padding: 0 5%;
-        }
-      }
+  padding: 0;
 
-      .dictionary-results-head {
-        display: flex;
-        justify-content: space-between;
-        padding: 0;
-        margin-bottom:
-      }
+  justify-content: space-between;
+}
 
-      h1 {
-        font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-h1-md);
-    font-weight: 400;
-    line-height: 40px;
-        color: var(--sc-secondary-text-color);
-        display: inline-block;
-        margin: 0 0 0 -2px;
-      }
+h1
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-h1-md);
+  font-weight: 400;
+  line-height: 40px;
 
-      .dictionary-results-term {
-        font-family: var(--sc-serif-font);
-        font-weight: bold;
-        color: var(--sc-primary-accent-color);
-      }
+  display: inline-block;
 
-      .related-terms {
+  margin: 0 0 0 -2px;
 
-        }
+  color: var(--sc-secondary-text-color);
+}
 
-      .related-terms ul {
-        margin: 0;
-        display: block;
-        list-style: none;
-        padding: 0;
-      }
+.dictionary-results-term
+{
+  font-family: var(--sc-serif-font);
+  font-weight: bold;
 
-      .related-terms h3 {
-        margin: 1em 0 0 0;
-        font-family: var(--sc-sans-font);
-        font-size: var(--sc-skolar-font-size-s);
-        color: var(--sc-secondary-text-color);
-        font-weight: bold;
-      }
+  color: var(--sc-primary-accent-color);
+}
 
-      .dictionary-entries {
-        padding: var(--sc-size-xl) 0 var(--sc-size-md);
-      }
+.related-terms ul
+{
+  display: block;
 
-      .related-terms li {
-        padding: 0;
-    margin: 0.5rem 1rem 0 0;
-    display: inline-block;
-    
+  margin: 0;
+  padding: 0;
 
-      }
+  list-style: none;
+}
 
-      .related-terms a {
-        color: var(--sc-primary-accent-color);        
-        text-decoration: none;
-        display: inline-block;
-        border-radius: 4px;
-        border-bottom: 4px solid rgba(0,0,0,0);
-      }
+.related-terms h3
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-s);
+  font-weight: bold;
 
-      .related-terms a:hover{
-        
-        text-decoration: underline;
-        color: var(--sc-primary-color);
-      }
+  margin: 1em 0 0 0;
 
-      .related-terms i {
-        color: var(--sc-secondary-text-color);
-      }
+  color: var(--sc-secondary-text-color);
+}
 
-      .dictionary-source {
-        font-family: var(--sc-sans-font);
-        font-size: var(--sc-skolar-font-size-s);
-        font-weight: 400;
-        line-height: 20px;
-        color: var(--sc-secondary-text-color);
-        margin: var(--sc-size-sm) 0 var(--sc-size-md);
-        font-weight: bold;
-        font-family: var(--sc-serif-font);
-      }
+.dictionary-entries
+{
+  padding: var(--sc-size-xl) 0 var(--sc-size-md);
+}
 
-      .dictionary-book-entry {
-        border-bottom: var(--sc-border);
-      }
+.related-terms li
+{
+  display: inline-block;
 
-      #drawer {
-        --app-drawer-content-container: {
-          overflow-y: scroll;
-          background-color: var(--sc-secondary-background-color);
-        }
-      }
+  margin: .5rem 1rem 0 0;
+  padding: 0;
+}
 
-      .selected-terms-item > a {
-          color: var(--sc-primary-color);
-          font-weight: bold
-      }
-      .selected-terms-item > a:hover{
-        text-decoration: none;
-        cursor: default;
-      }
+.related-terms a
+{
+  display: inline-block;
+
+  text-decoration: none;
+
+  color: var(--sc-primary-accent-color);
+  border-bottom: 4px solid rgba(0,0,0,0);
+  border-radius: 4px;
+}
+
+.related-terms a:hover
+{
+  text-decoration: underline;
+
+  color: var(--sc-primary-color);
+}
+
+.related-terms i
+{
+  color: var(--sc-secondary-text-color);
+}
+
+.dictionary-source
+{
+  font-family: var(--sc-sans-font);
+  font-family: var(--sc-serif-font);
+  font-size: var(--sc-skolar-font-size-s);
+  font-weight: 400;
+  font-weight: bold;
+  line-height: 20px;
+
+  margin: var(--sc-size-sm) 0 var(--sc-size-md);
+
+  color: var(--sc-secondary-text-color);
+}
+
+.dictionary-book-entry
+{
+  border-bottom: var(--sc-border);
+}
+
+.selected-terms-item > a
+{
+  font-weight: bold;;
+
+  color: var(--sc-primary-color);
+}
+
+.selected-terms-item > a:hover
+{
+  cursor: default;
+  text-decoration: none;
+}
+
     </style>
 
     <div class="dictionary-results-container">

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -149,9 +149,12 @@ class SCPageSearch extends LitLocalized(LitElement) {
         }
 
         .dictionary {
-          background-color: var(--sc-secondary-background-color);
-          box-shadow: var(--sc-shadow-elevation-2dp);
-          border-radius: var(--sc-size-xxs);
+
+      border-radius: var(--sc-size-sm);
+      background-color: var(--sc-secondary-background-color);
+      box-shadow: var(--sc-shadow-elevation-1dp);
+
+      padding: 0 1rem;
         }
 
         .dictionary .search-result-division {

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -23,236 +23,309 @@ class SCPageSearch extends LitLocalized(LitElement) {
   render() {
     return html`
       <style>
-        :host {
-          display: block;
-          width: 100%;
-          height: calc(100vh - var(--sc-size-xxl));
-              font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-md);
-    font-weight: 400;
-    line-height: 1.5;
+    :host
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-md);
+  font-weight: 400;
+  line-height: 1.5;
 
-    color: var(--sc-primary-text-color);
-        }
+  display: block;
 
-        #search_result_list {
-          padding: var(--sc-size-xl) 0 var(--sc-size-md);
-        }
+  width: 100%;
+  height: calc(100vh - var(--sc-size-xxl));
 
-        .search-results-container {
-          padding: var(--sc-size-xxl) 0;
-        }
+  color: var(--sc-primary-text-color);
+}
 
-        .search-results-main {
-          max-width: 720px;
-          margin: 0 auto;
-        }
+#search_result_list
+{
+  padding: var(--sc-size-xl) 0 var(--sc-size-md);
+}
 
-        .search-result-head {
-          color: var(--sc-secondary-text-color);
-          padding: 0 var(--sc-size-md);
-          display: flex;
-          justify-content: space-between;
-          flex-wrap: wrap;
-        }
+.search-results-container
+{
+  padding: var(--sc-size-xxl) 0;
+}
 
-        .search-result-header {
-          font-family: var(--sc-sans-font);
-          font-size: var(--sc-skolar-font-size-h1-md);
-          font-weight: 400;
-          display: inline-block;
-          margin: 0 1rem 1rem 0;
-          line-height: 1.25;
-        }
+.search-results-main
+{
+  max-width: 720px;
+  margin: 0 auto;
+}
 
-        .search-result-term {
-          font-family: var(--sc-serif-font);
-          font-weight: bold;
-          color: var(--sc-primary-accent-color);
-        }
+.search-result-head
+{
+  display: flex;
 
-        .search-result-item {
-          border-bottom: var(--sc-border);
-          display: flex;
-          flex-direction: column;
-        }
+  padding: 0 var(--sc-size-md);
 
-        .search-result-item dl a {
-          color: inherit;
-          text-decoration: underline;
-          text-decoration-color: var(--sc-primary-color);
-        }
+  color: var(--sc-secondary-text-color);
 
-        .search-result-item dl a:hover {
-          color: var(--sc-primary-color);
-        }
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
 
-        .search-result-item dl a:visited {
-          text-decoration-color: var(--sc-primary-color-dark);
-        }
+.search-result-header
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-h1-md);
+  font-weight: 400;
+  line-height: 1.25;
 
-        .search-result-item:focus {
-          outline: 0;
-        }
+  display: inline-block;
 
-        .padded-container {
-          display: flex;
-          flex-direction: column;
-          padding: 0;
-        }
+  margin: 0 1rem 1rem 0;
+}
 
-        .search-result-title {
-          font-size: var(--sc-skolar-font-size-static-subtitle);
-          font-weight: 400;
-          font-family: var(--sc-serif-font);
-          color: var(--sc-primary-accent-color);
-          margin: 1rem 0 0 0;
-          white-space: nowrap;
+.search-result-term
+{
+  font-family: var(--sc-serif-font);
+  font-weight: bold;
+
+  color: var(--sc-primary-accent-color);
+}
+
+.search-result-item
+{
+  display: flex;
+  flex-direction: column;
+
+  border-bottom: var(--sc-border);
+}
+
+.search-result-item dl a
+{
+  text-decoration: underline;
+
+  color: inherit;
+
+  text-decoration-color: var(--sc-primary-color);
+}
+
+.search-result-item dl a:hover
+{
+  color: var(--sc-primary-color);
+}
+
+.search-result-item dl a:visited
+{
+  text-decoration-color: var(--sc-primary-color-dark);
+}
+
+.search-result-item:focus
+{
+  outline: 0;
+}
+
+.padded-container
+{
+  display: flex;
+  flex-direction: column;
+
+  padding: 0;
+}
+
+.search-result-title
+{
+  font-family: var(--sc-serif-font);
+  font-size: var(--sc-skolar-font-size-static-subtitle);
+  font-weight: 400;
+
   overflow: hidden;
+
+  margin: 1rem 0 0 0;
+
+  white-space: nowrap;
   text-overflow: ellipsis;
-        }
 
-        .search-result-division {
-          font-family: var(--sc-sans-font);
-          font-size: var(--sc-skolar-font-size-s);
-          font-weight: 400;
-          color: var(--sc-secondary-text-color);
-          margin: 0 0 var(--sc-size-md);
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
+  color: var(--sc-primary-accent-color);
+}
 
-        .search-result-snippet {
-          font-family: var(--sc-sans-font);
-          font-size: var(--sc-skolar-font-size-md);
-          font-weight: 400;
-          margin: 0 0 1rem 0;
-        }
+.search-result-division
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-s);
+  font-weight: 400;
 
-        .search-result-snippet dd {
-          margin-left: 0;
-        }
+  overflow: hidden;
 
-        .search-result-snippet dfn {
-          font-style: normal;
-          font-weight: bold;
-        }
+  margin: 0 0 var(--sc-size-md);
 
-        .search-result-filter-menu {
-          margin-top: -20px;
-        }
+  white-space: nowrap;
+  text-overflow: ellipsis;
 
-        .search-result-link {
-          text-decoration: none;
-          color: initial;
-        }
+  color: var(--sc-secondary-text-color);
+}
 
-        .search-result-link:hover{
-          text-decoration: underline;
-          text-decoration-color: var(--sc-primary-accent-color);
+.search-result-snippet
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-md);
+  font-weight: 400;
 
-        }
+  margin: 0 0 1rem 0;
+}
 
-        .dictionary {
+.search-result-snippet dd
+{
+  margin-left: 0;
+}
 
-      border-radius: var(--sc-size-sm);
-      background-color: var(--sc-secondary-background-color);
-      box-shadow: var(--sc-shadow-elevation-1dp);
+.search-result-snippet dfn
+{
+  font-weight: bold;
+  font-style: normal;
+}
 
-      padding: 0 clamp(1rem, 3vw, 2rem);
-      margin: 2rem 0;
-        }
+.search-result-filter-menu
+{
+  margin-top: -20px;
+}
 
-        .dictionary .search-result-division {
-          display: none;
-        }
+.search-result-link
+{
+  text-decoration: none;
 
-        .dictionary .search-result-title {
-          font-family: var(--sc-sans-font);
-          font-size: var(--sc-skolar-font-size-md);
-          font-weight: 400;
-          
-        }
+  color: initial;
+}
 
-        .dictionary dfn {
-          font-family: var(--sc-sans-font);
-          font-size: var(--sc-skolar-font-size-static-subtitle);
-          font-weight: bold;
-        }
+.search-result-link:hover
+{
+  text-decoration: underline;
 
-        .dictionary dd p {
-          margin: 0 0 var(--sc-size-s) 0;
-        }
+  text-decoration-color: var(--sc-primary-accent-color);
+}
 
-        .dictionary .case {
-          color: var(--sc-secondary-text-color);
-          font-variant-caps: all-small-caps;
-          letter-spacing: var(--sc-caps-letter-spacing);
-          display: block;
-        }
+.dictionary
+{
+  margin: 2rem 0;
+  padding: 0 clamp(1rem, 3vw, 2rem);
 
-        .dictionary .ref {
-          font-size: var(--sc-skolar-font-size-s);
-          color: var(--sc-secondary-text-color);
-          background-color: var(--sc-textual-info-background-color);
-          border-radius: var(--sc-size-xxs);
-          padding: var(--sc-size-xs) var(--sc-size-sm) var(--sc-size-xxs);
-          white-space: nowrap;
-        }
+  border-radius: var(--sc-size-sm);
+  background-color: var(--sc-secondary-background-color);
+  box-shadow: var(--sc-shadow-elevation-1dp);
+}
 
-          dd ol, dd ul {
-    margin: 0;
-    padding: 0 0 0 1rem;
-  }
+.dictionary .search-result-division
+{
+  display: none;
+}
 
-  li{
-    padding-left: clamp(0.25rem, 1vw, 1rem);
-  }
+.dictionary .search-result-title
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-md);
+  font-weight: 400;
+}
 
-  li::marker{
-    color: var(--sc-secondary-text-color);
-    font-family: var(--sc-sans-font);
-    font-weight: bold;
-  }
+.dictionary dfn
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-static-subtitle);
+  font-weight: bold;
+}
 
-  p +ol, p +ul{
-    margin: 0.5em 0 1em
-  }
+.dictionary dd p
+{
+  margin: 0 0 var(--sc-size-s) 0;
+}
 
-        .paper-spinner {
-          position: absolute;
-          margin: 0;
-          top: 50%;
-          left: 50%;
-          transform: translate(-50%, -50%);
-        }
+.dictionary .case
+{
+  display: block;
 
-        .google-maps {
-          height: 480px;
-          margin: var(--sc-size-md-larger) 0;
-        }
+  letter-spacing: var(--sc-caps-letter-spacing);
 
-        .google-maps iframe {
-          height: 480px;
-          width: 100%;
-          border: none;
-        }
+  color: var(--sc-secondary-text-color);
 
-        .d-none {
-          display: none;
-        }
+  font-variant-caps: all-small-caps;
+}
 
-        [hidden] {
-          display: none !important;
-        }
+.dictionary .ref
+{
+  font-size: var(--sc-skolar-font-size-s);
 
-        .loading-indicator {
-          font-size: var(--sc-skolar-font-size-s);
-          text-align: center;
-          height: 60px;
-          margin-top: 25vh;
-        }
+  padding: var(--sc-size-xs) var(--sc-size-sm) var(--sc-size-xxs);
+
+  white-space: nowrap;
+
+  color: var(--sc-secondary-text-color);
+  border-radius: var(--sc-size-xxs);
+  background-color: var(--sc-textual-info-background-color);
+}
+
+dd ol,
+dd ul
+{
+  margin: 0;
+  padding: 0 0 0 1rem;
+}
+
+li
+{
+  padding-left: clamp(.25rem, 1vw, 1rem);
+}
+
+li::marker
+{
+  font-family: var(--sc-sans-font);
+  font-weight: bold;
+
+  color: var(--sc-secondary-text-color);
+}
+
+p + ol,
+p + ul
+{
+  margin: .5em 0 1em;
+}
+
+.paper-spinner
+{
+  position: absolute;
+  top: 50%;
+  left: 50%;
+
+  margin: 0;
+
+  transform: translate(-50%, -50%);
+}
+
+.google-maps
+{
+  height: 480px;
+  margin: var(--sc-size-md-larger) 0;
+}
+
+.google-maps iframe
+{
+  width: 100%;
+  height: 480px;
+
+  border: none;
+}
+
+.d-none
+{
+  display: none;
+}
+
+[hidden]
+{
+  display: none !important;
+}
+
+.loading-indicator
+{
+  font-size: var(--sc-skolar-font-size-s);
+
+  height: 60px;
+  margin-top: 25vh;
+
+  text-align: center;
+}
+
       </style>
 
       ${this.displayDataLoadError}  

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -10,6 +10,8 @@ import { store } from '../redux-store';
 import { LitLocalized } from '../elements/addons/localization-mixin';
 import { API_ROOT } from '../constants.js';
 
+import { typographyCommonStyles } from './styles/sc-typography-common-styles.js';
+
 /*
 The search page opens when a search string is typed into the search-input-box in the toolbar.
 
@@ -33,7 +35,7 @@ class SCPageSearch extends LitLocalized(LitElement) {
           padding: var(--sc-size-xl) 0 var(--sc-size-md);
         }
 
-        .suttaplex-item {
+        .dictionary-snippet-card {
           margin-top: var(--sc-size-xl);
           margin-bottom: calc(-1 * var(--sc-size-md));
         }
@@ -58,7 +60,6 @@ class SCPageSearch extends LitLocalized(LitElement) {
           font-family: var(--sc-sans-font);
           font-size: var(--sc-skolar-font-size-h1-md);
           font-weight: 400;
-          line-height: 40px;
           display: inline-block;
           margin: 0;
         }
@@ -92,7 +93,6 @@ class SCPageSearch extends LitLocalized(LitElement) {
 
         .search-result-item:focus {
           outline: 0;
-          background: linear-gradient(to right, var(--sc-primary-accent-color) 4px, transparent 4px);
         }
 
         .padded-container {
@@ -105,7 +105,6 @@ class SCPageSearch extends LitLocalized(LitElement) {
           font-family: var(--sc-sans-font);
           font-size: var(--sc-skolar-font-size-static-subtitle);
           font-weight: 400;
-          line-height: 32px;
           font-family: var(--sc-serif-font);
           color: var(--sc-primary-accent-color);
           margin: 22px 0 0 0;
@@ -115,7 +114,6 @@ class SCPageSearch extends LitLocalized(LitElement) {
           font-family: var(--sc-sans-font);
           font-size: var(--sc-skolar-font-size-s);
           font-weight: 400;
-          line-height: 24px;
           color: var(--sc-secondary-text-color);
           margin: 0 0 var(--sc-size-md);
           white-space: nowrap;
@@ -126,7 +124,6 @@ class SCPageSearch extends LitLocalized(LitElement) {
           font-family: var(--sc-sans-font);
           font-size: var(--sc-skolar-font-size-md);
           font-weight: 400;
-          line-height: 24px;
           margin: 0 0 20px 0;
         }
 
@@ -148,6 +145,12 @@ class SCPageSearch extends LitLocalized(LitElement) {
           color: initial;
         }
 
+        .search-result-link:hover{
+          text-decoration: underline;
+          text-decoration-color: var(--sc-primary-accent-color);
+
+        }
+
         .dictionary {
 
       border-radius: var(--sc-size-sm);
@@ -165,14 +168,12 @@ class SCPageSearch extends LitLocalized(LitElement) {
           font-family: var(--sc-sans-font);
           font-size: var(--sc-skolar-font-size-md);
           font-weight: 400;
-          line-height: 24px;
+          
         }
 
         .dictionary dfn {
           font-family: var(--sc-sans-font);
           font-size: var(--sc-skolar-font-size-static-subtitle);
-          font-weight: 400;
-          line-height: 32px;
           font-weight: bold;
         }
 
@@ -277,7 +278,7 @@ class SCPageSearch extends LitLocalized(LitElement) {
         </h1>
         <sc-search-filter-menu class="search-result-filter-menu" id="filter_menu"></sc-search-filter-menu>
       </div>
-      <div class="suttaplex-item">
+      <div class="dictionary-snippet-card">
         <sc-suttaplex .item=${this.suttaplex} .parallels-opened=${false}
           .difficulty="${this._computeItemDifficulty(this.suttaplex && this.suttaplex.difficulty ? this.suttaplex.difficulty : '')}"
           .expansion-data=${this.expansionReturns}>

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -10,8 +10,6 @@ import { store } from '../redux-store';
 import { LitLocalized } from '../elements/addons/localization-mixin';
 import { API_ROOT } from '../constants.js';
 
-import { typographyCommonStyles } from './styles/sc-typography-common-styles.js';
-
 /*
 The search page opens when a search string is typed into the search-input-box in the toolbar.
 
@@ -29,15 +27,16 @@ class SCPageSearch extends LitLocalized(LitElement) {
           display: block;
           width: 100%;
           height: calc(100vh - var(--sc-size-xxl));
+              font-family: var(--sc-sans-font);
+    font-size: var(--sc-skolar-font-size-md);
+    font-weight: 400;
+    line-height: 1.5;
+
+    color: var(--sc-primary-text-color);
         }
 
         #search_result_list {
           padding: var(--sc-size-xl) 0 var(--sc-size-md);
-        }
-
-        .dictionary-snippet-card {
-          margin-top: var(--sc-size-xl);
-          margin-bottom: calc(-1 * var(--sc-size-md));
         }
 
         .search-results-container {
@@ -54,6 +53,7 @@ class SCPageSearch extends LitLocalized(LitElement) {
           padding: 0 var(--sc-size-md);
           display: flex;
           justify-content: space-between;
+          flex-wrap: wrap;
         }
 
         .search-result-header {
@@ -61,7 +61,8 @@ class SCPageSearch extends LitLocalized(LitElement) {
           font-size: var(--sc-skolar-font-size-h1-md);
           font-weight: 400;
           display: inline-block;
-          margin: 0;
+          margin: 0 1rem 1rem 0;
+          line-height: 1.25;
         }
 
         .search-result-term {
@@ -73,14 +74,13 @@ class SCPageSearch extends LitLocalized(LitElement) {
         .search-result-item {
           border-bottom: var(--sc-border);
           display: flex;
-          flex-direction: row;
+          flex-direction: column;
         }
 
         .search-result-item dl a {
           color: inherit;
           text-decoration: underline;
           text-decoration-color: var(--sc-primary-color);
-          text-decoration-skip-ink: auto;
         }
 
         .search-result-item dl a:hover {
@@ -102,12 +102,14 @@ class SCPageSearch extends LitLocalized(LitElement) {
         }
 
         .search-result-title {
-          font-family: var(--sc-sans-font);
           font-size: var(--sc-skolar-font-size-static-subtitle);
           font-weight: 400;
           font-family: var(--sc-serif-font);
           color: var(--sc-primary-accent-color);
-          margin: 22px 0 0 0;
+          margin: 1rem 0 0 0;
+          white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
         }
 
         .search-result-division {
@@ -118,13 +120,14 @@ class SCPageSearch extends LitLocalized(LitElement) {
           margin: 0 0 var(--sc-size-md);
           white-space: nowrap;
           overflow: hidden;
+          text-overflow: ellipsis;
         }
 
         .search-result-snippet {
           font-family: var(--sc-sans-font);
           font-size: var(--sc-skolar-font-size-md);
           font-weight: 400;
-          margin: 0 0 20px 0;
+          margin: 0 0 1rem 0;
         }
 
         .search-result-snippet dd {
@@ -157,7 +160,8 @@ class SCPageSearch extends LitLocalized(LitElement) {
       background-color: var(--sc-secondary-background-color);
       box-shadow: var(--sc-shadow-elevation-1dp);
 
-      padding: 0 1rem;
+      padding: 0 clamp(1rem, 3vw, 2rem);
+      margin: 2rem 0;
         }
 
         .dictionary .search-result-division {
@@ -196,6 +200,25 @@ class SCPageSearch extends LitLocalized(LitElement) {
           padding: var(--sc-size-xs) var(--sc-size-sm) var(--sc-size-xxs);
           white-space: nowrap;
         }
+
+          dd ol, dd ul {
+    margin: 0;
+    padding: 0 0 0 1rem;
+  }
+
+  li{
+    padding-left: clamp(0.25rem, 1vw, 1rem);
+  }
+
+  li::marker{
+    color: var(--sc-secondary-text-color);
+    font-family: var(--sc-sans-font);
+    font-weight: bold;
+  }
+
+  p +ol, p +ul{
+    margin: 0.5em 0 1em
+  }
 
         .paper-spinner {
           position: absolute;

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -45,7 +45,7 @@ class SCPageSearch extends LitLocalized(LitElement) {
 
 .search-results-container
 {
-  padding: var(--sc-size-xxl) 0;
+  margin: 0 0 var(--sc-size-xxl) 0;
 }
 
 .search-results-main
@@ -57,8 +57,6 @@ class SCPageSearch extends LitLocalized(LitElement) {
 .search-result-head
 {
   display: flex;
-
-  padding: 0 var(--sc-size-md);
 
   color: var(--sc-secondary-text-color);
 
@@ -82,8 +80,6 @@ class SCPageSearch extends LitLocalized(LitElement) {
 {
   font-family: var(--sc-serif-font);
   font-weight: bold;
-
-  color: var(--sc-primary-accent-color);
 }
 
 .search-result-item
@@ -150,12 +146,14 @@ class SCPageSearch extends LitLocalized(LitElement) {
 
   overflow: hidden;
 
-  margin: 0 0 var(--sc-size-md);
+  margin: 0;
 
   white-space: nowrap;
   text-overflow: ellipsis;
 
   color: var(--sc-secondary-text-color);
+
+  height: 1.5rem;
 }
 
 .search-result-snippet
@@ -176,6 +174,8 @@ class SCPageSearch extends LitLocalized(LitElement) {
 {
   font-weight: bold;
   font-style: normal;
+
+  color: var(--sc-primary-color-dark);
 }
 
 .search-result-filter-menu
@@ -224,6 +224,17 @@ class SCPageSearch extends LitLocalized(LitElement) {
   font-family: var(--sc-sans-font);
   font-size: var(--sc-skolar-font-size-static-subtitle);
   font-weight: bold;
+
+  color: var(--sc-primary-color-dark);
+}
+
+.dictionary dfn,
+.highlight,
+.search-result-term,
+.selected-terms-item > a
+{
+  background-color: var(--sc-primary-color-light-transparent);
+  color: var(--sc-primary-color-darkest);
 }
 
 .dictionary dd p
@@ -244,15 +255,20 @@ class SCPageSearch extends LitLocalized(LitElement) {
 
 .dictionary .ref
 {
-  font-size: var(--sc-skolar-font-size-s);
+  font-family: var(--sc-sans-font);
+  font-weight: 600;
+  font-style: normal;
 
-  padding: var(--sc-size-xs) var(--sc-size-sm) var(--sc-size-xxs);
+  padding: 0 4px;
 
   white-space: nowrap;
+  letter-spacing: normal;
 
   color: var(--sc-secondary-text-color);
-  border-radius: var(--sc-size-xxs);
-  background-color: var(--sc-textual-info-background-color);
+  border-radius: 8px;
+  background-color: rgba(159, 158, 157, 0.15);
+
+  font-variant-caps: normal;
 }
 
 dd ol,

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -32,7 +32,7 @@ class SCPageSelector extends ReduxMixin(Localized(PolymerElement)) {
       }
 
       .container{
-        margin: 64px 3vw 0;
+        margin: 64px var(--sc-container-margin) 0;
       }
 
       .link-anchor {

--- a/client/elements/static/home-page.js
+++ b/client/elements/static/home-page.js
@@ -180,20 +180,9 @@ class SCHomePage extends SCStaticPage {
         align-self: flex-end;
       }
 
-      h1 {
-        margin: 0 0 0.25em 0;
-        font-size: 2em;
-        font-size: clamp(1.5em, 5vw, 2em);
-        line-height: 1.3333;
-        font-weight: 300;
-        font-family: var(--sc-serif-font);
-        padding-left: 4%;
-      }
-
       h2 {
         margin: 0 0 0 0;
-        font-size: 1.5em;
-        font-size: clamp(1.125em, 3.75vw, 1.5em);
+        font-size: var(--sc-skolar-font-size-static-subtitle);
         line-height: 1.3333;
         font-weight: 400;
         font-family: var(--sc-serif-font);

--- a/client/elements/styles/sc-colors-dark.json
+++ b/client/elements/styles/sc-colors-dark.json
@@ -9,7 +9,7 @@
   "--sc-primary-color-light-transparent": "rgba(255, 203, 97, 0.3)",
   "--sc-primary-color-medium": "#f6b735",
   "--sc-primary-color-dark": "#b37800",
-  "--sc-primary-color-darkest": "#8a5d00",
+  "--sc-primary-color-darkest": "#ffcb61",
   "--sc-primary-accent-color": "#8ace8d",
   "--sc-primary-accent-color-light": "#98e29b",
   "--sc-primary-accent-color-dark": "#74af76",

--- a/client/elements/styles/sc-dict-styles.js
+++ b/client/elements/styles/sc-dict-styles.js
@@ -16,7 +16,11 @@ export const dictStyles = html`
   }
 
   dd > p {
-    margin-top: 0;
+    margin: 0 0 0.5rem 0;
+  }
+
+  dd + dt{
+    margin-top: 1rem
   }
 
   dfn {
@@ -111,21 +115,16 @@ export const dictStyles = html`
   dd ol {
     margin: 0;
     padding: 0 0 0 1rem;
-
   }
 
-  li{
-    padding-left: 1rem
+  dd li{
+    padding-left: clamp(0rem, 3vw, 1rem);
   }
 
   li::marker{
     color: var(--sc-secondary-text-color);
     font-family: var(--sc-sans-font);
     font-weight: bold;
-  }
-
-  dd ol ul {
-    counter-reset: step-counter;
   }
 
   .little {

--- a/client/elements/styles/sc-dict-styles.js
+++ b/client/elements/styles/sc-dict-styles.js
@@ -78,9 +78,8 @@ dd .ref
   letter-spacing: normal;
 
   color: var(--sc-secondary-text-color);
-  border: 1px solid var(--sc-border-color);
   border-radius: 8px;
-  background-color: var(--sc-secondary-background-color);
+  background-color: rgba(159, 158, 157, 0.15);
 
   font-variant-caps: normal;
 }

--- a/client/elements/styles/sc-dict-styles.js
+++ b/client/elements/styles/sc-dict-styles.js
@@ -2,200 +2,261 @@ import { html } from 'lit-element';
 
 export const dictStyles = html`
 <style>
-  dl {
-    margin-top: var(--sc-size-sm);
-  }
+ dl
+{
+  margin-top: var(--sc-size-sm);
+}
 
-  dd {
-    margin: 0;
-    font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-md);
-    font-weight: 400;
-    line-height: 1.5;
-    font-family: var(--sc-serif-font);
-  }
+dd
+{
+  font-family: var(--sc-sans-font);
+  font-family: var(--sc-serif-font);
+  font-size: var(--sc-skolar-font-size-md);
+  font-weight: 400;
+  line-height: 1.5;
 
-  dd > p {
-    margin: 0 0 0.5rem 0;
-  }
+  margin: 0;
+}
 
-  dd + dt{
-    margin-top: 1rem
-  }
+dd > p
+{
+  margin: 0 0 .5rem 0;
+}
 
-  dfn {
-    font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-static-subtitle);
-    font-weight: 400;
-    line-height: 32px;
-    font-style: normal;
-    text-transform: lowercase;
-    color: var(--sc-primary-accent-color);
-    font-family: var(--sc-serif-font);
-  }
+dd + dt
+{
+  margin-top: 1rem;
+}
 
-  .dppn-entry dfn {
-    text-transform: capitalize;
-  }
+dfn
+{
+  font-family: var(--sc-sans-font);
+  font-family: var(--sc-serif-font);
+  font-size: var(--sc-skolar-font-size-static-subtitle);
+  font-weight: 400;
+  font-style: normal;
+  line-height: 32px;
 
-  .case {
-    font-variant-caps: all-small-caps;
-    letter-spacing: var(--sc-caps-letter-spacing);
-    color: var(--sc-secondary-text-color);
-    font-family: var(--sc-sans-font);
-    display: block;
-    font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-s);
-    font-weight: 400;
-    line-height: 24px;
-    white-space: nowrap;
-    overflow: hidden;
-  }
+  text-transform: lowercase;
 
-  dd .ref {
-    font-family: var(--sc-sans-font);
-    font-weight: 600;
-    font-style: normal;
+  color: var(--sc-primary-accent-color);
+}
 
-    white-space: nowrap;
-    letter-spacing: normal;
+.dppn-entry dfn
+{
+  text-transform: capitalize;
+}
 
-    padding: 0 4px;
+.case
+{
+  font-family: var(--sc-sans-font);
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-s);
+  font-weight: 400;
+  line-height: 24px;
 
-    color: var(--sc-secondary-text-color);
+  display: block;
+  overflow: hidden;
 
-    font-variant-caps: normal;
+  white-space: nowrap;
+  letter-spacing: var(--sc-caps-letter-spacing);
 
-    border: 1px solid var(--sc-border-color);
-    border-radius: 8px;
-    background-color: var(--sc-secondary-background-color);
-  }
+  color: var(--sc-secondary-text-color);
 
-  dd .author {
-    font-variant-caps: all-small-caps;
-    letter-spacing: var(--sc-caps-letter-spacing);
-  }
+  font-variant-caps: all-small-caps;
+}
 
-  dd .eti {
-    font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-s);
-    color: var(--sc-secondary-text-color);
-  }
+dd .ref
+{
+  font-family: var(--sc-sans-font);
+  font-weight: 600;
+  font-style: normal;
 
-  dd .term {
-    font-weight: normal;
-  }
+  padding: 0 4px;
 
-  dd .abbr {
-    font-size: var(--sc-skolar-font-size-s);
-    font-family: var(--sc-sans-font);
-    background-color: var(--sc-paper-tooltip-color);
-    color: var(--sc-tertiary-text-color);
-    font-weight: bold;
-    border-radius: var(--sc-size-xxs);
-    padding: var(--sc-size-xs) var(--sc-size-sm);
-  }
+  white-space: nowrap;
+  letter-spacing: normal;
 
-  dd .inline-li {
-    font-family: var(--sc-sans-font);
-    color: var(--sc-secondary-text-color);
-    font-weight: bold;
-    padding: 0 8px;
-  }
+  color: var(--sc-secondary-text-color);
+  border: 1px solid var(--sc-border-color);
+  border-radius: 8px;
+  background-color: var(--sc-secondary-background-color);
 
-  dd .square {
-    color: var(--sc-disabled-text-color);
-    font-size: 2.4em;
-    display: inline-block;
-    vertical-align: middle;
-    margin-left: -8px;
-    line-height: 0
-  }
+  font-variant-caps: normal;
+}
 
-  dd ol {
-    margin: 0;
-    padding: 0 0 0 1rem;
-  }
+dd .author
+{
+  letter-spacing: var(--sc-caps-letter-spacing);
 
-  dd li{
-    padding-left: clamp(0rem, 3vw, 1rem);
-  }
+  font-variant-caps: all-small-caps;
+}
 
-  li::marker{
-    color: var(--sc-secondary-text-color);
-    font-family: var(--sc-sans-font);
-    font-weight: bold;
-  }
+dd .eti
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-s);
 
-  .little {
-    list-style-type: decimal;
-  }
+  color: var(--sc-secondary-text-color);
+}
 
-  .little li {
-    margin: 0 0 0 0
-  }
+dd .term
+{
+  font-weight: normal;
+}
 
-  dd ul {
-    list-style-type: disc;
-    margin: 0 0 var(--sc-size-sm) var(--sc-size-md-larger) !important
-  }
+dd .abbr
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-s);
+  font-weight: bold;
 
-  dd ol + ul.compounds {
-    margin-top: var(--sc-size-md-larger) !important;
-  }
+  padding: var(--sc-size-xs) var(--sc-size-sm);
 
-  dd ol li {
-    margin: var(--sc-size-xs) 0 0 0;
+  color: var(--sc-tertiary-text-color);
+  border-radius: var(--sc-size-xxs);
+  background-color: var(--sc-paper-tooltip-color);
+}
 
-  }
+dd .inline-li
+{
+  font-family: var(--sc-sans-font);
+  font-weight: bold;
 
-  .compounds {
-    margin-left: var(--sc-size-md-larger) !important;
-    list-style-type: none;
-  }
+  padding: 0 8px;
 
-  .lower-greek {
-    list-style-type:lower-greek;
-  }
+  color: var(--sc-secondary-text-color);
+}
 
-  .compounds > li::before {
-    color: var(--sc-disabled-text-color);
-    content: "◦";
-    margin-left: -12px;
-  }
+dd .square
+{
+  font-size: 2.4em;
+  line-height: 0;;
 
-  .google-maps {
-    margin var(--sc-size-md) 0;
-    height: 480px;
-  }
+  display: inline-block;
 
-  .google-maps iframe {
-    height: 480px;
-    width: 100%;
-    border: none;
-  }
+  margin-left: -8px;
 
-  .info {
-    display: none;
-  }
+  vertical-align: middle;
 
-  h1, h2, h3, h4, h5, h6 {
-    text-align: left;
-    font-weight: normal;
-  }
+  color: var(--sc-disabled-text-color);
+}
 
-  dd a {
-    color: inherit;
-    text-decoration: underline;
-    text-decoration-color: var(--sc-primary-color);
-    text-decoration-skip-ink: auto;
-  }
+dd ol
+{
+  margin: 0;
+  padding: 0 0 0 1rem;
+}
 
-  dd a:hover {
-    color: var(--sc-primary-color);
-  }
+dd li
+{
+  padding-left: clamp(0rem, 3vw, 1rem);
+}
 
-  dd a:visited {
-    text-decoration-color: var(--sc-primary-color-dark);
-  }
+li::marker
+{
+  font-family: var(--sc-sans-font);
+  font-weight: bold;
+
+  color: var(--sc-secondary-text-color);
+}
+
+.little
+{
+  list-style-type: decimal;
+}
+
+.little li
+{
+  margin: 0 0 0 0;
+}
+
+dd ul
+{
+  margin: 0 0 var(--sc-size-sm) var(--sc-size-md-larger) !important;;
+
+  list-style-type: disc;
+}
+
+dd ol + ul.compounds
+{
+  margin-top: var(--sc-size-md-larger) !important;
+}
+
+dd ol li
+{
+  margin: var(--sc-size-xs) 0 0 0;
+}
+
+.compounds
+{
+  margin-left: var(--sc-size-md-larger) !important;
+
+  list-style-type: none;
+}
+
+.lower-greek
+{
+  list-style-type: lower-greek;
+}
+
+.compounds > li::before
+{
+  margin-left: -12px;
+
+  content: '◦';
+
+  color: var(--sc-disabled-text-color);
+}
+
+.google-maps
+{
+  height: 480px;
+  margin: var(--sc-size-md) 0;
+}
+
+.google-maps iframe
+{
+  width: 100%;
+  height: 480px;
+
+  border: none;
+}
+
+.info
+{
+  display: none;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6
+{
+  font-weight: normal;
+
+  text-align: left;
+}
+
+dd a
+{
+  text-decoration: underline;
+
+  color: inherit;
+
+  text-decoration-color: var(--sc-primary-color);
+}
+
+dd a:hover
+{
+  color: var(--sc-primary-color);
+}
+
+dd a:visited
+{
+  text-decoration-color: var(--sc-primary-color-dark);
+}
+
 </style>`;

--- a/client/elements/styles/sc-dict-styles.js
+++ b/client/elements/styles/sc-dict-styles.js
@@ -11,7 +11,7 @@ export const dictStyles = html`
     font-family: var(--sc-sans-font);
     font-size: var(--sc-skolar-font-size-md);
     font-weight: 400;
-    line-height: 24px;
+    line-height: 1.5;
     font-family: var(--sc-serif-font);
   }
 
@@ -101,14 +101,27 @@ export const dictStyles = html`
 
   dd .square {
     color: var(--sc-disabled-text-color);
+    font-size: 2.4em;
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: -8px;
+    line-height: 0
   }
 
   dd ol {
-    list-style-type: none;
-    counter-reset: step-counter;
-    margin: 0 0 0 32px;
-    padding: 0;
+    margin: 0;
+    padding: 0 0 0 1rem;
 
+  }
+
+  li{
+    padding-left: 1rem
+  }
+
+  li::marker{
+    color: var(--sc-secondary-text-color);
+    font-family: var(--sc-sans-font);
+    font-weight: bold;
   }
 
   dd ol ul {
@@ -133,7 +146,6 @@ export const dictStyles = html`
   }
 
   dd ol li {
-    counter-increment: step-counter;
     margin: var(--sc-size-xs) 0 0 0;
 
   }
@@ -143,47 +155,14 @@ export const dictStyles = html`
     list-style-type: none;
   }
 
-  dd ol + li {
-    counter-increment: step-counter !important;
-  }
-
-  .lower-latin > li::before {
-    content: counter(step-counter, lower-latin);
-  }
-
-  .upper-latin > li::before {
-    content: counter(step-counter, upper-latin);
-  }
-
-  .decimal > li::before {
-    content: counter(step-counter, decimal);
-  }
-
-  .upper-roman > li::before {
-    content: counter(step-counter, upper-roman);
-  }
-
-  .lower-roman > li::before {
-    content: counter(step-counter, lower-roman);
-  }
-
-  .lower-greek > li::before {
-    content: counter(step-counter, lower-greek);
+  .lower-greek {
+    list-style-type:lower-greek;
   }
 
   .compounds > li::before {
     color: var(--sc-disabled-text-color);
     content: "◦";
     margin-left: -12px;
-  }
-
-  dd li::before {
-    font-family: var(--sc-sans-font);
-    color: var(--sc-secondary-text-color);
-    font-weight: bold;
-    position: absolute;
-    text-align: right;
-    margin-left: -32px;
   }
 
   .google-maps {

--- a/client/elements/styles/sc-site-layout-styles.js
+++ b/client/elements/styles/sc-site-layout-styles.js
@@ -202,4 +202,5 @@ li a:hover
   {
   --ripple-color: gold;
   }
+
 `;

--- a/client/elements/styles/sc-site-layout-styles.js
+++ b/client/elements/styles/sc-site-layout-styles.js
@@ -1,220 +1,205 @@
 import { css, html } from "lit-element";
 
 export const SCSiteLayoutStyles = css`
-  :host {
-    display: block;
+  :host
+{
+  display: block;
+}
+
+p a,
+li a
+{
+  text-decoration: underline;
+
+  color: inherit;
+
+  text-decoration-color: var(--sc-primary-color);
+}
+
+p a:hover,
+li a:hover
+{
+  color: var(--sc-primary-color);
+}
+
+p a:visited,
+li a:visited
+{
+  text-decoration-color: var(--sc-primary-color-dark);
+}
+
+.close-dialog-icon
+{
+  margin: var(--sc-size-sm);
+
+  color: var(--sc-tertiary-text-color);
+}
+
+.homeTitle
+{
+  font-size: clamp(2rem, 8vw, 3rem);
+
+  display: flex;
+  overflow: hidden;
+  flex-direction: column;
+
+  box-sizing: border-box;
+  height: 144px;
+  margin: auto;
+
+  transition: all .1s;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  justify-content: center;
+}
+
+#mainTitle
+{
+  display: flex;
+
+  justify-content: center;
+  align-items: flex-end;
+}
+
+.homeTitle #mainTitle
+{
+  font-family: var(--sc-serif-font);
+  line-height: 1;
+
+  letter-spacing: var(--sc-caps-letter-spacing);
+
+  font-variant-caps: small-caps;
+}
+
+#subTitle
+{
+  font-size: .5em;
+  font-style: italic;
+}
+
+#universal_toolbar
+{
+  position: sticky;
+  z-index: 9999;
+  top: 0;
+
+  color: var(--sc-tertiary-text-color);
+  background-color: var(--sc-primary-color);
+  box-shadow: var(--sc-shadow-elevation-2dp);
+}
+
+#context_toolbar
+{
+  display: flex;
+
+  padding: 0 2%;
+
+  justify-content: space-between;
+}
+  .generalTitle 
+  {
+  display: flex;
+
+  align-items: center;
+
+  font-size: calc(20px * var(--sc-skolar-font-scale));
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   }
 
-  /* styles for the text dialogs: */
-  .dialog {
-    left: 0;
-    background-color: var(--sc-secondary-background-color);
-    white-space: initial;
-    max-width: 630px;
-    position: fixed;
-    top: 50px;
-    margin: 5% auto;
-    right: 0;
+@media print
+{
+  #universal_toolbar,
+  #title
+  {
+    display: none;
   }
+}
 
-  @media screen and (max-width: 960px) {
-    .dialog {
-      left: 0;
-    }
-  }
+.title-logo-icon
+{
+  width: 1.25em;
+  height: 1.25em;
+  /* these hacky margins compensate for the padding in the svg icon. Use em to scale with clamp*/
+  margin: .1em .1em -.1em -.1em;
+}
 
-  .dialog-header {
-    font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-static-subtitle);
-    font-weight: 400;
-    line-height: 32px;
-    padding: var(--sc-size-lg) 0;
-    color: var(--sc-tertiary-text-color);
-    margin: 0;
-  }
+#static_pages_nav_menu
+{
+  background-color: var(--sc-primary-color-dark);
+}
 
-  .buttons-bar {
-    margin-top: 0;
-    padding-right: 0;
-    display: flex;
-    justify-content: space-between;
-  }
+nav
+{
+  display: flex;
+  overflow-x: auto;
+  flex-direction: row;
 
-  .green-bg {
-    background-color: var(--sc-primary-accent-color);
-  }
+  box-sizing: border-box;
+  padding: 0 calc(2% - 8px);
 
-  .scrollable-dialog {
-    margin-bottom: var(--sc-size-lg);
-    margin-top: 0;
-    --divider-color: transparent;
-  }
+  white-space: nowrap;
+}
 
-  .dialog-section {
-    margin-top: var(--sc-size-lg);
-    color: var(--sc-primary-text-color);
-    font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-s);
-    font-weight: 400;
-    line-height: 20px;
-  }
+ul
+{
+  display: flex;
 
-  .dialog-section p[lang="ev"] {
-    font-family: var(--sc-tengwar-font);
-  }
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
 
-  p a,
-  li a {
-    color: inherit;
-    text-decoration: underline;
-    text-decoration-color: var(--sc-primary-color);
-    text-decoration-skip-ink: auto;
-  }
+li
+{
+  font-size: var(--sc-skolar-font-size-xs);
+  font-weight: 500;
 
-  p a:hover,
-  li a:hover {
-    color: var(--sc-primary-color);
-  }
+  margin-right: 8px;
 
-  p a:visited,
-  li a:visited {
-    text-decoration-color: var(--sc-primary-color-dark);
-  }
+  list-style-type: none;
 
-  .close-dialog-icon {
-    color: var(--sc-tertiary-text-color);
-    margin: var(--sc-size-sm);
-  }
+  letter-spacing: var(--sc-caps-letter-spacing);
+  text-transform: uppercase;
 
-  .homeTitle {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
+  align-items: center;
+}
 
-    box-sizing: border-box;
-    height: 144px;
-    margin: auto;
+li a
+{
+  position: relative;
 
-    transition: all 0.1s;
+  display: inline-block;
 
-    white-space: nowrap;
-    text-overflow: ellipsis;
+  padding: 14px 8px 10px;
 
-    overflow: hidden;
-    font-size: clamp(2rem, 8vw, 3rem);
-  }
+  text-decoration: none;
 
-  #mainTitle {
-    display: flex;
-    justify-content: center;
-    align-items: flex-end;
-  }
+  opacity: .8;
+  color: var(--sc-tertiary-text-color);
+  border-bottom: 4px solid rgba(0,0,0,0);
+}
 
-  .homeTitle #mainTitle {
-    
-    line-height: 1;
-    font-family: var(--sc-serif-font);
-    font-variant-caps: small-caps;
-    letter-spacing: var(--sc-caps-letter-spacing);
-  }
+li a:hover
+{
+  cursor: pointer;
 
-  #subTitle {
-    font-style: italic;
-    font-size: 0.5em;
-  
-  }
+  opacity: 1;
+  color: var(--sc-tertiary-text-color);
+  border-bottom: 4px solid var(--sc-primary-color-light);
+}
 
-  #universal_toolbar {
-    background-color: var(--sc-primary-color);
-    color: var(--sc-tertiary-text-color);
-    position: sticky;
-    top: 0;
-    box-shadow: var(--sc-shadow-elevation-2dp);
-    z-index: 9999;
-  }
+.staticPageSelected
+{
+  opacity: 1;
+  border-bottom: 4px solid var(--sc-primary-color-light);
+}
 
-  #context_toolbar {
-    display: flex;
-    justify-content: space-between;
-    padding: 0 2%;
-  }
-
-  .generalTitle {
-    display: flex;
-    align-items: center;
-    font-size: calc(20px * var(--sc-skolar-font-scale));
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  @media print {
-    #universal_toolbar,
-    #title {
-      display: none;
-    }
-  }
-
-  .title-logo-icon {
-    height: 1.25em;
-    width: 1.25em;
-/* these hacky margins compensate for the padding in the svg icon. Use em to scale with clamp*/
-    margin: 0.1em 0.1em -0.1em -0.1em;
-  }
-
-  #static_pages_nav_menu {
-    background-color: var(--sc-primary-color-dark);
-  }
-
-  nav {
-    display: flex;
-    overflow-x: auto;
-    flex-direction: row;
-    box-sizing: border-box;
-    padding: 0 calc(2% - 8px);
-    white-space: nowrap;
-  }
-
-  ul {
-    display: flex;
-    width: 100%;
-    margin: 0;
-    padding: 0;
-  }
-
-  li {
-    font-size: var(--sc-skolar-font-size-xs);
-    font-weight: 500;
-    list-style-type: none;
-    align-items: center;
-    letter-spacing: var(--sc-caps-letter-spacing);
-    text-transform: uppercase;
-    margin-right: 8px;
-  }
-
-  li a {
-    position: relative;
-    display: inline-block;
-    padding: 14px 8px 10px;
-    text-decoration: none;
-    border-bottom: 4px solid rgba(0,0,0,0);
-    opacity: .8;
-    color: var(--sc-tertiary-text-color);
-  }
-
-  li a:hover {
-    color: var(--sc-tertiary-text-color);
-    cursor: pointer;
-    border-bottom: 4px solid var(--sc-primary-color-light);
-    opacity: 1;
-  }
-
-  .staticPageSelected {
-    opacity: 1;
-    border-bottom: 4px solid var(--sc-primary-color-light);
-  }
-
-  morph-ripple {
-    --ripple-color: gold;
+  morph-ripple 
+  {
+  --ripple-color: gold;
   }
 `;

--- a/client/elements/styles/sc-typography-common-styles.js
+++ b/client/elements/styles/sc-typography-common-styles.js
@@ -101,6 +101,9 @@ header
 }
 header ul
 {
+    margin: 0;
+    padding: 0;
+
     font-family: var(--sc-sans-font);
 
     list-style-type: none;
@@ -130,19 +133,47 @@ header + blockquote
     margin: 4em 0;
 
     border-left: 4px solid var(--sc-primary-color-light);
+
+  border-radius: 4px;
 }
 
 .contents ul{
      list-style-type: none;
 }
 
+.contents ol
+{
+  margin: 0 0 0 2rem;
+padding: 0 0 0 1rem;
+}
+
 .contents li {
-padding: 0.5em 1em;
-    margin: 0 0 0 1em;
+  font-family: var(--sc-serif-font);
+  font-size: var(--sc-skolar-font-size-md);
+  font-weight: 400;
+
+  margin: .5em 0;
+  padding: .25em 0 .25em clamp(0rem, 3vw, 1rem);
+}
+
+.contents li::marker
+{
+  font-family: var(--sc-sans-font);
+  font-weight: bold;
+
+  color: var(--sc-secondary-text-color);
 }
 
 .contents a{
     text-decoration: none;
+    color: inherit;
+}
+
+a:hover
+{
+  color: var(--sc-primary-color);
+  text-decoration: underline;
+  text-decoration-color: var(--sc-primary-color);
 }
 
 /* tables */

--- a/client/elements/styles/sc-typography-common-styles.js
+++ b/client/elements/styles/sc-typography-common-styles.js
@@ -63,7 +63,7 @@ h1
 h2
 {
     font-size: 1.5em;
-    font-size: clamp(1.125em, 3.75vw, 1.5em);
+    font-size: clamp(1.333em, 3.75vw, 1.5em);
     font-weight: 400;
 }
 h3

--- a/client/elements/styles/sc-utility-styles.js
+++ b/client/elements/styles/sc-utility-styles.js
@@ -20,6 +20,8 @@ template.innerHTML = `
       --sc-size-xl: 48px;
       --sc-size-xxl: 64px;
 
+      --sc-container-margin: 3vw;
+
       --sc-size-language-icon: 19px;
 
       --sc-border: 1px solid var(--sc-border-color);

--- a/client/elements/text/sc-stepper.js
+++ b/client/elements/text/sc-stepper.js
@@ -8,118 +8,152 @@ class SCStepper extends LitElement {
     return html`
     <style>
 
-      @media print {
-        :host {
-          display: none;
-        }
-      }
+@media print
+{
+  :host
+  {
+    display: none;
+  }
+}
 
-      .bar {
-        display: flex;
-        width: 100vw;
-        margin: 0 calc(-1 * var(--sc-container-margin));
-        height: 96px;
-        background-color: var(--sc-secondary-text-color);
-        overflow: hidden
-      }
+.bar
+{
+  display: flex;
+  overflow: hidden;
 
-      .button {
-        width: 100%;
-      }
+  height: 96px;
+  margin: 0 calc(-1 * var(--sc-container-margin));
 
-      .button-container {
-        position: relative;
-        margin: 0;
-        height: 100%;
-        width: 50%;
-      }
+  background-color: var(--sc-secondary-text-color);
+}
 
-      .button {
-        width: 100%;
-        height: 100%;
-      }
+.button
+{
+  width: 100%;
+}
 
-      .action {
-        font-family: var(--sc-sans-font);
-        font-size: var(--sc-skolar-font-size-md);
-        color: var(--sc-paper-tooltip-text-color);
-        opacity: .55;
-      }
+.button-container
+{
+  position: relative;
 
-      .text-title {
-        font-family: var(--sc-sans-font);
-        font-size: var(--sc-skolar-font-size-l);
-        color: var(--sc-paper-tooltip-text-color);
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
-      }
+  width: 50%;
+  height: 100%;
+  margin: 0;
+}
 
-      .link {
-        text-decoration: none;
-        color: inherit;
-      }
+.button
+{
+  width: 100%;
+  height: 100%;
+}
 
-      .button {
-        display: flex;
-        height: 100%;
-      }
+.action
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-md);
 
-      .button-right {
-        justify-content: flex-end;
-      }
+  opacity: .55;
+  color: var(--sc-paper-tooltip-text-color);
+}
 
-      .text {
-        margin: auto 0;
-        display: flex;
-      }
+.text-title
+{
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-l);
 
-      .text-element {
-        display: inline-grid;
-        text-overflow: ellipsis;
-      }
+  overflow: hidden;
 
-      .text-element-right {
-        text-align: end;
-      }
+  white-space: nowrap;
+  text-overflow: ellipsis;
 
-      .arrow {
-        font-size: var(--sc-skolar-font-size-l);
-        width: var(--sc-size-md-larger);
-        min-width: var(--sc-size-md-larger);
-        color: var(--sc-paper-tooltip-text-color);
-        margin-top: 1em;
-        margin-left: .5em;
-        margin-right: .5em;
-      }
+  color: var(--sc-paper-tooltip-text-color);
+}
 
-      .separator {
-        width: 10%;
-      }
+.link
+{
+  text-decoration: none;
 
-      @media (min-width: 1280px) {
-        .button-right {
-          margin-right: 20%;
-          width: 80%;
-        }
+  color: inherit;
+}
 
-        .button-left {
-          margin-left: 20%;
-          width: 80%;
-        }
+.button
+{
+  display: flex;
 
-        .arrow-right {
-          margin-left: 1em;
-        }
+  height: 100%;
+}
 
-        .arrow-left {
-          margin-right: 1em;
-        }
-      }
+.button-right
+{
+  justify-content: flex-end;
+}
 
-      morph-ripple {
-        --ripple-color: var(--sc-primary-color);
-      }
+.text
+{
+  display: flex;
+
+  margin: auto 0;
+}
+
+.text-element
+{
+  display: inline-grid;
+
+  text-overflow: ellipsis;
+}
+
+.text-element-right
+{
+  text-align: end;
+}
+
+.arrow
+{
+  font-size: var(--sc-skolar-font-size-l);
+
+  width: var(--sc-size-md-larger);
+  min-width: var(--sc-size-md-larger);
+  margin-top: 1em;
+  margin-right: .5em;
+  margin-left: .5em;
+
+  color: var(--sc-paper-tooltip-text-color);
+}
+
+.separator
+{
+  width: 10%;
+}
+
+@media (min-width: 1280px)
+{
+  .button-right
+  {
+    width: 80%;
+    margin-right: 20%;
+  }
+
+  .button-left
+  {
+    width: 80%;
+    margin-left: 20%;
+  }
+
+  .arrow-right
+  {
+    margin-left: 1em;
+  }
+
+  .arrow-left
+  {
+    margin-right: 1em;
+  }
+}
+
+  morph-ripple 
+  {
+    --ripple-color: var(--sc-primary-color);
+  }
     </style>
 
     <div class="bar">

--- a/client/elements/text/sc-stepper.js
+++ b/client/elements/text/sc-stepper.js
@@ -16,7 +16,8 @@ class SCStepper extends LitElement {
 
       .bar {
         display: flex;
-        width: 100%;
+        width: 100vw;
+        margin: 0 -3vw;
         height: 96px;
         background-color: var(--sc-secondary-text-color);
         overflow: hidden

--- a/client/elements/text/sc-stepper.js
+++ b/client/elements/text/sc-stepper.js
@@ -17,7 +17,7 @@ class SCStepper extends LitElement {
       .bar {
         display: flex;
         width: 100vw;
-        margin: 0 -3vw;
+        margin: 0 calc(-1 * var(--sc-container-margin));
         height: 96px;
         background-color: var(--sc-secondary-text-color);
         overflow: hidden

--- a/client/elements/text/sc-text-page-selector.js
+++ b/client/elements/text/sc-text-page-selector.js
@@ -22,6 +22,11 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
   render() {
     return html`
       <style>
+
+      :host{
+        display: flex;
+        flex-direction: column
+      }
         .loading-indicator {
           font-size: var(--sc-skolar-font-size-s);
           text-align: center;

--- a/client/index.html
+++ b/client/index.html
@@ -62,6 +62,7 @@
     
     html, body {
       height: 100%;
+      overflow-x: hidden;
     }
 
     body {

--- a/client/index.html
+++ b/client/index.html
@@ -62,7 +62,6 @@
     
     html, body {
       height: 100%;
-      overflow-x: hidden;
     }
 
     body {


### PR DESCRIPTION
This set of changes addresses a variety of issues with styling, principally dealing with the container behavior, ensuring that pages did not trigger overflows and were flush with the horizontal edges.

A few details.

- For elements such as the stepper and the lookup tool, which appear at the bottom of the page and must be flush with the sides, use `margin: 0 calc(-1 * var(--sc-container-margin))`.
- I have removed the drawer from the dictionary searches, and thus the `drawer` and the `sc-scrollbar` may now be removed entirely from the app.
- I have modernized the CSS, fixed some errors, and linted with CSS comb.
- I apply an explicit height and background color to the breadcrumbs on both `:host` and `nav`. This is so that this element renders the background right away, making the page transition smoother (rather than relying on the content to determine the height). I experimented applying these properties to either `:host` or `nav` but it seemed smoother when it was both. Perhaps the timing of the rendering varies in the browser? Anyway, that's why these are duplicated!
- Another big focus was the dictionary and search results, which now have better and more consistent styling.