### PR TITLE
header height and other tweaks to make page transitions smoother

### DIFF
--- a/client/elements/addons/sc-bottom-sheet.js
+++ b/client/elements/addons/sc-bottom-sheet.js
@@ -71,6 +71,7 @@ header div
 {
     display: flex;
     flex-direction: row;
+    align-items: center;
 }
 
 details
@@ -78,8 +79,6 @@ details
     font-size: 14px;
 
     z-index: 1;
-
-    padding: 4px;
 
     color: var(--sc-primary-background-color);
     background-color: var(--sc-secondary-text-color);

--- a/client/elements/navigation/sc-linden-leaves.js
+++ b/client/elements/navigation/sc-linden-leaves.js
@@ -18,7 +18,7 @@ class SCLindenLeaves extends LitLocalized(LitElement) {
 {
   display: block;
 
-  height: 48px;
+  height: 40px;
 
   background-color: rgb(75, 74, 74);
 }
@@ -31,8 +31,8 @@ nav
   flex-direction: row;
 
   box-sizing: border-box;
-  height: 48px;
-  padding: 0 calc(2% - 8px);
+  height: 40px;
+  padding: 0 calc(2% - 2px);
 
   white-space: nowrap;
 
@@ -41,7 +41,7 @@ nav
   justify-content: space-between;
 }
 
-nav ul
+ul
 {
   display: flex;
 
@@ -50,8 +50,9 @@ nav ul
   padding: 0;
 }
 
-nav li
+li
 {
+  font-family: 'Skolar Sans PE Compressed', var(--sc-sans-font);
   font-size: var(--sc-skolar-font-size-xs);
   font-weight: 500;
 
@@ -64,7 +65,7 @@ nav li
   align-items: center;
 }
 
-nav li a
+li a
 {
   position: relative;
 
@@ -72,7 +73,7 @@ nav li a
 
   box-sizing: border-box;
   height: 100%;
-  padding: 0 8px;
+  padding: 4px 2px 0;
 
   text-decoration: none;
 
@@ -83,7 +84,7 @@ nav li a
   align-items: center;
 }
 
-nav li a:hover
+li a:hover
 {
   cursor: pointer;
 
@@ -91,18 +92,18 @@ nav li a:hover
   border-bottom: 4px solid var(--sc-primary-color-light);
 }
 
-nav li:last-child
+li:last-child
 {
-  font-weight: 800;
+  font-weight: 700;
 
   box-sizing: border-box;
   height: 100%;
-  padding: 0 8px;
+  padding: 4px 2px 0;
 
   border-bottom: 4px solid var(--sc-primary-color-light);
 }
 
-nav li:last-child a:hover
+li:last-child a:hover
 {
   cursor: default;
 
@@ -117,7 +118,7 @@ nav li:last-child a
   opacity: 1;
 }
 
-nav li:first-of-type
+li:first-of-type
 {
   margin-left: 0;
 }

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -284,13 +284,13 @@ class SCPageSelector extends ReduxMixin(Localized(PolymerElement)) {
   _setTitleState() {
     if (this.route.path === '/') {
       this.dispatch('changeToolbarTitle', 'SuttaCentral');
-      this.parentNode.querySelector('#context_toolbar').style.height = '';
+      this.parentNode.querySelector('#context_toolbar').style.height = '180px';
       this.parentNode.querySelector('.title-logo-icon').style.display = '';
       this.parentNode.querySelector('#title').classList.add('homeTitle');
       this.parentNode.querySelector('#title').classList.remove('generalTitle');
       this.parentNode.querySelector('#subTitle').style.display = 'initial';
     } else {
-      this.parentNode.querySelector('#context_toolbar').style.height = '3.5em';
+      this.parentNode.querySelector('#context_toolbar').style.height = '60px';
       this.parentNode.querySelector('.title-logo-icon').style.display = 'none';
       this.parentNode.querySelector('#title').classList.remove('homeTitle');
       this.parentNode.querySelector('#title').classList.add('generalTitle');

--- a/client/elements/sc-site-layout.js
+++ b/client/elements/sc-site-layout.js
@@ -317,16 +317,16 @@ class SCSiteLayout extends LitLocalized(LitElement) {
       rootDOM.getElementById('universal_toolbar').style.transition = transitionStyle;
       rootDOM.getElementById('breadCrumb').style.transition = transitionStyle;
       rootDOM.getElementById('mainTitle').style.transition = transitionStyle;
-      rootDOM.getElementById('subTitle').style.transition = transitionStyle;
+      rootDOM.getElementById('subTitle').style.transition = 'transform 300ms ease-in-out';
 
       if (this.changedRoute.path === '/' && (document.body.scrollTop > 100 || document.documentElement.scrollTop > 100)) {
-        rootDOM.getElementById('universal_toolbar').style.transform = 'translateY(-90px)';
-        rootDOM.getElementById('breadCrumb').style.transform = 'translateY(90px)';
-        rootDOM.getElementById('mainTitle').style.transform = 'translateY(58px) scale(0.667)';
+        rootDOM.getElementById('universal_toolbar').style.transform = 'translateY(-120px)';
+        rootDOM.getElementById('breadCrumb').style.transform = 'translateY(120px)';
+        rootDOM.getElementById('mainTitle').style.transform = 'translateY(74px) scale(0.667)';
         rootDOM.getElementById('subTitle').style.opacity = '0';
         rootDOM.getElementById('subTitle').style.transform = 'scale(0)';
         if (window.innerWidth < 480) {
-          rootDOM.getElementById('mainTitle').style.transform = 'translateY(55px) scale(0.667)';
+          rootDOM.getElementById('mainTitle').style.transform = 'translateY(70px) scale(0.667)';
         }
       } else {
         rootDOM.getElementById('universal_toolbar').style.transform = 'none';

--- a/client/elements/styles/sc-site-layout-styles.js
+++ b/client/elements/styles/sc-site-layout-styles.js
@@ -35,16 +35,20 @@ li a:visited
   color: var(--sc-tertiary-text-color);
 }
 
+  /* apply font size here to avoid resizing title when returning to Home */
+#title
+{
+  font-size: clamp(2rem, 8vw, 3em);
+}
+
 .homeTitle
 {
-  font-size: clamp(2rem, 8vw, 3rem);
-
   display: flex;
   overflow: hidden;
   flex-direction: column;
 
   box-sizing: border-box;
-  height: 144px;
+  height: 180px;
   margin: auto;
 
   transition: all .1s;
@@ -97,19 +101,22 @@ li a:visited
 
   justify-content: space-between;
 }
-  .generalTitle 
+ .generalTitle 
   {
   display: flex;
 
   align-items: center;
-
-  font-size: calc(20px * var(--sc-skolar-font-scale));
 
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   }
 
+  /* apply font size here to avoid resizing title when returning to Home */
+.generalTitle span
+{
+    font-size: calc(20px * var(--sc-skolar-font-scale));
+}
 @media print
 {
   #universal_toolbar,
@@ -129,6 +136,8 @@ li a:visited
 
 #static_pages_nav_menu
 {
+  height: 48px;
+
   background-color: var(--sc-primary-color-dark);
 }
 
@@ -136,12 +145,16 @@ nav
 {
   display: flex;
   overflow-x: auto;
+  overflow-y: hidden;
   flex-direction: row;
 
   box-sizing: border-box;
+  height: 48px;
   padding: 0 calc(2% - 8px);
 
   white-space: nowrap;
+
+  background-color: var(--sc-primary-color-dark);
 }
 
 ul
@@ -172,15 +185,19 @@ li a
 {
   position: relative;
 
-  display: inline-block;
+  display: flex;
 
-  padding: 14px 8px 10px;
+  box-sizing: border-box;
+  height: 100%;
+  padding: 4px 8px 0;
 
   text-decoration: none;
 
   opacity: .8;
   color: var(--sc-tertiary-text-color);
   border-bottom: 4px solid rgba(0,0,0,0);
+
+  align-items: center;
 }
 
 li a:hover

--- a/client/elements/text/sc-stepper.js
+++ b/client/elements/text/sc-stepper.js
@@ -21,7 +21,7 @@ class SCStepper extends LitElement {
   display: flex;
   overflow: hidden;
 
-  height: 96px;
+  height: 100px;
   margin: 0 calc(-1 * var(--sc-container-margin));
 
   background-color: var(--sc-secondary-text-color);

--- a/client/elements/text/sc-text-page-selector.js
+++ b/client/elements/text/sc-text-page-selector.js
@@ -39,7 +39,7 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
         }
 
         .wrapper {
-        min-height: calc(100vh - 334px);
+        min-height: calc(101vh - 328px);
         margin-bottom: 64px;
         }
 

--- a/client/index.html
+++ b/client/index.html
@@ -62,6 +62,7 @@
     
     html, body {
       height: 100%;
+      min-height: 101vh;
     }
 
     body {


### PR DESCRIPTION
Some subtle adjustments to sizing of headers, make CSS more consistent.

- Ensure height is explicitly set
- Adjust height of toolbar components to ensure pleasing proportions
- Use consistent flex approach in both breadcrumbs and tab bar.
- Set universal `min-height: 101vh` to avoid resetting page width when scrollbar disappears and reappears.
- Ensure there is as little movement on the page as possible when coming to and from Home page.