### PR TITLE
Sujato best

### DIFF
--- a/client/elements/addons/localization-mixin.js
+++ b/client/elements/addons/localization-mixin.js
@@ -161,6 +161,9 @@ export const LitLocalized = base => class extends connect(store)(base) {
 
   async __loadLanguage(lang) {
     if (SUPPORTED_TRANSLATIONS.includes(lang)) {
+      if (!this.localizedStringsPath) {
+        return;
+      }
       const path = `${this.localizedStringsPath}/${lang}.json`;
 
       if (path in localizationCache) {

--- a/client/elements/addons/sc-bottom-sheet.js
+++ b/client/elements/addons/sc-bottom-sheet.js
@@ -36,7 +36,7 @@ export class SCBottomSheet extends LitElement {
         bottom: 0;
       
         width: 100%;
-        margin: 0 calc(-1 * var(--sc-container-margin));
+        margin: 0;
       
         background-color: var(--sc-secondary-background-color);
         box-shadow: var(--sc-shadow-elevation-2dp);

--- a/client/elements/menus/sc-action-items.js
+++ b/client/elements/menus/sc-action-items.js
@@ -22,6 +22,14 @@ class SCActionItems extends LitLocalized(LitElement) {
         align-items: baseline;
       }
 
+            @media only screen and (max-width: 600px)
+{
+#tools_menu {
+        justify-content: space-around;
+        width: 100%;
+      }
+}
+
       .invisible {
         display: none;
       }

--- a/client/elements/menus/sc-action-items.js
+++ b/client/elements/menus/sc-action-items.js
@@ -22,14 +22,6 @@ class SCActionItems extends LitLocalized(LitElement) {
         align-items: baseline;
       }
 
-            @media only screen and (max-width: 600px)
-{
-#tools_menu {
-        justify-content: space-around;
-        width: 100%;
-      }
-}
-
       .invisible {
         display: none;
       }

--- a/client/elements/navigation/sc-navigation-styles.js
+++ b/client/elements/navigation/sc-navigation-styles.js
@@ -53,9 +53,6 @@ export const navigationNormalModeStyles = html`
       .home-card + .home-card {
         margin-left: 0;
       }
-      .header-right {
-        width: 90px;
-      }
     }
 
     .card:hover {

--- a/client/elements/navigation/sc-navigation-styles.js
+++ b/client/elements/navigation/sc-navigation-styles.js
@@ -9,7 +9,7 @@ export const navigationNormalModeStyles = html`
 
     @media (max-width: 680px) {
       main {
-        margin-top: -50px;
+        margin-top: -40px;
       }
     }
 
@@ -25,7 +25,7 @@ export const navigationNormalModeStyles = html`
       position: relative;
       overflow: hidden;
 
-      margin-bottom:  0.5rem;
+      margin-bottom:  var(--sc-size-md);
       padding-bottom: 0.5rem;
 
       cursor: pointer;

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -31,7 +31,7 @@ class SCPageSelector extends ReduxMixin(Localized(PolymerElement)) {
       }
 
       .container{
-        margin: 64px var(--sc-container-margin) 0;
+        margin-top: 64px;
       }
 
       .link-anchor {

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -289,7 +289,6 @@ class SCPageSelector extends ReduxMixin(Localized(PolymerElement)) {
       this.parentNode.querySelector('#title').classList.remove('generalTitle');
       this.parentNode.querySelector('#subTitle').style.display = 'initial';
     } else {
-      this.parentNode.querySelector('#context_toolbar').style.height = '60px';
       this.parentNode.querySelector('.title-logo-icon').style.display = 'none';
       this.parentNode.querySelector('#title').classList.remove('homeTitle');
       this.parentNode.querySelector('#title').classList.add('generalTitle');

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -289,6 +289,7 @@ class SCPageSelector extends ReduxMixin(Localized(PolymerElement)) {
       this.parentNode.querySelector('#title').classList.remove('generalTitle');
       this.parentNode.querySelector('#subTitle').style.display = 'initial';
     } else {
+      this.parentNode.querySelector('#context_toolbar').style.height = '60px';
       this.parentNode.querySelector('.title-logo-icon').style.display = 'none';
       this.parentNode.querySelector('#title').classList.remove('homeTitle');
       this.parentNode.querySelector('#title').classList.add('generalTitle');

--- a/client/elements/sc-site-layout.js
+++ b/client/elements/sc-site-layout.js
@@ -353,6 +353,19 @@ class SCSiteLayout extends LitLocalized(LitElement) {
       }
     }));
 
+    let lastScrollTop = 0;
+    addEventListener('scroll', throttle(300, () => {
+      let displaySettingMenu = store.getState().displaySettingMenu;
+      let displaySuttaParallels = store.getState().displaySuttaParallels;
+      if (this.changedRoute.path !== '/' && !displaySettingMenu && !displaySuttaParallels) {
+        let currentScrollTop = window.pageYOffset || document.documentElement.scrollTop;
+        if (currentScrollTop > lastScrollTop){
+          rootDOM.getElementById('universal_toolbar').style.transform = 'translateY(-156px)';
+        }
+        lastScrollTop = currentScrollTop <= 0 ? 0 : currentScrollTop; // For Mobile or negative scrolling
+      }
+    }));
+
     window.addEventListener('resize', () => {
       rootDOM.getElementById('universal_toolbar').style.transition = '';
       rootDOM.getElementById('breadCrumb').style.transition = '';

--- a/client/elements/sc-site-layout.js
+++ b/client/elements/sc-site-layout.js
@@ -360,7 +360,8 @@ class SCSiteLayout extends LitLocalized(LitElement) {
       if (this.changedRoute.path !== '/' && !displaySettingMenu && !displaySuttaParallels) {
         let currentScrollTop = window.pageYOffset || document.documentElement.scrollTop;
         if (currentScrollTop > lastScrollTop){
-          rootDOM.getElementById('universal_toolbar').style.transform = 'translateY(-156px)';
+          const universalToolbarHeight = 156;
+          rootDOM.getElementById('universal_toolbar').style.transform = `translateY(-${universalToolbarHeight}px)`;
         }
         lastScrollTop = currentScrollTop <= 0 ? 0 : currentScrollTop; // For Mobile or negative scrolling
       }

--- a/client/elements/static/home-page.js
+++ b/client/elements/static/home-page.js
@@ -268,7 +268,7 @@ class SCHomePage extends SCStaticPage {
         }
 
         sc-tipitaka {
-          margin-top: -50px;
+          margin-top: -40px;
         }
       }
     `;

--- a/client/elements/static/home-page.js
+++ b/client/elements/static/home-page.js
@@ -35,7 +35,7 @@ class SCHomePage extends SCStaticPage {
         display: flex;
         flex-direction: column;
       
-        margin: auto;
+        margin: auto 3vw;
         padding: 6% 0 0;
       
         text-align: center;

--- a/client/elements/styles/sc-site-layout-styles.js
+++ b/client/elements/styles/sc-site-layout-styles.js
@@ -112,6 +112,8 @@ export const SCSiteLayoutStyles = css`
   #context_toolbar {
     display: flex;
 
+     height: 60px;
+
     padding: 0 2%;
 
     justify-content: space-between;
@@ -123,7 +125,7 @@ export const SCSiteLayoutStyles = css`
     {
         flex-direction: column;
 
-        height: 100px!important;
+        height: 100px;
 
         justify-content: center;
     }

--- a/client/elements/styles/sc-site-layout-styles.js
+++ b/client/elements/styles/sc-site-layout-styles.js
@@ -119,19 +119,6 @@ export const SCSiteLayoutStyles = css`
     justify-content: space-between;
   }
 
-      @media only screen and (max-width: 600px)
-{
-    #context_toolbar
-    {
-        flex-direction: column;
-
-        height: 100px;
-
-        justify-content: center;
-    }
-}
-
-
   .generalTitle {
     display: flex;
 

--- a/client/elements/styles/sc-site-layout-styles.js
+++ b/client/elements/styles/sc-site-layout-styles.js
@@ -117,6 +117,19 @@ export const SCSiteLayoutStyles = css`
     justify-content: space-between;
   }
 
+      @media only screen and (max-width: 600px)
+{
+    #context_toolbar
+    {
+        flex-direction: column;
+
+        height: 100px!important;
+
+        justify-content: center;
+    }
+}
+
+
   .generalTitle {
     display: flex;
 

--- a/client/elements/styles/sc-typography-common-styles.js
+++ b/client/elements/styles/sc-typography-common-styles.js
@@ -19,6 +19,10 @@ export const typographyCommonStyles = css`
     justify-content: center;
   }
 
+  article{
+    margin: 0 3vw;
+  }
+
 /* text block elements */
 
 ul,

--- a/client/elements/suttaplex/card/sc-sutta-parallels.js
+++ b/client/elements/suttaplex/card/sc-sutta-parallels.js
@@ -11,13 +11,19 @@ class SCSuttaParallels extends LitLocalized(LitElement) {
     return css`
       :host {
         display: none;
-        z-index: 2;
+        z-index: 1000;
         color: var(--sc-primary-text-color);
+        position: absolute;
+        width: 100%;
+        border-bottom: 1px solid #ccc;
+        background-color: var(--sc-secondary-background-color);
+        box-shadow: var(--sc-shadow-elevation-4dp);
       }
 
       .sutta-list {
         transition: margin-top 0.3s, margin-bottom 0.3s;
-        margin: 0 auto var(--sc-size-xxl);
+        margin: var(--sc-size-xl) auto ;
+        max-width: 720px;
       }
     `;
   }

--- a/client/elements/suttaplex/card/sc-suttaplex-css.js
+++ b/client/elements/suttaplex/card/sc-suttaplex-css.js
@@ -38,8 +38,6 @@ summary
 
     display: flex;
 
-    padding: 8px;
-
     cursor: pointer;
 
     color: var(--sc-primary-text-color);

--- a/client/elements/suttaplex/card/sc-suttaplex-css.js
+++ b/client/elements/suttaplex/card/sc-suttaplex-css.js
@@ -1,10 +1,57 @@
 import { html } from 'lit-element';
 
+
 export const suttaplexCss = html`
 <style>
-  :host {
-    --paper-card-background-color: var(--sc-secondary-background-color);
+ 
+ article{
+  background-color: var(--sc-secondary-background-color);
   }
+
+  details
+{
+    position: relative;
+
+    box-sizing: border-box;
+    margin: 0 0 0 4px;
+}
+
+details p
+{
+    position: absolute;
+    z-index: 10;
+    
+    max-width: 360px;
+    margin: 4px 0 0 0;
+    padding: 8px 12px;
+
+    color: var(--sc-primary-text-color);
+    border: 1px solid var(--sc-border-color);
+    border-radius: 8px;
+    background-color: var(--sc-tertiary-background-color);
+    box-shadow: var(--sc-shadow-elevation-4dp);
+}
+
+summary
+{
+    font-weight: 600;
+
+    display: flex;
+
+    padding: 8px;
+
+    cursor: pointer;
+
+    color: var(--sc-primary-text-color);
+    outline-color: var(--sc-border-color);
+
+    align-items: baseline;
+}
+
+summary::-webkit-details-marker
+{
+    color: var(--sc-disabled-text-color);
+}
 
   .menu-listbox {
       --paper-input-container-focus-color: var(--sc-primary-accent-color);
@@ -36,23 +83,23 @@ export const suttaplexCss = html`
     box-shadow: var(--sc-shadow-elevation-1dp);
   }
 
-  .suttaplex:not(.compact) {
+    .suttaplex:not(.compact) {
     margin-bottom: var(--sc-size-md);
     padding: var(--sc-size-md);
     border-radius: var(--sc-size-sm);
   }
 
-  .section-details.main-translations {
-    border-top: 1px solid var(--sc-border-color);
-    margin-top: var(--sc-size-md);
-    padding-top: var(--sc-size-sm);
-  }
+      .section-details.main-translations {
+        border-top: 1px solid var(--sc-border-color);
+        margin-top: var(--sc-size-md);
+        padding-top: var(--sc-size-sm);
+      }
 
-  .compact .section-details.main-translations{
-    border-top: none;
-    padding-top: 0;
-    margin-top: var(--sc-size-sm);
-  }
+      .compact .section-details.main-translations{
+        border-top: none;
+        padding-top: 0;
+        margin-top: var(--sc-size-sm);
+      }
 
   .top-row {
     display: flex;
@@ -104,8 +151,8 @@ export const suttaplexCss = html`
  
   .suttaplex-nerdy-row {
     font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-s);
-    font-weight: 400;
+        font-size: var(--sc-skolar-font-size-s);
+        font-weight: 400;
     color: var(--sc-secondary-text-color);
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -118,7 +165,7 @@ export const suttaplexCss = html`
   }
 
   .popuptext.show {
-    display: unset;
+     display: unset;
   }
   
   .nerdy-row-element {
@@ -279,8 +326,8 @@ export const suttaplexTxCss = html`
   .tx-publication {
     color: var(--sc-secondary-text-color);
     font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-s);
-    font-weight: 400;
+        font-size: var(--sc-skolar-font-size-s);
+        font-weight: 400;
   }
   
   .arrow {
@@ -347,8 +394,8 @@ export const parallelsListCss = html`
   
   .parallels-root-id {
     font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-s);
-    font-weight: 400;
+        font-size: var(--sc-skolar-font-size-s);
+        font-weight: 400;
   }
 
   .paper-spinner {
@@ -399,8 +446,8 @@ export const parallelItemCss = html`
 
   .parallel-item-biblio-info {
     font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-s);
-    font-weight: 400;
+        font-size: var(--sc-skolar-font-size-s);
+        font-weight: 400;
     box-shadow: var(--sc-shadow-elevation-3dp);
     border-top: var(--sc-border);
     position: absolute;
@@ -417,8 +464,8 @@ export const parallelItemCss = html`
 
   .parallel-item-details {
     font-family: var(--sc-sans-font);
-    font-size: var(--sc-skolar-font-size-s);
-    font-weight: 400;
+        font-size: var(--sc-skolar-font-size-s);
+        font-weight: 400;
     color: var(--sc-secondary-text-color);
     overflow: hidden;
   }
@@ -455,7 +502,7 @@ export const parallelItemCss = html`
   }
 
   .nerdy-row-summary {
-    overflow: hidden;
+      overflow: hidden;
   }
   
   morph-ripple {

--- a/client/elements/suttaplex/card/sc-suttaplex.js
+++ b/client/elements/suttaplex/card/sc-suttaplex.js
@@ -1,10 +1,8 @@
 import '@polymer/iron-icon/iron-icon.js';
 import { html, css, LitElement } from 'lit-element';
-import '@polymer/paper-card/paper-card.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/paper-listbox/paper-listbox.js';
 import '@polymer/paper-menu-button/paper-menu-button.js';
-import '@polymer/paper-styles/paper-styles.js';
 import { API_ROOT, SUTTACENTRAL_VOICE_URL } from '../../../constants';
 import '../../../img/sc-svg-icons.js';
 import {
@@ -32,18 +30,12 @@ class SCSuttaplex extends LitLocalized(LitElement) {
       translationsOpened: Boolean,
       rootTextsOpened: Boolean,
       compactToggle: Boolean,
-      clearBorderRadius: Boolean,
-      borderRadiusStyle: Object,
     }
   }
 
   constructor() {
     super();
     this.localizedStringsPath = '/localization/elements/sc-suttaplex';
-    this.clearBorderRadius = false;
-    this.borderRadiusStyle = html`
-      <style></style>
-    `;
   }
 
   connectedCallback() {
@@ -66,22 +58,6 @@ class SCSuttaplex extends LitLocalized(LitElement) {
         })
       }
     }, 1000);
-
-    if (this.clearBorderRadius) {
-      this.borderRadiusStyle = this._unsetBorderRadius();
-    }
-  }
-
-  _unsetBorderRadius() {
-    return html`
-      <style>
-        .suttaplex:not(.compact) {
-          border-radius: unset;
-          border: 0px;
-          outline: 1px solid rgb(204,204,204);
-        }
-      </style>
-    `;
   }
 
   shouldUpdate(changedProperties) {
@@ -202,8 +178,8 @@ class SCSuttaplex extends LitLocalized(LitElement) {
 
     return html`
       ${suttaplexCss}
-      ${this.borderRadiusStyle}
-      <paper-card class="suttaplex ${this.suttaplexListStyle}" id="${this.item.uid}" elevation="1">
+      
+      <article class="suttaplex ${this.suttaplexListStyle}" id="${this.item.uid}">
         <div>
           <div class="top-row">
             <h1 class="${this.suttaplexListStyle}" title="${this.mainHeadingTitle}" @click="${this.toggleCompact}">
@@ -227,7 +203,7 @@ class SCSuttaplex extends LitLocalized(LitElement) {
           ${this.modernLanguageTranslationsTemplate}
           ${this.parallelsTemplate}
         ` : ''}
-      </paper-card>`;
+      </article>`;
   }
 
   get topRowIconsTemplate() {

--- a/client/elements/suttaplex/sc-suttaplex-list.css.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.css.js
@@ -16,6 +16,12 @@ export const suttaplexListCss = html`<style>
     max-width: 720px;
   }
 
+        @media (max-width: 680px) {
+      .main {
+        margin-top: -40px;
+      }
+    }
+
   .node {
     padding: var(--sc-size-md) var(--sc-size-md) 0;
     color: var(--sc-secondary-text-color);

--- a/client/elements/text/sc-stepper.js
+++ b/client/elements/text/sc-stepper.js
@@ -18,7 +18,7 @@ class SCStepper extends LitElement {
           overflow: hidden;
 
           height: 100px;
-          margin: 0 calc(-1 * var(--sc-container-margin));
+          margin: 0;
 
           background-color: var(--sc-secondary-text-color);
         }


### PR DESCRIPTION
- Style the parallels on text page top sheet, use `position: absolute`.
- Use `<article>` instead of `<paper-card>` for suttaplex. It turns out we are not actually using any features of the paper card, so we can just use `<article>` and it works fine., And we can remove some dependencies.
- I have adjusted the way the side margins are handled so as to make more efficient use of space on mobiles.
- I tried to introduce a responsive design for the toolbar action items, but I could not do it in pure CSS so I reverted it. See #1792 

## Bugs!

There are a few bugs on my local machine. I do not know if these are from changes I am making in this commit, or because there was a bug when upgrading my local system to latest database. Anyway I mention them here:

- Suttaplexes don't display blurbs or legacy translations
- `<sc-stepper>` does not display.
