### PR TITLE
Sujato topsheet select

### DIFF
--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -310,6 +310,20 @@ class SCTopSheetViews extends LitLocalized(LitElement) {
         --mdc-theme-primary: var(--sc-primary-color);
         --mdc-theme-on-primary: white;
       }
+
+select {
+  font-family: var(--sc-sans-font);
+  font-size: var(--sc-skolar-font-size-sm);
+  color: var(--sc-primary-text-color);
+  padding: 8px;
+  width: 100%;
+  margin: 4px 0 0 0;
+  border: 1px solid var(--sc-border-color);
+  border-radius: var(--sc-size-sm);
+  background-color: var(--sc-primary-background-color);
+}
+
+
     `;
   }
 
@@ -490,13 +504,13 @@ class SCTopSheetViews extends LitLocalized(LitElement) {
               <p>${this.localize('changePaliScriptDescription')}</p>
             </details>
             <div class="form-controls">
-              <mwc-select label="" @selected="${this._onPaliScriptChanged}">
+              <select @selected="${this._onPaliScriptChanged}">
                 ${scriptIdentifiers.map(
                   script => html`
-                    <mwc-list-item>${script.language}</mwc-list-item>
+                    <option value="${script.language}">${script.language}</option>
                   `
                 )}
-              </mwc-select>
+              </select>
             </div>
           </div>
         `

--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -5,7 +5,6 @@ import '@material/mwc-formfield';
 import '@material/mwc-radio';
 import '@material/mwc-checkbox';
 import '@material/mwc-switch';
-import '@material/mwc-select';
 import '@material/mwc-list/mwc-list-item';
 
 import '../addons/sc-toasts';

--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -192,7 +192,6 @@ class SCTopSheetViews extends LitLocalized(LitElement) {
         font-family: var(--sc-sans-font);
 
         position: absolute;
-        z-index: 1000;
 
         display: grid;
         overflow-x: scroll;
@@ -317,9 +316,9 @@ select {
   padding: 8px;
   width: 100%;
   margin: 4px 0 0 0;
-  border: 1px solid var(--sc-border-color);
+  border: 2px solid var(--sc-disabled-text-color);
   border-radius: var(--sc-size-sm);
-  background-color: var(--sc-primary-background-color);
+  background-color: var(--sc-secondary-background-color);
 }
 
 

--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -316,7 +316,7 @@ select {
   padding: 8px;
   width: 100%;
   margin: 4px 0 0 0;
-  border: 2px solid var(--sc-disabled-text-color);
+  border: 2px solid var(--sc-border-color);
   border-radius: var(--sc-size-sm);
   background-color: var(--sc-secondary-background-color);
 }

--- a/client/elements/menus/sc-language-base-menu-css.js
+++ b/client/elements/menus/sc-language-base-menu-css.js
@@ -6,6 +6,7 @@ export const languageBaseMenuCss = html`
       overflow-y: scroll;
       --mdc-menu-min-width: 500px;
       --mdc-theme-text-primary-on-background: var(--sc-primary-text-color);
+      --mdc-list-side-padding: 16px
     }
 
     .separator {

--- a/client/elements/menus/sc-more-menu.js
+++ b/client/elements/menus/sc-more-menu.js
@@ -59,10 +59,7 @@ class SCMoreMenu extends LitLocalized(LitElement) {
         padding: 4px;
         margin: 0 4px 0 1px;
         --mdc-theme-surface: var(--sc-tertiary-background-color);
-      }
-
-      .switch-item {
-        
+        --mdc-theme-secondary: var(--sc-primary-accent-color);
       }
 
       .chevron-right {

--- a/client/elements/menus/sc-more-menu.js
+++ b/client/elements/menus/sc-more-menu.js
@@ -17,6 +17,7 @@ class SCMoreMenu extends LitLocalized(LitElement) {
     return css`
       :host {
         font-family: var(--sc-sans-font);
+        --mdc-list-side-padding: 0px
       }
 
       .more-menu-link {
@@ -61,7 +62,7 @@ class SCMoreMenu extends LitLocalized(LitElement) {
       }
 
       .switch-item {
-        padding-left: calc(var(--mdc-list-side-padding, 16px) - 4px);
+        
       }
 
       .chevron-right {
@@ -86,6 +87,8 @@ class SCMoreMenu extends LitLocalized(LitElement) {
       .menu-item-wrapper {
         display: flex;
         align-items: center;
+        padding: 100% 16px;
+}
       }
     `;
   }


### PR DESCRIPTION
- use native select
- remove mwc-select
- fix bug with more-menu appearing behind top-sheet. This has removed the z-index from top sheet. It seems okay, but best watch for any unintended side-effects.