### PR TITLE
Sujato data clean

### DIFF
--- a/client/elements/menus/sc-search-filter-menu.js
+++ b/client/elements/menus/sc-search-filter-menu.js
@@ -1,7 +1,4 @@
 import { css, html, LitElement } from 'lit-element';
-import '@polymer/paper-dropdown-menu/paper-dropdown-menu.js';
-import '@polymer/paper-listbox/paper-listbox.js';
-import '@polymer/paper-item/paper-item.js';
 import { LitLocalized } from '../addons/localization-mixin';
 import '@material/mwc-select';
 import '@material/mwc-list/mwc-list-item';
@@ -20,6 +17,7 @@ class SCSearchFilterMenu extends LitLocalized(LitElement) {
       :host {
         --mdc-theme-primary: var(--sc-primary-accent-color);
         --mdc-select-fill-color: transparent;
+        --mdc-typography-font-family: var(--sc-sans-font);
       }
     `;
   }

--- a/client/elements/navigation/sc-navigation-styles.js
+++ b/client/elements/navigation/sc-navigation-styles.js
@@ -205,6 +205,10 @@ a
     align-items: center;
 }
 
+.number-translated{
+    white-space: nowrap;
+    }
+
 .essay-link
 {
     font-family: var(--sc-serif-font);

--- a/client/elements/navigation/sc-navigation-styles.js
+++ b/client/elements/navigation/sc-navigation-styles.js
@@ -178,6 +178,32 @@ export const navigationNormalModeStyles = html`
     font-variant-caps: all-small-caps;
 }
 
+    .subTitle::before {
+      content: attr(lang);
+      background-color: var(--sc-disabled-text-color);
+      color: white;
+      font-weight: 800;
+      padding: 0 4px;
+      margin-right: 8px;
+      line-height: 20px;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+      display: inline-block;
+      text-align: center;
+      font-size: 14px;
+      --notchSize: 4px;
+      clip-path: polygon(
+        0% var(--notchSize),
+        var(--notchSize) 0%,
+        calc(100% - var(--notchSize)) 0%,
+        100% var(--notchSize),
+        100% calc(100% - var(--notchSize)),
+        calc(100% - var(--notchSize)) 100%,
+        var(--notchSize) 100%,
+        0% calc(100% - var(--notchSize))
+      );
+    }
+
 a
 {
     cursor: pointer;

--- a/client/elements/navigation/sc-navigation.js
+++ b/client/elements/navigation/sc-navigation.js
@@ -338,7 +338,7 @@ class SCNavigation extends LitLocalized(LitElement) {
                 >
                   <header>
                     <span class="header-left">
-                      <span class="title" lang="${child.root_lang_iso}">
+                      <span class="title">
                         ${child.translated_name || child.root_name || child.uid}
                       </span>
                       <div class="navigation-nerdy-row">
@@ -453,7 +453,7 @@ class SCNavigation extends LitLocalized(LitElement) {
                 >
                   <header>
                     <span class="header-left">
-                      <span class="title" lang="${child.root_lang_iso}">
+                      <span class="title">
                         ${child.translated_name || child.root_name || child.uid}
                       </span>
                       <div class="navigation-nerdy-row">

--- a/client/elements/static-templates/home-page.js
+++ b/client/elements/static-templates/home-page.js
@@ -531,7 +531,7 @@ class SCHomePage extends SCStaticPage {
                 ${_`Indexes and Terminology`}
               </div>
               <div class="image-card-text">
-                ${_`Like any specialized field, Buddhist studies has it's own terminology and content. It's easy to get lost or to miss references, so here we provide indexes of terms in the early texts sorted by subject, name and simile, as well a glossary of important terms. These hand-curated lists offer another way to find the sutta or passage that you're looking for.`}
+                ${_`Like any specialized field, Buddhist studies has its own terminology. It's easy to get lost or to miss references, so here we provide indexes of terms in the early texts sorted by subject, name and simile, as well a glossary of important terms. These hand-curated lists offer another way to find the sutta or passage that you're looking for.`}
               </div>
             </div>
             <div>

--- a/client/localization/elements/sc-language-menu/pt.json
+++ b/client/localization/elements/sc-language-menu/pt.json
@@ -1,9 +1,0 @@
-{
-    "pt": {
-        "more": "Mais",
-        "selectLanguage": "Selecione um idioma",
-        "anonym": "Anônimo",
-        "selectTranslation": "Selecione tradução em {lang} por {author}.",
-        "selectOriginal": "Selecione o texto em {lang} por {author}."
-    }
-}

--- a/client/localization/elements/sc-language-menu/zh.json
+++ b/client/localization/elements/sc-language-menu/zh.json
@@ -1,9 +1,0 @@
-{
-    "zh": {
-        "more": "更多",
-        "selectLanguage": "语言选择",
-        "anonym": "匿名",
-        "selectTranslation": "选择{lang}翻译{author}",
-        "selectOriginal": "选择{lang}文献{author}。"
-    }
-}

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -539,7 +539,7 @@ def generate_relationship_edges(
                                 continue
                             true_to_uids = uid_matcher.get_matching_uids(to_uid)
                             if not true_to_uids:
-                                logging.error(
+                                logging.warning(
                                     f'Relationship to uid could not be matched: {to_uid} (appears as orphan)'
                                 )
                                 true_to_uids = ['orphan']

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -539,7 +539,7 @@ def generate_relationship_edges(
                                 continue
                             true_to_uids = uid_matcher.get_matching_uids(to_uid)
                             if not true_to_uids:
-                                logging.warning(
+                                logging.info(
                                     f'Relationship to uid could not be matched: {to_uid} (appears as orphan)'
                                 )
                                 true_to_uids = ['orphan']

--- a/server/server/data_loader/sc_html.py
+++ b/server/server/data_loader/sc_html.py
@@ -18,7 +18,7 @@ import regex
 from lxml.html import defs
 
 
-defs.html5_tags = frozenset({'section', 'article', 'hgroup'})
+defs.html5_tags = frozenset({'section', 'article', 'header'})
 
 
 class CssSelectorFailed(Exception):

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -195,12 +195,12 @@ class TextInfoModel:
         return None
 
     def _get_name(self, root, lang_uid, uid):
-        hgroup = root.select_one('.hgroup')
-        if not hgroup:
-            logger.error(f'No hgroup found in {lang_uid}/{uid}')
+        header = root.select_one('header')
+        if not header:
+            logger.error(f'No header found in {lang_uid}/{uid}')
             return ''
 
-        h1 = hgroup.select_one('h1')
+        h1 = header.select_one('h1')
         if not h1:
             logger.error(f'No h1 found in {lang_uid}/{uid}')
             return ''


### PR DESCRIPTION
This makes a few minor changes that eliminate false flags on `make load-data`

- orphaned texts are `info` so don't show by default
- sc-language-menu I think is a deprecated element, I remove it from localization
- we don't use hgroup, check for header instead

I also made a bunch of changes to sc-data that fix various small errors.

Only remaining error is the zz pages: `Text uids do not match menu uids`. These are not in the menu, they are various demo pages.

Anything else is an actual error!
