### PR TITLE
Sujato 200

### DIFF
--- a/client/elements/addons/sc-top-sheet-publication-bilara.js
+++ b/client/elements/addons/sc-top-sheet-publication-bilara.js
@@ -326,17 +326,16 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
                 <span property="dct:title">${this.authorName}</span>
               </a>
               has waived all copyright and related or neighboring rights to
-              <cite property="dct:title">${this.translationTitle}</cite>
-              . This work is published from
+              <cite property="dct:title">${this.translationTitle}</cite>. This work is published
+              from
               <span
                 property="vcard:Country"
                 datatype="dct:ISO3166"
                 content="AU"
                 about="https://suttacentral.net/licensing"
               >
-                Australia
-              </span>
-              .
+                Australia </span
+              >.
             </p>
             <h3>About this license</h3>
             <p class="license-statement">${this.licenseStatement}</p>

--- a/client/elements/addons/sc-top-sheet-publication-bilara.js
+++ b/client/elements/addons/sc-top-sheet-publication-bilara.js
@@ -246,11 +246,10 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
 
           <section class="text-metadata" about="${this.sourceURL}">
             <p>
-              This text is transcluded in
+              This text is included in
               <cite>${this.translationTitle}</cite>
               by
-              <span>${this.authorName}</span>
-              .
+              <span>${this.authorName}</span>.
             </p>
             <dl class="main-details">
               <dt class="translation-title">Translation title</dt>

--- a/client/elements/addons/sc-top-sheet-publication-bilara.js
+++ b/client/elements/addons/sc-top-sheet-publication-bilara.js
@@ -139,6 +139,7 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
         dd.source-url,
         dd.publication-number {
           font-family: mono;
+          font-size: 16px;
         }
 
         .number-of_volumes,

--- a/client/elements/addons/sc-top-sheet-publication-bilara.js
+++ b/client/elements/addons/sc-top-sheet-publication-bilara.js
@@ -122,6 +122,25 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
           margin-left: 0;
         }
 
+        dd.translation-title,
+        dd.root-title {
+          font-weight: 800;
+        }
+
+        dd.translation-subtitle {
+          font-weight: 600;
+        }
+
+        dd.author-name {
+          font-variant-caps: small-caps;
+        }
+
+        dd.edition-url,
+        dd.source-url,
+        dd.publication-number {
+          font-family: mono;
+        }
+
         .number-of_volumes,
         .text-uid {
           display: none;
@@ -237,16 +256,16 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
               <dd class="translation-title" property="dc:title">${this.translationTitle}</dd>
               <dt class="translation-subtitle">Translation subtitle</dt>
               <dd class="translation-subtitle" property="dc:title">${this.translationSubtitle}</dd>
+              <dt class="author-name">Translator</dt>
+              <dd class="author-name" property="dc:creator">${this.authorName}</dd>
+              <dt class="root-title">Root title</dt>
+              <dd class="root-title" property="dc:title">${this.rootTitle}</dd>
               <dt class="translation-language">Translation language</dt>
               <dd class="translation-language" property="dc:language">
                 ${this.translationLanguage}
               </dd>
-              <dt class="root-title">Root title</dt>
-              <dd class="root-title" property="dc:title">${this.rootTitle}</dd>
               <dt class="root-language">Root language</dt>
               <dd class="root-language">${this.rootLanguage}</dd>
-              <dt class="author-name">Translator</dt>
-              <dd class="author-name" property="dc:creator">${this.authorName}</dd>
             </dl>
             <dl class="descriptive-details">
               <dt class="translation-description">Translation description</dt>

--- a/client/elements/addons/sc-top-sheet-publication-bilara.js
+++ b/client/elements/addons/sc-top-sheet-publication-bilara.js
@@ -103,6 +103,7 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
         }
 
         .main-details,
+        .translation-details,
         .edition {
           display: grid;
 
@@ -122,8 +123,7 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
           margin-left: 0;
         }
 
-        dd.translation-title,
-        dd.root-title {
+        dd.translation-title {
           font-weight: 800;
         }
 
@@ -245,12 +245,7 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
           <h2>Publication details</h2>
 
           <section class="text-metadata" about="${this.sourceURL}">
-            <p>
-              This text is included in
-              <cite>${this.translationTitle}</cite>
-              by
-              <span>${this.authorName}</span>.
-            </p>
+            <p>This text is included in the following publication.</p>
             <dl class="main-details">
               <dt class="translation-title">Translation title</dt>
               <dd class="translation-title" property="dc:title">${this.translationTitle}</dd>
@@ -258,6 +253,8 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
               <dd class="translation-subtitle" property="dc:title">${this.translationSubtitle}</dd>
               <dt class="author-name">Translator</dt>
               <dd class="author-name" property="dc:creator">${this.authorName}</dd>
+            </dl>
+            <dl class="translation-details">
               <dt class="root-title">Root title</dt>
               <dd class="root-title" property="dc:title">${this.rootTitle}</dd>
               <dt class="translation-language">Translation language</dt>

--- a/client/elements/addons/sc-top-sheet-publication-bilara.js
+++ b/client/elements/addons/sc-top-sheet-publication-bilara.js
@@ -246,7 +246,7 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
 
           <section class="text-metadata" about="${this.sourceURL}">
             <p>
-              This text is included in
+              This text is transcluded in
               <cite>${this.translationTitle}</cite>
               by
               <span>${this.authorName}</span>

--- a/client/package.json
+++ b/client/package.json
@@ -74,6 +74,6 @@
     "printWidth": 100,
     "trailingComma": "es5",
     "arrowParens": "avoid",
-    "htmlWhitespaceSensitivity": "ignore"
+    "htmlWhitespaceSensitivity": "css"
   }
 }


### PR DESCRIPTION
- adjusts publications.json
- Change prettier settings to `"htmlWhitespaceSensitivity": "css"` (which is modern default). Previous setting created extra space when a tag preceded punctuation, eg. `</span> .`
