### PR TITLE
Fixed Prev/next localization and breadcrumbs are still buggy #2046

### DIFF
--- a/client/elements/navigation/sc-navigation-common.js
+++ b/client/elements/navigation/sc-navigation-common.js
@@ -318,8 +318,13 @@ export async function RefreshNav(uid) {
   let currentURL = '/pitaka';
   const currentNav = store.getState().navigationArray;
 
+  const truePathLength = URLs.filter(x => x !== null && x !== '' && x !== 'pitaka').length;
+  const navSuttaPathLength = currentNav.filter(
+    x => x != null && x.groupId !== uid && x.type !== 'home'
+  ).length;
+
   const fatherLevelExists = currentNav.some(x => x !== null && x.groupId === URLs[URLs.length - 1]);
-  if (fatherLevelExists) {
+  if (fatherLevelExists && navSuttaPathLength === truePathLength) {
     return;
   }
 

--- a/client/elements/navigation/sc-navigation.js
+++ b/client/elements/navigation/sc-navigation.js
@@ -243,60 +243,40 @@ class SCNavigation extends LitLocalized(LitElement) {
     this.compactStyles = this.isCompactMode ? navigationCompactModeStyles : null;
   }
 
-  async _fetchMainData() {
+  _fetchMainData() {
     this.loading = true;
-    await this._fetchTipitakaData();
-    await this._fetchPitakaData();
+    this._fetchTipitakaData();
     this.loading = false;
   }
 
-  async _fetchTipitakaData() {
-    try {
-      // if (!this.navDataCache) {
-      //   this.navDataCache = new Map(Object.entries(store.getState().navDataCache || {}));
-      // }
-      // if (this.navDataCache.has('tipitakaData')) {
-      //   this.tipitakaData = this.navDataCache.get('tipitakaData');
-      // } else {
-      //   this.tipitakaData = await (await fetch(`${API_ROOT}/menu?language=${this.siteLanguage || 'en'}`)).json();
-      //   this._updateNavDataCache('tipitakaData', this.tipitakaData);
-      // }
-      this.tipitakaData = await (
-        await fetch(`${API_ROOT}/menu?language=${this.siteLanguage || 'en'}`)
-      ).json();
-    } catch (e) {
-      this.lastError = e;
-    }
-  }
-
-  async _fetchPitakaData(params) {
-    if (!this.tipitakaData) {
-      await this._fetchTipitakaData();
-    }
-    this.pitakaData = this.tipitakaData.find(x => {
-      return x.uid === this.pitakaUid;
-    });
+  _fetchTipitakaData() {
+    const url = `${API_ROOT}/menu?language=${this.siteLanguage || 'en'}`;
+    fetch(url)
+      .then(r => r.json())
+      .then(menuData => {
+        this.tipitakaData = menuData;
+        this.pitakaData = this.tipitakaData.find(x => x.uid === this.pitakaUid);
+      })
+      .catch(e => console.error(e));
   }
 
   async _fetchChildrenData(childId) {
     const url = `${API_ROOT}/menu/${childId}?language=${this.siteLanguage || 'en'}`;
     try {
-      // if (!this.navDataCache) {
-      //   this.navDataCache = new Map(Object.entries(store.getState().navDataCache || {}));
-      // }
-      // if (this.navDataCache.has(url)) {
-      //   return this.navDataCache.get(url);
-      // } else {
-      //   const childrenData = await (await fetch(url)).json();
-      //   this._updateNavDataCache(url, childrenData);
-      //   return childrenData;
-      // }
       const childrenData = await (await fetch(url)).json();
       return childrenData;
     } catch (e) {
       this.lastError = e;
       return {};
     }
+
+    // const url = `${API_ROOT}/menu/${childId}?language=${this.siteLanguage || 'en'}`;
+    // fetch(url)
+    //   .then(r => r.json())
+    //   .then(menuData => {
+    //     return menuData;
+    //   })
+    //   .catch(e => console.error(e));
   }
 
   _updateNavDataCache(url, data) {
@@ -436,6 +416,7 @@ class SCNavigation extends LitLocalized(LitElement) {
         this.parallelsData[0].uid;
       this._dispatchNavState(this.navArray, navIndexesOfType.position, toolbarTitle);
       this._setCurrentURL(params.childId);
+      this.requestUpdate();
     }
   }
 

--- a/client/elements/navigation/sc-navigation.js
+++ b/client/elements/navigation/sc-navigation.js
@@ -41,7 +41,6 @@ class SCNavigation extends LitLocalized(LitElement) {
     this._verifyURL();
     this._appViewModeChanged();
     this._fetchMainData();
-    this._initPitakaCards({ dispatchState: true });
     this._parseURL();
   }
 

--- a/client/elements/navigation/sc-navigation.js
+++ b/client/elements/navigation/sc-navigation.js
@@ -148,6 +148,7 @@ class SCNavigation extends LitLocalized(LitElement) {
         this.localize(this.pitakaName)
       );
     }
+    this.requestUpdate();
   }
 
   _stateChanged(state) {
@@ -243,21 +244,23 @@ class SCNavigation extends LitLocalized(LitElement) {
     this.compactStyles = this.isCompactMode ? navigationCompactModeStyles : null;
   }
 
-  _fetchMainData() {
+  async _fetchMainData() {
     this.loading = true;
-    this._fetchTipitakaData();
+    await this._fetchTipitakaData();
     this.loading = false;
   }
 
-  _fetchTipitakaData() {
-    const url = `${API_ROOT}/menu?language=${this.siteLanguage || 'en'}`;
-    fetch(url)
-      .then(r => r.json())
-      .then(menuData => {
-        this.tipitakaData = menuData;
+  async _fetchTipitakaData() {
+    try {
+      this.tipitakaData = await (
+        await fetch(`${API_ROOT}/menu?language=${this.siteLanguage || 'en'}`)
+      ).json();
+      if (this.tipitakaData) {
         this.pitakaData = this.tipitakaData.find(x => x.uid === this.pitakaUid);
-      })
-      .catch(e => console.error(e));
+      }
+    } catch (e) {
+      this.lastError = e;
+    }
   }
 
   async _fetchChildrenData(childId) {
@@ -269,14 +272,6 @@ class SCNavigation extends LitLocalized(LitElement) {
       this.lastError = e;
       return {};
     }
-
-    // const url = `${API_ROOT}/menu/${childId}?language=${this.siteLanguage || 'en'}`;
-    // fetch(url)
-    //   .then(r => r.json())
-    //   .then(menuData => {
-    //     return menuData;
-    //   })
-    //   .catch(e => console.error(e));
   }
 
   _updateNavDataCache(url, data) {

--- a/client/elements/navigation/sc-tipitaka.js
+++ b/client/elements/navigation/sc-tipitaka.js
@@ -67,20 +67,6 @@ class SCTipitaka extends LitLocalized(LitElement) {
       ['vinaya', '/vinaya'],
       ['abhidhamma', '/abhidhamma'],
     ]);
-    this.tipitakaBlurb = new Map([
-      [
-        'sutta',
-        'The Buddha’s teachings on meditation, morality, the nature of the world, and the path to freedom. These scriptures are our primary sources for the historical Buddha’s life and practice. They depict the Buddha and his students in lively conversation with a diverse range of people.',
-      ],
-      [
-        'vinaya',
-        'The texts on Monastic Law (vinaya) detail the lifestyle, rules, and procedures for Buddhist monks and nuns. They provide the guidelines for Buddhist monastics to this day, and in addition, paint a detailed and vivid picture of everyday life in ancient India.',
-      ],
-      [
-        'abhidhamma',
-        'Abhidhamma texts are systematic summaries and analyses of the teachings drawn from the earlier discourses. The Abhidhamma (spelled abhidharma in Sanskrit) is intended for advanced students who have mastered the teachings of the discourses.',
-      ],
-    ]);
     this.navDataCache = new Map(Object.entries(store.getState().navDataCache || {}));
   }
 
@@ -138,9 +124,7 @@ class SCTipitaka extends LitLocalized(LitElement) {
                     </header>
                   </a>
                   <div class="nav-card-content">
-                    <div class="blurb" id="${item.root_name}_blurb">
-                      ${this.tipitakaBlurb.get(item.uid)}
-                    </div>
+                    <div class="blurb" id="${item.root_name}_blurb">${item.blurb}</div>
                     <a class="essay-link" href="${this.tipitakaGuide.get(item.uid)}">
                       <div class="essay">${this.localize(`${item.uid}_essayTitle`)}</div>
                     </a>
@@ -154,9 +138,7 @@ class SCTipitaka extends LitLocalized(LitElement) {
   }
 
   render() {
-    return html`
-      ${this.currentStyles} ${this.compactStyles} ${this.tipitakaCardTemplate}
-    `;
+    return html` ${this.currentStyles} ${this.compactStyles} ${this.tipitakaCardTemplate} `;
   }
 }
 

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -360,9 +360,7 @@ class SCPageSelector extends LitLocalized(LitElement) {
 
   render() {
     return this.routeDefinition
-      ? html`
-          <div class="container">${this.routeDefinition.content}</div>
-        `
+      ? html` <div class="container">${this.routeDefinition.content}</div> `
       : html`
           <div class="page-not-found-container">
             <h2>${this.localize('error404')}</h2>
@@ -481,6 +479,10 @@ class SCPageSelector extends LitLocalized(LitElement) {
       case 'HOME':
         this.actions.changeToolbarTitle('SuttaCentral');
         break;
+      case 'NAVIGATION':
+        return;
+      case 'SUTTAPLEX':
+        return;
       default:
         const key = `${this.currentRoute.name}-TITLE`;
         if (this.__resources[key]) {

--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -88,7 +88,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
       const navArray = store.getState().navigationArray;
       const currentNav = navArray.find(x => x !== null && x.groupId === this.categoryId);
       if (!currentNav) {
-        RefreshNav(this.categoryId);
+        RefreshNav(this.categoryId, false);
       }
     }
 
@@ -199,11 +199,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
           ></sc-bouncing-loader>
         </div>
 
-        ${this.hasError()
-          ? html`
-              <sc-error-icon type="no-network"></sc-error-icon>
-            `
-          : ''}
+        ${this.hasError() ? html` <sc-error-icon type="no-network"></sc-error-icon> ` : ''}
         ${this.suttaplexData &&
         repeat(
           this.suttaplexData,

--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -45,6 +45,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
   constructor() {
     super();
     this.localizedStringsPath = '/localization/elements/sc-navigation-menu';
+    this.siteLanguage = store.getState().siteLanguage;
   }
 
   isSuttaplex(item) {
@@ -80,16 +81,22 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
 
   _stateChanged(state) {
     super._stateChanged(state);
-    if (this.categoryId !== state.currentRoute.params.categoryId) {
+    if (
+      this.categoryId !== state.currentRoute.params.categoryId ||
+      this.siteLanguage !== state.siteLanguage
+    ) {
       this.categoryId = state.currentRoute.params.categoryId;
       if (this.categoryId && state.siteLanguage) {
         this._fetchCategory();
       }
-      const navArray = store.getState().navigationArray;
-      const currentNav = navArray.find(x => x !== null && x.groupId === this.categoryId);
-      if (!currentNav) {
-        RefreshNav(this.categoryId, false);
+
+      let forceRefresh = false;
+      if (this.siteLanguage !== state.siteLanguage) {
+        this.siteLanguage = state.siteLanguage;
+        forceRefresh = true;
       }
+
+      RefreshNav(this.categoryId, true);
     }
 
     if (this.suttaplexListDisplay !== state.suttaplexListDisplay) {

--- a/client/elements/text/sc-text-page-selector.js
+++ b/client/elements/text/sc-text-page-selector.js
@@ -153,6 +153,20 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
     this.siteLanguage = store.getState().siteLanguage;
     this.isLoading = false;
     this.bilaraDataPath = '/files/bilara-data';
+    this.langIsoCode = store.getState().currentRoute.params.langIsoCode;
+    this.authorUid = store.getState().currentRoute.params.authorUid;
+    this.suttaId = store.getState().currentRoute.params.suttaId;
+  }
+
+  firstUpdated() {
+    this._refreshData(true);
+  }
+
+  _refreshData(forceRefresh) {
+    this._paramChanged();
+    this.refreshing = true;
+    RefreshNav(this.suttaId, forceRefresh);
+    this.refreshing = false;
   }
 
   get actions() {
@@ -261,17 +275,11 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
     }
     if (state.currentRoute.params.suttaId !== this.suttaId && state.currentRoute.params.suttaId) {
       this.suttaId = state.currentRoute.params.suttaId;
-      this._paramChanged();
-      this.refreshing = true;
-      RefreshNav(this.suttaId, false);
-      this.refreshing = false;
+      this._refreshData(false);
     }
     if (this.siteLanguage !== state.siteLanguage) {
       this.siteLanguage = state.siteLanguage;
-      this._paramChanged();
-      this.refreshing = true;
-      RefreshNav(this.suttaId, true);
-      this.refreshing = false;
+      this._refreshData(true);
     }
   }
 

--- a/client/elements/text/sc-text-page-selector.js
+++ b/client/elements/text/sc-text-page-selector.js
@@ -299,7 +299,7 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
     if (this.responseData) {
       this.isSegmentedText = !!this.responseData.segmented;
       this.suttaplex = this.responseData.suttaplex;
-      this._bindDataToSCSuttaParallels(this.suttaplex);
+      this._bindDataToSCSuttaParallels(this.suttaId);
       this.translatedSutta = this.responseData.translation;
       this.rootSutta = this.responseData.root_text;
       if (this.translatedSutta) {
@@ -322,16 +322,22 @@ class SCTextPageSelector extends LitLocalized(LitElement) {
     this._updateNav();
   }
 
-  _bindDataToSCSuttaParallels(suttaplex) {
-    this.dispatchEvent(
-      new CustomEvent('bind-data-to-sc-sutta-parallels', {
-        detail: {
-          suttaplexItem: suttaplex,
-        },
-        bubbles: true,
-        composed: true,
+  _bindDataToSCSuttaParallels(uid) {
+    const url = `${API_ROOT}/suttaplex/${uid}?language=${this.siteLanguage}`;
+    fetch(url)
+      .then(r => r.json())
+      .then(suttaplex => {
+        this.dispatchEvent(
+          new CustomEvent('bind-data-to-sc-sutta-parallels', {
+            detail: {
+              suttaplexItem: suttaplex[0],
+            },
+            bubbles: true,
+            composed: true,
+          })
+        );
       })
-    );
+      .catch(e => console.error(e));
   }
 
   _getSuttaTextUrl() {

--- a/server/server/api/views/views.py
+++ b/server/server/api/views/views.py
@@ -529,6 +529,7 @@ class Sutta(Resource):
 
         """
         lang = request.args.get('lang', 'en')
+        siteLang = request.args.get('siteLanguage', 'en')
 
         db = get_db()
 
@@ -543,7 +544,7 @@ class Sutta(Resource):
             doc = result[k]
             if doc:
                 self.convert_paths_to_content(doc)
-                self.calculate_sutta_neighbors(uid, doc, k, lang)
+                self.calculate_sutta_neighbors(uid, doc, k, siteLang)
 
         return result, 200
 
@@ -565,7 +566,7 @@ class Sutta(Resource):
                         doc[to_prop] = load_func(f)
 
     @staticmethod
-    def calculate_sutta_neighbors(uid, doc, textType, lang):
+    def calculate_sutta_neighbors(uid, doc, textType, siteLang):
         db = get_db()
         sutta_prev_next = {'prev_uid': '', 'next_uid': ''}
         for i in range(1, 10):
@@ -589,12 +590,12 @@ class Sutta(Resource):
             is_root = True
 
         for k, v in sutta_prev_next.items():
-            name_results = db.aql.execute(SUTTA_NAME, bind_vars={'uid': v, 'lang': lang})
+            name_results = db.aql.execute(SUTTA_NAME, bind_vars={'uid': v, 'lang': siteLang})
             name_result = list(name_results)
             if k == 'next_uid' and doc['next']:
-                doc['next']['name'] = ''.join(name_result)
+                doc['next']['name'] = name_result
             elif k == 'prev_uid' and doc['previous']:
-                doc['previous']['name'] = ''.join(name_result)
+                doc['previous']['name'] = name_result
 
 
 class SegmentedSutta(Resource):

--- a/server/server/api/views/views.py
+++ b/server/server/api/views/views.py
@@ -543,7 +543,7 @@ class Sutta(Resource):
             doc = result[k]
             if doc:
                 self.convert_paths_to_content(doc)
-                self.calculate_sutta_neighbors(uid, doc, k)
+                self.calculate_sutta_neighbors(uid, doc, k, lang)
 
         return result, 200
 
@@ -565,7 +565,7 @@ class Sutta(Resource):
                         doc[to_prop] = load_func(f)
 
     @staticmethod
-    def calculate_sutta_neighbors(uid, doc, textType):
+    def calculate_sutta_neighbors(uid, doc, textType, lang):
         db = get_db()
         sutta_prev_next = {'prev_uid': '', 'next_uid': ''}
         for i in range(1, 10):
@@ -589,7 +589,7 @@ class Sutta(Resource):
             is_root = True
 
         for k, v in sutta_prev_next.items():
-            name_results = db.aql.execute(SUTTA_NAME, bind_vars={'uid': v, 'is_root': is_root})
+            name_results = db.aql.execute(SUTTA_NAME, bind_vars={'uid': v, 'lang': lang})
             name_result = list(name_results)
             if k == 'next_uid' and doc['next']:
                 doc['next']['name'] = ''.join(name_result)

--- a/server/server/common/queries.py
+++ b/server/server/common/queries.py
@@ -643,10 +643,21 @@ RETURN neighbors
 '''
 
 SUTTA_NAME = '''
-FOR name IN names
-    FILTER name.uid == @uid AND name.is_root == @is_root
-    LIMIT 1
-    RETURN name.name
+LET translated_name = (
+    FOR name IN names
+        FILTER name.uid == @uid AND name.is_root == false AND name.lang == @lang
+        LIMIT 1
+        RETURN name.name
+)[0]
+
+LET root_name = (
+    FOR name IN names
+        FILTER name.uid == @uid AND name.is_root == true
+        LIMIT 1
+        RETURN name.name
+)[0]
+
+RETURN translated_name ? translated_name : root_name
 '''
 
 SEGMENTED_SUTTA_VIEW = '''


### PR DESCRIPTION
Currently, the prev/next name is always obtained from the names collection, such as an4.58, with only pli and German versions, no English version, and the pali name is displayed by default if there is no version of the language.