### PR TITLE
Fix a bug of more-menu.

### DIFF
--- a/client/elements/menus/sc-more-menu.js
+++ b/client/elements/menus/sc-more-menu.js
@@ -167,17 +167,12 @@ class SCMoreMenu extends LitLocalized(LitElement) {
 
   _onThemeChanged(e) {
     const chk = e.currentTarget.shadowRoot.querySelector('mwc-checkbox');
-    chk.addEventListener('change', () => {
-      const newTheme = chk.checked ? 'dark' : 'light';
-      this.actions.changeAppTheme(newTheme);
-    });
+    this.actions.changeAppTheme(chk.checked ? 'dark' : 'light');
   }
 
   _onToolbarDisplayModeChanged(e) {
     const chk = e.currentTarget.shadowRoot.querySelector('mwc-checkbox');
-    chk.addEventListener('change', () => {
-      this.actions.changeAlwaysShowToolbarState(chk.checked);
-    });
+    this.actions.changeAlwaysShowToolbarState(chk.checked);
   }
 
   _showLanguageMenu() {
@@ -190,115 +185,117 @@ class SCMoreMenu extends LitLocalized(LitElement) {
 
   _renderMoreMenu() {
     return html`
-      <mwc-list-item
-        class="more-menu-mwc-list-item language-choice-box"
-        @click="${this._showLanguageMenu}"
-      >
-        <div class="menu-item-wrapper">
-          ${icon.language}
-          <div id="language-wrapper">
-            <span id="language-text-wrapper">${this._displayCurrentSiteLanguage()}</span>
-            ${icon.chevron_right}
-          </div>
-        </div>
-      </mwc-list-item>
-      <a class="more-menu-link" href="/donations">
-        <mwc-list-item class="more-menu-mwc-list-item">
-          <div class="menu-item-wrapper">${icon.pray} ${this.localize('Donations')}</div>
-        </mwc-list-item>
-      </a>
-      <a class="more-menu-link" href="/offline">
-        <mwc-list-item class="more-menu-mwc-list-item">
-          <div class="menu-item-wrapper">${icon.offline_bolt} ${this.localize('UseOffline')}</div>
-        </mwc-list-item>
-      </a>
-      <mwc-check-list-item
-        class="more-menu-mwc-list-item"
-        id="theme_toggler"
-        left
-        ?selected="${this.darkThemeChosen}"
-        @request-selected="${this._onThemeChanged}"
-      >
-        ${this.localize('DarkTheme')}
-      </mwc-check-list-item>
-      <mwc-check-list-item
-        class="more-menu-mwc-list-item"
-        id="alwaysShowToolbar_toggler"
-        left
-        ?selected="${this.alwaysShowUniversalToolbar}"
-        @request-selected="${this._onToolbarDisplayModeChanged}"
-      >
-        ${this.localize('AlwaysShowToolbar')}
-      </mwc-check-list-item>
-      <a class="more-menu-link" href="/downloads">
-        <mwc-list-item class="more-menu-mwc-list-item">
-          <div class="menu-item-wrapper">${icon.file_download} ${this.localize('Downloads')}</div>
-        </mwc-list-item>
-      </a>
-      <a class="more-menu-link" href="/languages">
-        <mwc-list-item class="more-menu-mwc-list-item">
-          <div class="menu-item-wrapper">${icon.translate} ${this.localize('Languages')}</div>
-        </mwc-list-item>
-      </a>
-      <li divider role="separator"></li>
-      <a class="more-menu-link" href="/numbering">
-        <mwc-list-item class="more-menu-mwc-list-item">
+      <mwc-list multi>
+        <mwc-list-item
+          class="more-menu-mwc-list-item language-choice-box"
+          @click="${this._showLanguageMenu}"
+        >
           <div class="menu-item-wrapper">
-            ${icon.format_list_numbered} ${this.localize('Numbering')}
+            ${icon.language}
+            <div id="language-wrapper">
+              <span id="language-text-wrapper">${this._displayCurrentSiteLanguage()}</span>
+              ${icon.chevron_right}
+            </div>
           </div>
         </mwc-list-item>
-      </a>
-      <a class="more-menu-link" href="/abbreviations">
-        <mwc-list-item class="more-menu-mwc-list-item">
-          <div class="menu-item-wrapper">
-            ${icon.abbreviations} ${this.localize('Abbreviations')}
-          </div>
-        </mwc-list-item>
-      </a>
-      <a class="more-menu-link" href="/methodology">
-        <mwc-list-item class="more-menu-mwc-list-item">
-          <div class="menu-item-wrapper">${icon.school} ${this.localize('Methodology')}</div>
-        </mwc-list-item>
-      </a>
-      <li divider role="separator"></li>
-      <a class="more-menu-link" href="/acknowledgments">
-        <mwc-list-item class="more-menu-mwc-list-item">
-          <div class="menu-item-wrapper">${icon.people} ${this.localize('Acknowledgments')}</div>
-        </mwc-list-item>
-      </a>
-      <a class="more-menu-link" href="/licensing">
-        <mwc-list-item class="more-menu-mwc-list-item">
-          <div class="menu-item-wrapper">${icon.copyright} ${this.localize('Licensing')}</div>
-        </mwc-list-item>
-      </a>
-      <a class="more-menu-link" href="/about">
-        <mwc-list-item class="more-menu-mwc-list-item">
-          <div class="menu-item-wrapper">${icon.info_outline} ${this.localize('About')}</div>
-        </mwc-list-item>
-      </a>
-      <li divider role="separator"></li>
-      <a
-        class="more-menu-link"
-        href="${this.getDiscourseUrl(this.routeName)}"
-        title="${this.getDiscourseTitle(this.routeName)}"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <mwc-list-item class="more-menu-mwc-list-item">
-          <div class="menu-item-wrapper">${icon.forum} ${this.localize('Discuss')}</div>
-        </mwc-list-item>
-      </a>
-      <a
-        class="more-menu-link"
-        href="https://voice.suttacentral.net/scv/index.html#/sutta${this.routeName}"
-        title="Listen to suttas"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <mwc-list-item class="more-menu-mwc-list-item">
-          <div class="menu-item-wrapper">${icon.speaker} ${this.localize('Voice')}</div>
-        </mwc-list-item>
-      </a>
+        <a class="more-menu-link" href="/donations">
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">${icon.pray} ${this.localize('Donations')}</div>
+          </mwc-list-item>
+        </a>
+        <a class="more-menu-link" href="/offline">
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">${icon.offline_bolt} ${this.localize('UseOffline')}</div>
+          </mwc-list-item>
+        </a>
+        <mwc-check-list-item
+          class="more-menu-mwc-list-item"
+          id="theme_toggler"
+          left
+          ?selected="${this.darkThemeChosen}"
+          @request-selected="${this._onThemeChanged}"
+        >
+          ${this.localize('DarkTheme')}
+        </mwc-check-list-item>
+        <mwc-check-list-item
+          class="more-menu-mwc-list-item"
+          id="alwaysShowToolbar_toggler"
+          left
+          ?selected="${this.alwaysShowUniversalToolbar}"
+          @request-selected="${this._onToolbarDisplayModeChanged}"
+        >
+          ${this.localize('AlwaysShowToolbar')}
+        </mwc-check-list-item>
+        <a class="more-menu-link" href="/downloads">
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">${icon.file_download} ${this.localize('Downloads')}</div>
+          </mwc-list-item>
+        </a>
+        <a class="more-menu-link" href="/languages">
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">${icon.translate} ${this.localize('Languages')}</div>
+          </mwc-list-item>
+        </a>
+        <li divider role="separator"></li>
+        <a class="more-menu-link" href="/numbering">
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">
+              ${icon.format_list_numbered} ${this.localize('Numbering')}
+            </div>
+          </mwc-list-item>
+        </a>
+        <a class="more-menu-link" href="/abbreviations">
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">
+              ${icon.abbreviations} ${this.localize('Abbreviations')}
+            </div>
+          </mwc-list-item>
+        </a>
+        <a class="more-menu-link" href="/methodology">
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">${icon.school} ${this.localize('Methodology')}</div>
+          </mwc-list-item>
+        </a>
+        <li divider role="separator"></li>
+        <a class="more-menu-link" href="/acknowledgments">
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">${icon.people} ${this.localize('Acknowledgments')}</div>
+          </mwc-list-item>
+        </a>
+        <a class="more-menu-link" href="/licensing">
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">${icon.copyright} ${this.localize('Licensing')}</div>
+          </mwc-list-item>
+        </a>
+        <a class="more-menu-link" href="/about">
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">${icon.info_outline} ${this.localize('About')}</div>
+          </mwc-list-item>
+        </a>
+        <li divider role="separator"></li>
+        <a
+          class="more-menu-link"
+          href="${this.getDiscourseUrl(this.routeName)}"
+          title="${this.getDiscourseTitle(this.routeName)}"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">${icon.forum} ${this.localize('Discuss')}</div>
+          </mwc-list-item>
+        </a>
+        <a
+          class="more-menu-link"
+          href="https://voice.suttacentral.net/scv/index.html#/sutta${this.routeName}"
+          title="Listen to suttas"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <mwc-list-item class="more-menu-mwc-list-item">
+            <div class="menu-item-wrapper">${icon.speaker} ${this.localize('Voice')}</div>
+          </mwc-list-item>
+        </a>
+      </mwc-list>
     `;
   }
 

--- a/client/elements/menus/sc-more-menu.js
+++ b/client/elements/menus/sc-more-menu.js
@@ -165,13 +165,19 @@ class SCMoreMenu extends LitLocalized(LitElement) {
     });
   }
 
-  _onThemeChanged() {
-    const newTheme = this.darkThemeChosen ? 'light' : 'dark';
-    this.actions.changeAppTheme(newTheme);
+  _onThemeChanged(e) {
+    const chk = e.currentTarget.shadowRoot.querySelector('mwc-checkbox');
+    chk.addEventListener('change', () => {
+      const newTheme = chk.checked ? 'dark' : 'light';
+      this.actions.changeAppTheme(newTheme);
+    });
   }
 
   _onToolbarDisplayModeChanged(e) {
-    this.actions.changeAlwaysShowToolbarState(!e.target.selected);
+    const chk = e.currentTarget.shadowRoot.querySelector('mwc-checkbox');
+    chk.addEventListener('change', () => {
+      this.actions.changeAlwaysShowToolbarState(chk.checked);
+    });
   }
 
   _showLanguageMenu() {

--- a/client/elements/menus/sc-more-menu.js
+++ b/client/elements/menus/sc-more-menu.js
@@ -151,8 +151,7 @@ class SCMoreMenu extends LitLocalized(LitElement) {
     return this.localize(title);
   }
 
-  connectedCallback() {
-    super.connectedCallback();
+  updated() {
     if (!this.languageIsVisible) {
       this._initializeListeners();
     }


### PR DESCRIPTION
> There's a small bug affecting this.
> 
> The mwc-check-list-item has an odd UI where there are two clickable fields: the item as a whole, and the actual checkbox. (I think it should be just the checkbox, but this is what the mwc official demo does.) So on the demo, if you click anywhere on the item, it turns the checkbox on or off:
> 
> https://material-components.github.io/material-components-web-components/demos/list/
> 
> On our implementation, however, the *function* works when clicking anywhere on the item, but the check mark does not appear unless you click the checkbox itself. That means you can end up in a state where the dark theme is applied, yet it is not checked:
> 
> ![Screenshot from 2021-03-13 10-46-20](https://user-images.githubusercontent.com/6112010/111010080-8fe99280-83e9-11eb-975a-39adf6499bdf.png)
> 
> If you refresh the page, the check appears.
> 
> 

This PR will fix the above problems.