### PR TITLE
Fixed: Pali texts (and other root texts?) are not showing in search results #2094

### DIFF
--- a/server/server/common/queries.py
+++ b/server/server/common/queries.py
@@ -70,7 +70,7 @@ FOR text IN sc_bilara_texts
         author_short: author_doc.short_name,
         root_lang: text.lang,
         acronym: nav_doc.acronym,
-        mtime: 1615772139.177768
+        mtime: mtime_doc.mtime  / 1000000000
     }
 '''
 

--- a/server/server/common/queries.py
+++ b/server/server/common/queries.py
@@ -68,7 +68,7 @@ FOR text IN sc_bilara_texts
         author: author_doc.long_name,
         author_uid: author_doc.uid,
         author_short: author_doc.short_name,
-        root_lang: text.lang,
+        root_lang: nav_doc.root_lang,
         acronym: nav_doc.acronym,
         mtime: mtime_doc.mtime  / 1000000000
     }


### PR DESCRIPTION
The code for this PR generates indexes of bilara text.

run `make index-elasticsearch` to rebuild the index.