### PR TITLE
Add reference data to texts on user request.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ client/data/
 /server/nextdata/
 .DS_Store
 /client/node_modules/
-package-lock.json
 client/build/
 /client/localization/pootle/prePootleFiles/
 /client/localization/pootle/generatedPoFiles/
@@ -20,4 +19,8 @@ client/build/
 generatedPoFiles/
 /pootle/log/*
 .prod.env
-environment_prod.yml
+.history
+client/.eslintrc.json
+client/.eslintrc.js
+client/.prettierrc
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ client/build/
 generatedPoFiles/
 /pootle/log/*
 .prod.env
+environment_prod.yml
 .history
 client/.eslintrc.json
 client/.eslintrc.js

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ client/data/
 /server/nextdata/
 .DS_Store
 /client/node_modules/
+package-lock.json
 client/build/
 /client/localization/pootle/prePootleFiles/
 /client/localization/pootle/generatedPoFiles/
@@ -23,4 +24,3 @@ generatedPoFiles/
 client/.eslintrc.json
 client/.eslintrc.js
 client/.prettierrc
-.gitignore

--- a/client/elements/addons/sc-top-sheet-publication-bilara.js
+++ b/client/elements/addons/sc-top-sheet-publication-bilara.js
@@ -276,7 +276,7 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
                 : ''}
               ${this.collaborator
                 ? html`
-                    <dt class="author-name">Collaborator</dt>
+                    <dt class="author-name">Translator</dt>
                     <dd class="author-name" property="dc:creator">${this.collaborator}</dd>
                   `
                 : ''}

--- a/client/elements/addons/sc-top-sheet-publication-bilara.js
+++ b/client/elements/addons/sc-top-sheet-publication-bilara.js
@@ -229,7 +229,7 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
       this.rootTitle = data.root_title;
       this.rootLanguage = data.root_lang_name;
       this.authorName = data.author_name;
-      this.collaborator = data.collaborator;
+      this.collaborator = data.collaborator?.map(author => author.author_name)?.join();
       this.translationDescription = data.translation_description;
       this.translationProcess = data.translation_process;
       this.sourceURL = data.source_url;
@@ -277,9 +277,7 @@ class SCTopSheetPublicationBilara extends SCTopSheetCommon {
               ${this.collaborator
                 ? html`
                     <dt class="author-name">Collaborator</dt>
-                    <dd class="author-name" property="dc:creator">
-                      ${this.collaborator.map(author => html` ${author.author_name} , `)}
-                    </dd>
+                    <dd class="author-name" property="dc:creator">${this.collaborator}</dd>
                   `
                 : ''}
             </dl>

--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -578,6 +578,7 @@ class SCTopSheetViews extends LitLocalized(LitElement) {
         item.edition_set !== 'none' ? item : { ...item, checked: false }
       );
     }
+    this.requestUpdate();
     this.actions.setDisplayedReferences(
       this.references.filter(({ checked }) => checked).map(({ edition_set }) => edition_set)
     );

--- a/client/elements/text/sc-bilara-segmented-text.js
+++ b/client/elements/text/sc-bilara-segmented-text.js
@@ -770,6 +770,8 @@ class SCBilaraSegmentedText extends SCLitTextPage {
         className = 'pts';
       } else if (editionInfo?.uid?.length >= 3 && editionInfo?.uid?.substring(0, 3) === 'sya') {
         className = 'sya';
+      } else if (editionInfo?.uid?.length >= 3 && editionInfo?.uid?.substring(0, 3) === 'csp') {
+        className = 'csp';
       } else if (item.length >= 2 && item.substring(0, 2) === 'sc') {
         className = 'sc';
       } else {

--- a/client/elements/text/sc-bilara-segmented-text.js
+++ b/client/elements/text/sc-bilara-segmented-text.js
@@ -161,6 +161,11 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       } else {
         this._setScript();
       }
+      if (this.displayedReferences?.length > 0 && this.displayedReferences?.[0] !== 'none') {
+        this._deleteReference();
+        this._initReference();
+        this._addReferenceText();
+      }
       this._addVariantText();
       if (this.isPaliLookupEnabled && this.rootSutta.lang === 'pli') {
         this._paliLookupStateChanged();

--- a/client/elements/text/sc-bilara-segmented-text.js
+++ b/client/elements/text/sc-bilara-segmented-text.js
@@ -40,7 +40,6 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       bilaraTranslatedSutta: { type: Object },
       showParagraphs: { type: Boolean },
       paragraphs: { type: Array },
-      paragraphTitles: { type: Object },
       suttaId: { type: String },
       suttaReference: { type: Object },
       suttaComment: { type: Object },
@@ -162,11 +161,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       } else {
         this._setScript();
       }
-      this._initReference();
-      this._addReferenceText();
-      // this._addCommentText();
       this._addVariantText();
-      // this._addCommentSpanId();
       if (this.isPaliLookupEnabled && this.rootSutta.lang === 'pli') {
         this._paliLookupStateChanged();
       }
@@ -182,7 +177,6 @@ class SCBilaraSegmentedText extends SCLitTextPage {
     this._prepareNavigation();
 
     setTimeout(() => {
-      // this._recalculateCommentSpanHeight();
       this._changeTextView();
     }, 0);
     this.actions.changeSuttaMetaText('');
@@ -211,7 +205,9 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   _scrollToSection(sectionId, margin = 120) {
     if (!sectionId) return;
     try {
-      let targetElement = this.shadowRoot.querySelector(`#${CSS.escape(location.hash.substr(1))}`);
+      const targetElement = this.shadowRoot.querySelector(
+        `#${CSS.escape(location.hash.substr(1))}`
+      );
       if (targetElement) {
         targetElement.scrollIntoView();
         window.scrollTo(0, window.scrollY - margin);
@@ -222,24 +218,22 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   }
 
   _recalculateCommentSpanHeight() {
-    let gutterWidth = 5;
+    const gutterWidth = 5;
     this.commentSpanRectInfo.clear();
     const Comments = this.shadowRoot.querySelectorAll('.comment');
     Comments.forEach(element => {
-      let rect = element.getBoundingClientRect();
-      let elementNoId = element.id.slice(8); //id:comment_1 => get: 1
-      let nextComment = this.shadowRoot.querySelector(`#comment_${parseInt(elementNoId) + 1}`);
+      const rect = element.getBoundingClientRect();
+      const elementNoId = element.id.slice(8); // id:comment_1 => get: 1
+      const nextComment = this.shadowRoot.querySelector(`#comment_${parseInt(elementNoId) + 1}`);
       if (nextComment) {
-        let nextCommentTop = nextComment.getBoundingClientRect().top;
+        const nextCommentTop = nextComment.getBoundingClientRect().top;
         if (rect.top + rect.height > nextCommentTop) {
-          element.style.height = nextCommentTop - rect.top - gutterWidth + 'px';
+          element.style.height = `${nextCommentTop - rect.top - gutterWidth}px`;
           element.style.overflow = 'scroll';
         }
-      } else {
-        if (rect.top + rect.height > this.parentNode.clientHeight) {
-          element.style.height = this.parentNode.clientHeight - rect.top + 'px';
-          element.style.overflow = 'scroll';
-        }
+      } else if (rect.top + rect.height > this.parentNode.clientHeight) {
+        element.style.height = `${this.parentNode.clientHeight - rect.top}px`;
+        element.style.overflow = 'scroll';
       }
       this.commentSpanRectInfo.set(element.id, element.style.height);
     });
@@ -288,9 +282,6 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   }
 
   updated(changedProps) {
-    if (changedProps.has('showParagraphs')) {
-      //this._computeParagraphs();
-    }
     if (changedProps.has('chosenTextView')) {
       this._changeTextView();
     }
@@ -310,13 +301,6 @@ class SCBilaraSegmentedText extends SCLitTextPage {
         this._chineseLookupStateChanged();
       }
     }
-    if (changedProps.has('currentStyles')) {
-      if (this._isPlusStyle()) {
-        //this._recalculateCommentSpanHeight();
-      } else {
-        //this._resetCommentSpan();
-      }
-    }
     if (changedProps.has('markup')) {
       this._updateView();
     }
@@ -328,6 +312,15 @@ class SCBilaraSegmentedText extends SCLitTextPage {
     }
     if (changedProps.has('showHighlighting')) {
       this._showHighlightingChanged();
+    }
+    if (changedProps.has('displayedReferences')) {
+      if (this.displayedReferences?.length > 0 && this.displayedReferences?.[0] !== 'none') {
+        this._deleteReference();
+        this._initReference();
+        this._addReferenceText();
+      } else {
+        this._deleteReference();
+      }
     }
   }
 
@@ -472,7 +465,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   }
 
   _prepareNavigation() {
-    let sutta = this.bilaraTranslatedSutta ? this.bilaraTranslatedSutta : this.bilaraRootSutta;
+    const sutta = this.bilaraTranslatedSutta ? this.bilaraTranslatedSutta : this.bilaraRootSutta;
     if (!sutta) {
       this.actions.showToc([]);
       return;
@@ -499,7 +492,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
       changeSuttaMetaText(metaText) {
         store.dispatch({
           type: 'CHANGE_SUTTA_META_TEXT',
-          metaText: metaText,
+          metaText,
         });
       },
       changeSuttaPublicationInfo(publicationInfo) {
@@ -588,7 +581,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
 
   _deleteTranslatedSuttaMarkup() {
     this._articleElement().forEach(article => {
-      let translatedSuttaMarkup = article.querySelectorAll('.translation');
+      const translatedSuttaMarkup = article.querySelectorAll('.translation');
       if (translatedSuttaMarkup) {
         translatedSuttaMarkup.forEach(element => {
           element.parentNode.removeChild(element);
@@ -632,10 +625,10 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   }
 
   _addTranslationSuttaSpan() {
-    let spanElement = document.createElement('span');
+    const spanElement = document.createElement('span');
     spanElement.className = 'translation';
     spanElement.lang = this.translatedSutta.lang;
-    let textSpan = document.createElement('span');
+    const textSpan = document.createElement('span');
     textSpan.className = 'text';
     spanElement.appendChild(textSpan);
     return spanElement;
@@ -649,10 +642,18 @@ class SCBilaraSegmentedText extends SCLitTextPage {
     Object.keys(this.bilaraRootSutta).forEach(key => {
       const segmentElement = this.shadowRoot.querySelector(`#${CSS.escape(key)}`);
       if (segmentElement) {
-        let refSpan = this._addReferenceSpan();
+        const refSpan = this._addReferenceSpan();
         refSpan.appendChild(this._addDefaultReferenceAnchor(key));
         this._prependChild(segmentElement, refSpan);
       }
+    });
+  }
+
+  _deleteReference() {
+    this._articleElement().forEach(article => {
+      article.querySelectorAll('.reference').forEach(element => {
+        element.parentNode.removeChild(element);
+      });
     });
   }
 
@@ -666,13 +667,13 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   }
 
   _addDefaultReferenceAnchor(key) {
-    let subKey = key.substring(key.indexOf(':') + 1, key.length);
-    let anchor = document.createElement('a');
+    const subKey = key.substring(key.indexOf(':') + 1, key.length);
+    const anchor = document.createElement('a');
     anchor.className = 'sc';
     anchor.id = subKey;
     anchor.href = `#${subKey}`;
     anchor.title = this.localize('segmentNumber');
-    let text = document.createTextNode(subKey);
+    const text = document.createTextNode(subKey);
     anchor.appendChild(text);
     return anchor;
   }
@@ -690,11 +691,11 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   }
 
   _addCommentSpan(value) {
-    let span = document.createElement('span');
+    const span = document.createElement('span');
     span.className = 'comment';
     span.title = 'translator’s note';
     span.dataset.tooltip = value;
-    let text = document.createTextNode(value);
+    const text = document.createTextNode(value);
     span.appendChild(text);
     return span;
   }
@@ -712,28 +713,28 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   }
 
   _addVariantSpan(value) {
-    let variantText = `Variant: ${value}`;
-    let span = document.createElement('span');
+    const variantText = `Variant: ${value}`;
+    const span = document.createElement('span');
     span.className = 'variant';
     span.dataset.tooltip = variantText;
-    let text = document.createTextNode(variantText);
+    const text = document.createTextNode(variantText);
     span.appendChild(text);
     return span;
   }
 
   _addRootSuttaSpan() {
-    let spanElement = document.createElement('span');
+    const spanElement = document.createElement('span');
     spanElement.className = 'root';
     spanElement.lang = this.rootSutta.lang;
     spanElement.setAttribute('translate', 'no');
-    let textSpan = document.createElement('span');
+    const textSpan = document.createElement('span');
     textSpan.className = 'text';
     spanElement.appendChild(textSpan);
     return spanElement;
   }
 
   _addReferenceSpan() {
-    let spanElement = document.createElement('span');
+    const spanElement = document.createElement('span');
     spanElement.className = 'reference';
     return spanElement;
   }
@@ -751,7 +752,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   }
 
   _addReferenceAnchor(ref, refElement) {
-    let arrayRef = ref.replace(/\s*/g, '').split(','); //"pts1ed1.1, pts2ed1.1, sc1" or  "pts-cs1.1, pts-vp-pli1.1, sc1"
+    const arrayRef = ref.replace(/\s*/g, '').split(','); // "pts1ed1.1, pts2ed1.1, sc1" or  "pts-cs1.1, pts-vp-pli1.1, sc1"
     if (arrayRef.length === 0) return;
     arrayRef.forEach(item => {
       // 1:pts????, 2:pts-?????
@@ -760,7 +761,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
         (item.substring(0, 3).toLowerCase() === 'pts' ||
           item.substring(0, 4).toLowerCase() === 'pts-')
       ) {
-        let anchor = document.createElement('a');
+        const anchor = document.createElement('a');
         anchor.className = 'pts';
         anchor.title = this.localize('paliTextSocietyPageNo');
 
@@ -778,11 +779,11 @@ class SCBilaraSegmentedText extends SCLitTextPage {
     });
   }
 
-  //<a class="pts" id="2ed1.1" title="Pali Text Society vol/page number." href="#2ed1.1">2ed1.1</a>
+  // <a class="pts" id="2ed1.1" title="Pali Text Society vol/page number." href="#2ed1.1">2ed1.1</a>
   _initPtsReferenceAnchor(anchor, refStr) {
     anchor.id = refStr;
     anchor.href = `#${refStr}`;
-    let text = document.createTextNode(refStr);
+    const text = document.createTextNode(refStr);
     anchor.appendChild(text);
   }
 
@@ -836,7 +837,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
 
   _putSegmentIntoSpans(segment, unit) {
     const text = segment.innerHTML;
-    let div = document.createElement('div');
+    const div = document.createElement('div');
     div.innerHTML = text;
     this._recurseDomChildren(div, true, unit);
     segment.innerHTML = div.innerHTML
@@ -893,7 +894,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   }
 
   _addPaliLookupEvent(selector) {
-    const lookup = this.shadowRoot.querySelector(`#pali_lookup`);
+    const lookup = this.shadowRoot.querySelector('#pali_lookup');
     const allWordSpans = this.shadowRoot.querySelectorAll(selector);
     const spans = Array.from(allWordSpans);
     spans.forEach(word => {
@@ -910,7 +911,7 @@ class SCBilaraSegmentedText extends SCLitTextPage {
   }
 
   _addChineseLookupEvent(selector) {
-    const lookup = this.shadowRoot.querySelector(`#chinese_lookup`);
+    const lookup = this.shadowRoot.querySelector('#chinese_lookup');
     const allWordSpans = this.shadowRoot.querySelectorAll(selector);
     const spans = Array.from(allWordSpans);
     spans.forEach(word => {

--- a/server/server/api/views/__init__.py
+++ b/server/server/api/views/__init__.py
@@ -31,4 +31,6 @@ from .views import (
     SuttaFullPath,
     PaliReferenceEdition,
     PublicationInfo,
+    AvailableVoices,
+    RootEdition,
 )

--- a/server/server/api/views/views.py
+++ b/server/server/api/views/views.py
@@ -36,6 +36,7 @@ from common.queries import (
     SUTTA_PATH,
     SUTTA_PALI_REFERENCE,
     SUTTA_PUBLICATION_INFO,
+    AVAILABLE_VOICES,
 )
 
 from common.utils import (
@@ -1025,7 +1026,6 @@ class SuttaFullPath(Resource):
 
 
 class PaliReferenceEdition(Resource):
-
     @cache.cached(key_prefix=make_cache_key, timeout=default_cache_timeout)
     def get(self):
         db = get_db()
@@ -1036,7 +1036,6 @@ class PaliReferenceEdition(Resource):
 
 
 class PublicationInfo(Resource):
-
     @cache.cached(key_prefix=make_cache_key, timeout=default_cache_timeout)
     def get(self, uid, lang):
         db = get_db()
@@ -1045,3 +1044,18 @@ class PublicationInfo(Resource):
             return {'error': 'Not Found'}, 404
         return publication_info
 
+class AvailableVoices(Resource):
+    @cache.cached(key_prefix=make_cache_key, timeout=default_cache_timeout)
+    def get(self, uid):
+        db = get_db()
+        data = list(db.aql.execute(AVAILABLE_VOICES, bind_vars={'uid': uid}))
+        if not data:
+            return {'error': 'Not Found'}, 404
+        return data, 200
+
+class RootEdition(Resource):
+    @cache.cached(key_prefix=make_cache_key, timeout=default_cache_timeout)
+    def get(self):
+        db = get_db()
+        data = db.collection('root_edition').all()
+        return list(data), 200

--- a/server/server/app.py
+++ b/server/server/app.py
@@ -39,6 +39,8 @@ from api.views import (
     SuttaFullPath,
     PaliReferenceEdition,
     PublicationInfo,
+    AvailableVoices,
+    RootEdition,
 )
 from common.arangodb import ArangoDB
 from common.extensions import cache
@@ -99,6 +101,8 @@ def app_factory() -> Tuple[Api, Flask]:
     api.add_resource(SuttaFullPath, '/suttafullpath/<string:uid>')
     api.add_resource(PaliReferenceEdition, '/pali_reference_edition')
     api.add_resource(PublicationInfo, '/publication_info/<string:uid>/<string:lang>')
+    api.add_resource(AvailableVoices, '/available_voices/<string:uid>')
+    api.add_resource(RootEdition, '/root_edition')
     app.register_blueprint(api_bp)
     register_extensions(app)
 

--- a/server/server/common/queries.py
+++ b/server/server/common/queries.py
@@ -1121,3 +1121,12 @@ FOR d IN publications
     FILTER (d.text_uid IN path_docs OR d.text_uid == @uid) AND d.translation_lang_iso == @lang
     RETURN d
 '''
+
+AVAILABLE_VOICES = '''
+FOR v IN available_voices
+    FILTER v.uid == @uid
+    RETURN {
+        uid: v.uid,
+        voices: v.voices
+    }
+'''

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -262,6 +262,16 @@ def load_author_edition(change_tracker, additional_info_dir, db):
             authors = json.load(authorf)
         db['author_edition'].import_bulk_logged(authors, wipe=True)
 
+def load_available_voices(change_tracker, additional_info_dir, db):
+    voices_file = additional_info_dir / 'available_voices.json'
+    voices_info = json_load(voices_file)
+
+    docs = []
+    for key, value in voices_info.items():
+        docs.append({'uid': key, 'voices': value})
+
+    db['available_voices'].truncate()
+    db.collection('available_voices').import_bulk_logged(docs, wipe=True)
 
 def load_html_texts(change_tracker, data_dir, db, html_dir):
     print('Loading HTML texts')
@@ -329,6 +339,9 @@ def load_pali_reference_edition_file(db: Database, pali_reference_edition_file: 
     pali_reference_content = json_load(pali_reference_edition_file)
     db.collection('pali_reference_edition').import_bulk(pali_reference_content)
 
+def load_root_edition_file(db: Database, root_edition_file: Path):
+    root_edition_content = json_load(root_edition_file)
+    db.collection('root_edition').import_bulk(root_edition_content)
 
 def run(no_pull=False):
     """Runs data load.
@@ -380,11 +393,17 @@ def run(no_pull=False):
     print_stage("Loading author_edition.json")
     load_author_edition(change_tracker, additional_info_dir, db)
 
+    print_stage("Loading available_voices.json")
+    load_available_voices(change_tracker, additional_info_dir, db)
+
     print_stage('Loading guides.json')
     load_guides_file(db, structure_dir / 'guides.json')
 
     print_stage('Loading pali_reference_edition.json')
     load_pali_reference_edition_file(db, misc_dir / 'pali_reference_edition.json')
+
+    print_stage('Loading root_edition.json')
+    load_root_edition_file(db, misc_dir / 'root_edition.json')
 
     print_stage("Loading languages")
     languages.load_languages(db, languages_file, localized_elements_dir)

--- a/server/server/migrations/migrations/add_available_voices_036.py
+++ b/server/server/migrations/migrations/add_available_voices_036.py
@@ -1,0 +1,11 @@
+from common.arangodb import get_db
+from migrations.base import Migration
+
+
+class SecondMigration(Migration):
+    migration_id = 'add_available_voices_036'
+    tasks = ['create_collections']
+
+    def create_collections(self):
+        db = get_db()
+        db.create_collection('available_voices', edge=False)

--- a/server/server/migrations/migrations/add_root_edition_037.py
+++ b/server/server/migrations/migrations/add_root_edition_037.py
@@ -1,0 +1,11 @@
+from common.arangodb import get_db
+from migrations.base import Migration
+
+
+class SecondMigration(Migration):
+    migration_id = 'add_root_edition_037'
+    tasks = ['create_collections']
+
+    def create_collections(self):
+        db = get_db()
+        db.create_collection('root_edition', edge=False)


### PR DESCRIPTION
1. No references are loaded by default.
2. References are loaded on user request via the "Reference" options in the top sheet.
3. Users may select as many sets of references as they wish.
4. User selections are persistent until the user changes it.
5. Load the `root_edition.json` to ArangoDB
6. Add API `API/root_edition`
7. Load the `available_voices` to ArangoDB
8. Add API `API/available_voices`