### PR TITLE
Use Bilara author metadata for segmented texts.

### DIFF
--- a/server/server/common/queries.py
+++ b/server/server/common/queries.py
@@ -51,7 +51,7 @@ FOR text IN sc_bilara_texts
     )[0]
 
     LET author_doc = (
-        FOR author IN author_edition
+        FOR author IN bilara_author_edition
             FILTER author.uid IN text.muids
             LIMIT 1
             RETURN author
@@ -342,7 +342,7 @@ FOR v, e, p IN 0..6 OUTBOUND CONCAT('super_nav_details/', @uid) super_nav_detail
                 volpage: text.volpage
                 }
             // Add title if it is in desired language
-            RETURN (text.lang == @language) ? MERGE(res, {title: text.name}) : res 
+            RETURN (text.lang == @language) ? MERGE(res, {title: text.name}) : res
         )
 
     LET bilara_translations = (
@@ -351,9 +351,9 @@ FOR v, e, p IN 0..6 OUTBOUND CONCAT('super_nav_details/', @uid) super_nav_detail
             SORT text.lang
             LET lang_doc = DOCUMENT('language', text.lang)
             LET author_doc = (
-                FOR author IN author_edition 
+                FOR author IN bilara_author_edition
                     FILTER author.uid IN text.muids
-                    LIMIT 1 
+                    LIMIT 1
                     RETURN author
             )[0]
             LET name_doc = (
@@ -504,7 +504,7 @@ FOR v, e, p IN OUTBOUND CONCAT('super_nav_details/', @uid) relationship
             FILTER text.uid == target.uid AND 'root' IN text.muids
 
             LET author_doc = (
-                FOR author IN author_edition
+                FOR author IN bilara_author_edition
                     FILTER author.uid IN text.muids
                     LIMIT 1
                     RETURN author
@@ -612,7 +612,7 @@ SUTTA_VIEW = (
             FILTER doc.uid == @uid AND 'root' IN doc.muids
             LIMIT 1
             LET author_doc = (
-                FOR author IN author_edition
+                FOR author IN bilara_author_edition
                     FILTER author.uid IN doc.muids
                     LIMIT 1
                     RETURN author
@@ -651,7 +651,7 @@ SUTTA_VIEW = (
             FILTER doc.uid == @uid AND doc.lang == @language AND @author_uid IN doc.muids
             LIMIT 1
             LET author_doc = (
-                FOR author IN author_edition
+                FOR author IN bilara_author_edition
                     FILTER author.uid IN doc.muids
                     LIMIT 1
                     RETURN author

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -436,6 +436,9 @@ def run(no_pull=False):
     print_stage('Load texts from sc_bilara_data')
     sc_bilara_data.load_texts(db, sc_bilara_data_dir)
 
+    print_stage('Load bilara_author_edition from sc_bilara_data')
+    sc_bilara_data.load_bilara_author_edition(db, sc_bilara_data_dir)
+
     print_stage("Generating and loading relationships")
     generate_relationship_edges(
         change_tracker, relationship_dir, additional_info_dir, db

--- a/server/server/data_loader/sc_bilara_data.py
+++ b/server/server/data_loader/sc_bilara_data.py
@@ -117,3 +117,42 @@ def load_texts(db: Database, sc_bilara_data_dir: Path) -> None:
     print(f'{len(res)} texts added or updated')
     db['sc_bilara_texts'].truncate()
     db['sc_bilara_texts'].import_bulk(res)
+
+
+def load_bilara_author_edition(db: Database, sc_bilara_data_dir: Path) -> None:
+    db['bilara_author_edition'].truncate()
+    docs = load_bilara_author(db, sc_bilara_data_dir) + \
+        load_bilara_edition(db, sc_bilara_data_dir)
+    db.collection('bilara_author_edition').import_bulk_logged(docs, wipe=True)
+
+
+def load_bilara_author(db: Database, sc_bilara_data_dir: Path) -> None:
+    author_file = sc_bilara_data_dir / '_author.json'
+    authors: Dict[str, dict] = json_load(author_file)
+
+    docs = []
+    for key, value in authors.items():
+        docs.append({
+            'type': 'author',
+            'uid': key,
+            'short_name': key,
+            'long_name': value['name']
+        })
+
+    return docs
+
+
+def load_bilara_edition(db: Database, sc_bilara_data_dir: Path) -> None:
+    edition_file = sc_bilara_data_dir / '_edition.json'
+    editions: Dict[str, dict] = json_load(edition_file)
+
+    docs = []
+    for key, value in editions.items():
+        docs.append({
+            'type': 'edition',
+            'uid': key,
+            'language': value['language'],
+            'is_root': value['is_root']
+        })
+
+    return docs

--- a/server/server/migrations/migrations/add_bilara_author_edition_039.py
+++ b/server/server/migrations/migrations/add_bilara_author_edition_039.py
@@ -1,0 +1,11 @@
+from common.arangodb import get_db
+from migrations.base import Migration
+
+
+class SecondMigration(Migration):
+    migration_id = 'add_bilara_author_edition_039'
+    tasks = ['create_collections']
+
+    def create_collections(self):
+        db = get_db()
+        db.create_collection('bilara_author_edition', edge=False)


### PR DESCRIPTION
The impact of this update is as follows:
1. Author info of the Suttaplex.
2. Author info of the Parallels.
3. Author info of the Sutta (segmented text).

The modification must ensure that the author information in the above list is consistent with the previous information.