### PR TITLE
Fix: Search returns stale results.

### DIFF
--- a/client/webpack.common.js
+++ b/client/webpack.common.js
@@ -39,6 +39,10 @@ module.exports = {
           handler: 'NetworkFirst',
         },
         {
+          urlPattern: new RegExp('/search'),
+          handler: 'NetworkFirst',
+        },
+        {
           urlPattern: new RegExp('/(?:img|files)/(.*)'),
           handler: 'CacheFirst',
           options: {


### PR DESCRIPTION
At present, cookies are not used in search results. One possibility is that service-worker caches the search results. I have modified the relevant configuration to see if the problem is solved.