### PR TITLE
Fix: Transliteration:  Many of the script labels are gibberish #2115

### DIFF
--- a/client/elements/addons/sc-aksharamukha-converter.js
+++ b/client/elements/addons/sc-aksharamukha-converter.js
@@ -55,69 +55,90 @@ export const paliScriptsStyles = css`
     font-family: 'Mukta Malar Regular' !important;
     font-feature-settings: 'ss04', 'kern';
   }
+
   .tamil-script {
     font-family: 'Noto Sans Tamil' !important;
   }
+
   .tibetandbumed-script {
     font-family: 'Tibetan Dbu Med' !important;
     line-height: 2.3em;
   }
+
   .tibetan-script {
     font-family: 'Noto Sans Tibetan' !important;
     font-size: 110%;
   }
+
   .buhid-script {
     font-family: 'Noto Sans Buhid' !important;
   }
+
   .rejang-script {
     font-family: 'Noto Sans Rejang' !important;
   }
+
   .hanunoo-script {
     font-family: 'Noto Sans Hanunoo' !important;
   }
+
   .saurashtra-script {
     font-family: 'Noto Sans Saurashtra' !important;
   }
+
   .sorasompeng-script {
     font-family: 'Noto Sans SoraSompeng' !important;
   }
+
   .khamtishan-script {
     font-family: 'Khamti Regular' !important;
   }
+
   .warangciti-script {
     font-family: 'Noto Sans WarangCiti' !important;
   }
+
   .balinese-script {
     font-family: 'Noto Serif Bali' !important;
   }
+
   .kannada-script {
     font-family: 'Noto Sans Kannada' !important;
   }
+
   .javanese-script {
     font-family: 'Noto Sans Javanese', 'Javanese Text' !important;
   }
+
   .avestan-script {
     font-family: 'Noto Sans Avestan' !important;
     direction: rtl;
   }
+
   .buginese-script {
     font-family: 'Noto Sans Buginese' !important;
   }
+
   .sinhala-script {
     font-family: 'Noto Sans Sinhala' !important;
   }
+
   .dogra-script {
     font-family: 'Noto Serif Dogra' !important;
   }
+
   .tagalog-script {
     font-family: 'Noto Sans Tagalog' !important;
   }
+
   .tagbanwa-script {
     font-family: 'Noto Sans Tagbanwa' !important;
   }
+
   .sundanese-script {
     font-family: 'Noto Sans Sundanese' !important;
   }
+
   .cham-script {
     font-family: 'Noto Sans Cham' !important;
   }
@@ -138,241 +159,311 @@ export const paliScriptsStyles = css`
   .malayalam-script {
     font-family: 'Noto Sans Malayalam' !important;
   }
+
   .malayalamold-script {
     font-family: 'Meera' !important;
     font-size: 130%;
     line-height: 125%;
   }
+
   .chakma-script {
     font-family: 'Noto Sans ChakmaPali' !important;
   }
+
   .lepcha-script {
     font-family: 'Noto Sans Lepcha' !important;
   }
+
   .limbu-script {
     font-family: 'Noto Sans Limbu' !important;
   }
+
   .batakkaro-script {
     font-family: 'Noto Sans Batak' !important;
   }
+
   .batakmanda-script {
     font-family: 'Noto Sans Batak' !important;
   }
+
   .batakpakpak-script {
     font-family: 'Noto Sans Batak' !important;
   }
+
   .bataksima-script {
     font-family: 'Noto Sans Batak' !important;
   }
+
   .bataktoba-script {
     font-family: 'Noto Sans Batak' !important;
   }
+
   .telugu-script {
     font-family: 'Noto Sans Telugu' !important;
   }
+
   .teluguzha-script {
     font-family: 'Aazhvaar Telugu' !important;
   }
+
   .khmer-script {
     font-family: 'Noto Sans Khmer' !important;
   }
+
   .meeteimayek-script {
     font-family: 'Noto Sans Meetei Mayek' !important;
   }
+
   .tolongsiki-script {
     font-family: 'kellytolong' !important;
   }
+
   .tamilbrahmi-script {
     font-family: 'Adinatha Tamil Brahmi' !important;
   }
+
   .phagspa-script {
     font-family: 'Microsoft PhagsPa', 'Noto Sans PhagsPa' !important;
     writing-mode: vertical-lr;
     line-height: 1.8em;
   }
+
   .urdu-script {
     font-family: 'Noto Sans Nastaliq Urdu' !important;
     direction: rtl;
   }
+
   .kaithi-script {
     font-family: 'Noto Sans Kaithi' !important;
   }
+
   .gujarati-script {
     font-family: 'Noto Serif Gujarati' !important;
   }
+
   .modi-script {
     font-family: 'Noto Sans Modi' !important;
   }
+
   .devanagari-script {
     font-family: 'Noto Sans Devanagari' !important;
   }
+
   .multani-script {
     font-family: 'Noto Sans Multani' !important;
   }
+
   .hanifirohingya-script {
     font-family: 'Noto Sans HanifiRohingya' !important;
     direction: rtl;
   }
+
   .ahom-script {
     font-family: 'Noto Serif Ahom' !important;
   }
+
   .tirhuta-script {
     font-family: 'MithilaUni' !important;
   }
+
   .oldpersian-script {
     font-family: 'Noto Sans OldPersian' !important;
   }
+
   .takri-script {
     font-family: 'Noto Sans Takri' !important;
   }
+
   .taitham-script {
     font-family: 'PaliTilok' !important;
     font-size: 150%;
   }
+
   .khomthai-script {
     font-family: 'Patimokkha' !important;
     font-size: 150%;
   }
+
   .taithamlao-script {
     font-family: 'Lamphun' !important;
     font-size: 150%;
   }
+
   .laotham-script {
     font-family: 'Lamphun' !important;
     font-size: 150%;
   }
+
   .sylotinagri-script {
     font-family: 'Noto Sans SylotiNagri' !important;
   }
+
   .granthagrantamil-script {
     font-family: 'e-Grantamil' !important;
     font-size: 110%;
     line-height: 1.5em;
   }
+
   .tamilgrantha-script {
     font-family: 'e-Grantamil' !important;
     font-size: 110%;
     line-height: 1.5em;
   }
+
   .tamilextended-script {
     font-family: 'Agastya Extended Tamil' !important;
     line-height: 1.6em;
   }
+
   .tamilextendedserif-script {
     font-family: 'Agastya Serif' !important;
     line-height: 1.6em;
   }
+
   .siddhammukta-script {
     font-size: 120%;
     font-family: Muktamsiddham;
   }
+
   .siddham-script {
     font-family: 'Noto Sans Siddham' !important;
   }
+
   .grantha-script {
     font-family: 'Noto Sans Grantha2' !important;
     line-height: 2em;
     font-feature-settings: 'ss04', 'ss06';
   }
+
   .granthaserif-script {
     font-family: 'Noto Serif Grantha' !important;
     font-feature-settings: 'ss04', 'ss06';
     line-height: 2em;
   }
+
   .granthalig-script {
     font-family: 'Noto Sans Grantha2' !important;
     font-feature-settings: 'ss04', 'ss06', 'ss03';
     line-height: 2em;
   }
+
   .granthaseriflig-script {
     font-family: 'Noto Serif Grantha' !important;
     font-feature-settings: 'ss04', 'ss06', 'ss03';
     line-height: 2em;
   }
+
   .kharoshthi-script {
     font-family: 'Segoe UI Historic', 'Noto Sans Kharoshthi' !important;
     direction: rtl;
   }
+
   .thaana-script {
     direction: rtl;
   }
+
   .zanabazarsquare-script {
     font-family: 'Noto Sans Zanabazar Square' !important;
     font-feature-settings: 'ss01';
     line-height: 3em;
   }
+
   .newa-script {
     font-family: 'Noto Sans Newa' !important;
   }
+
   .sharada-script {
     font-family: 'Noto Sans Sharada' !important;
   }
+
   .thainative-script {
     font-family: 'Kaccayana Thai' !important;
   }
+
   .mahajani-script {
     font-family: 'Noto Sans Mahajani' !important;
   }
+
   .multani-script {
     font-family: 'Noto Sans Multani' !important;
   }
+
   .bhaiksuki-script {
     font-family: 'Noto Sans Bhaiksuki' !important;
   }
+
   .khojki-script {
     font-family: 'Noto Sans Khojki' !important;
   }
+
   .khudawadi-script {
     font-family: 'Noto Sans Khudawadi' !important;
   }
+
   .granthapandya-script {
     font-family: 'e-Pandya' !important;
   }
+
   .vatteluttu-script {
     font-family: 'e-Vatteluttu' !important;
   }
+
   .brahmi-script {
     font-family: 'Segoe UI Historic', 'Noto Sans Brahmi' !important;
   }
+
   .siddhamap-script {
     font-family: 'ApDevaSiddham' !important;
   }
+
   .limbudeva-script {
     font-family: 'AnnaPurna' !important;
   }
+
   .laopali-script {
     font-family: 'Serif Lao Reg' !important;
   }
+
   .nepaldevafont-script {
     font-family: 'Nepal2' !important;
   }
+
   .santali-script {
     font-family: 'Noto Sans Ol Chiki' !important;
   }
+
   .ranjana-script {
     font-family: 'RanjanaUnicode' !important;
   }
+
   .ranjanalantsa-script {
     font-family: 'JMYZK--LZT Lantsa' !important;
   }
+
   .ranjanawartu-script {
     font-family: 'JMYZK--WDT Wartu' !important;
   }
+
   .taikuen-script {
     font-family: 'A Tai Tham KH New' !important;
   }
+
   .khuentham-script {
     font-family: 'A Tai Tham KH New' !important;
   }
+
   .luetham-script {
     font-family: 'Pali TaiLue' !important;
   }
+
   .wancho-script {
     font-family: 'Noto Sans Wancho' !important;
   }
+
   .mro-script {
     font-family: 'Noto Sans Mro' !important;
   }
+
   .marchen-script {
     font-family: 'Noto Sans Marchen' !important;
     line-height: 2.5em;

--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -508,7 +508,7 @@ class SCTopSheetViews extends LitLocalized(LitElement) {
                       class="${script.script.toLowerCase()}-script"
                       title="${script.script}"
                     >
-                      ${script.language}
+                      ${script.script === 'latin' ? '' : `${script.script}-`}${script.language}
                     </option>
                   `
                 )}


### PR DESCRIPTION
On @virtualvinodh's advice, the appropriate English label was kept in the language list.

![深度截图_选择区域_20210525001649](https://user-images.githubusercontent.com/4037966/119434139-24596500-bd4a-11eb-9911-affa7a0eb874.png)
