### PR TITLE
Add instant search API endpoint

### DIFF
--- a/server/server/app.py
+++ b/server/server/app.py
@@ -47,7 +47,7 @@ from api.views import (
 from common.arangodb import ArangoDB
 from common.extensions import cache
 from config import app_config, swagger_config, swagger_template
-from search.view import Search
+from search.view import Search, InstantSearch
 
 
 def app_factory() -> Tuple[Api, Flask]:
@@ -67,6 +67,7 @@ def app_factory() -> Tuple[Api, Flask]:
     api.add_resource(TranslationCountByDivision, '/translation_count/<string:iso_code>')
     api.add_resource(TranslationCountByLanguage, '/translation_count')
     api.add_resource(Search, '/search')
+    api.add_resource(InstantSearch, '/search/instant')
     api.add_resource(DictionaryFull, '/dictionary_full/<string:word>')
     api.add_resource(Menu, '/menu', '/menu/<path:submenu_id>')
     api.add_resource(SuttaplexList, '/suttaplex/<path:uid>')

--- a/server/server/migrations/migrations/add_instant_search_041.py
+++ b/server/server/migrations/migrations/add_instant_search_041.py
@@ -1,0 +1,83 @@
+from common.arangodb import get_db
+from migrations.base import Migration
+
+class SecondMigration(Migration):
+    migration_id = 'add_instant_search_041'
+    tasks = ['create_analyzers', 'create_view']
+
+    def create_analyzers(self):
+        db = get_db()
+
+        db.create_analyzer(
+            "normalize",
+            "norm",
+            {
+                "locale": "en.utf-8",
+                "case": "lower",
+                "accent": False,
+                "stemming": False,
+            },
+            ["frequency", "norm", "position"],
+        )
+
+        db.create_analyzer(
+            "common_text",
+            "text",
+            {
+                "locale": "en.utf8-",
+                "case": "lower",
+                "accent": False,
+                "stemming": False,   
+                "stopwords": []
+            },
+            ["frequency", "norm", "position"]
+        )
+
+        db.create_analyzer(
+            "common_ngram",
+            "ngram",
+            {
+                "min": 4, 
+                "max": 4,
+                "preserveOriginal": True,
+                "streamType": "utf8"
+            },
+            ["frequency", "norm", "position"],
+        )
+
+        db.create_analyzer(
+            "cjk_ngram",
+            "ngram",
+            {
+                "min": 1, 
+                "max": 5, 
+                "preserveOriginal": True,
+                "streamType": "utf8"
+            },
+            ["frequency", "norm", "position"],
+        )
+
+        db.create_analyzer("splitter", "delimiter", {"delimiter": "-"})
+    
+    def create_view(self):
+        common_fields = {
+            "fields": {
+                "uid": {
+                    "analyzers": ["identity"]
+                },
+                "lang": {
+                    "analyzers": ["identity"]
+                },
+                "name": {
+                    "analyzers": ["normalize", "common_ngram", "common_text"]
+                }                
+            }
+        }
+        view = {
+            "links": {
+                "names": common_fields,
+                "super_nav_details": common_fields
+            }
+        }
+
+        get_db().create_arangosearch_view("instant_search", view)

--- a/server/server/search/instant_search.py
+++ b/server/server/search/instant_search.py
@@ -1,0 +1,58 @@
+from common.arangodb import get_db
+
+
+INSTANT_SEARCH_QUERY = '''
+FOR doc IN instant_search
+  SEARCH PHRASE(doc.name, @query, "common_text")
+  OR ANALYZER(STARTS_WITH(doc.name, @query), "normalize")
+  OR NGRAM_MATCH(
+        doc.name, 
+        @query, 
+        0.4, 
+        'common_ngram'
+    )
+  FILTER doc.root_lang OR @lang == NULL or doc.lang == @lang
+  LET uid = doc.uid
+  LET nav_doc = DOCUMENT('super_nav_details', doc.uid)
+  LET lang_uid = doc.lang ? doc.lang : doc.root_lang
+  FILTER nav_doc.type == 'leaf'
+  
+  COLLECT name = doc.name, lang = lang_uid INTO group KEEP uid
+  
+  LET score_division_boost_factor = {
+    dn: 1.2,
+    mn: 1.2,
+    sn: 1.2,
+    an: 1.15
+  }
+  
+  LET score_map = (
+    FOR uid IN group[*].uid
+        LET div_uid = REGEX_REPLACE(uid, '[0-9.-]', '')
+        LET subscore = MAX([1, score_division_boost_factor[div_uid]])
+        SORT subscore DESC
+        RETURN {uid, subscore}
+  )
+  
+  LET norm_name = FIRST(TOKENS(name, "normalize"))
+  LET norm_query = FIRST(TOKENS(@query, "normalize"))
+  LET contains_score = CONTAINS(norm_name, norm_query) ? 1 : 0
+  LET nps_score = NGRAM_POSITIONAL_SIMILARITY(name, @query, 3)
+  LET starts_score = (STARTS_WITH(norm_name, norm_query) ? 2 : 0.5) * (STARTS_WITH(name, @query) ? 1 : 0.5)
+  
+  LET score = (starts_score + contains_score + nps_score) * MAX(score_map[*].subscore)
+  
+  SORT score DESC
+  LIMIT 10
+  RETURN {
+    name: name,
+    lang: lang,
+    uid: FIRST(score_map).uid
+  } 
+    
+'''
+
+    
+def instant_search_query(query, lang):
+    cursor = get_db().aql.execute(INSTANT_SEARCH_QUERY, bind_vars={'query': query, 'lang': lang})
+    return list(cursor)

--- a/server/server/search/view.py
+++ b/server/server/search/view.py
@@ -9,7 +9,17 @@ from common.extensions import cache, make_cache_key
 from common.queries import SUTTAPLEX_LIST
 from search import dictionaries
 from search import query as query_search
+from search.instant_search import instant_search_query
 
+
+class InstantSearch(Resource):
+  def get(self):
+    """
+    Search for the given query in arangodb, very fast
+    """
+    query = request.args.get('query')
+    lang = request.args.get('lang')
+    return instant_search_query(query, lang)
 
 class Search(Resource):
     @cache.cached(timeout=600, key_prefix=make_cache_key)


### PR DESCRIPTION
Adds endpoint for instance search, i.e.

`/search/instant?query=roar&lang=en`

Do `make migrate` to create the views.