### PR TITLE
Tuning: Populate volpage and alt_volpage in text_extra_info.json from bilara-data/reference #2152

### DIFF
--- a/client/elements/suttaplex/card/sc-parallel-item.js
+++ b/client/elements/suttaplex/card/sc-parallel-item.js
@@ -1,3 +1,4 @@
+/* eslint-disable indent */
 import { html, LitElement } from 'lit-element';
 import { icon } from '../../../img/sc-icon';
 import {
@@ -5,6 +6,7 @@ import {
   transformId,
   pickVolPage,
   hasTwoPTSEditions,
+  formatVolPages,
 } from '../../../utils/suttaplex';
 import { LitLocalized } from '../../addons/sc-localization-mixin';
 import { parallelItemCss } from './sc-suttaplex-css';
@@ -117,10 +119,49 @@ class SCParallelItem extends LitLocalized(LitElement) {
     return pickVolPage(this.parallelItem.volpages);
   }
 
+  get briefVolPage() {
+    const volpages = this.parallelItem.volpages.split(',');
+    if (this.parallelItem.volpages && volpages.length > 1) {
+      const volPagesEnd = formatVolPages(volpages[volpages.length - 1]);
+      return `${volpages[0]} –${volPagesEnd}`;
+    }
+    return this.parallelItem.volpages;
+  }
+
+  get altVolPage() {
+    return pickVolPage(this.parallelItem.alt_volpages);
+  }
+
+  get briefAltVolPage() {
+    const volpages = this.parallelItem.alt_volpages.split(',');
+    if (this.parallelItem.alt_volpages && volpages.length > 1) {
+      const volPagesEnd = formatVolPages(volpages[volpages.length - 1]);
+      return `${volpages[0]} –${volPagesEnd}`;
+    }
+    return this.parallelItem.alt_volpages;
+  }
+
   get volPageTitle() {
     return hasTwoPTSEditions(this.parallelItem.volpages)
       ? this.localize('volumeAndPagePTS1', this.parallelItem.volpages)
       : this.localize('volumeAndPage');
+  }
+
+  get volPageTemplate() {
+    return html`
+      <span class="volPage-row" title="${this.localize('volumeAndPage')}">
+        <span class="book">${icon.book}</span>
+        <span class="vol-page"> ${this.briefVolPage} </span>
+      </span>
+      ${this.altVolPage && this.altVolPage !== this.volPage
+        ? html`
+            <span class="volPage-row" title="${this.localize('volumeAndPage')}">
+              <span class="book">${icon.book}</span>
+              <span class="vol-page"> ${this.briefAltVolPage} </span>
+            </span>
+          `
+        : ''}
+    `;
   }
 
   render() {
@@ -158,31 +199,14 @@ class SCParallelItem extends LitLocalized(LitElement) {
                       ${this.parallelItem.biblio &&
                       html`
                         <details>
-                          <summary>
-                            ${icon.book}
-                            <span class="vol-page" title="${this.volPageTitle}">
-                              ${this.volPage}
-                            </span>
-                          </summary>
+                          <summary>${this.volPageTemplate}</summary>
                           <p
                             class="parallel-item-biblio-info"
                             .innerHTML="${this.parallelItem.biblio}"
                           ></p>
                         </details>
                       `}
-                      ${!this.parallelItem.biblio
-                        ? html`
-                            <span
-                              class="book scrollable-dialog"
-                              title="${this.localize('volumeAndPage')}"
-                            >
-                              ${icon.book}
-                            </span>
-                            <span class="vol-page" title="${this.volPageTitle}">
-                              ${this.volPage}
-                            </span>
-                          `
-                        : ''}
+                      ${!this.parallelItem.biblio ? this.volPageTemplate : ''}
                     </div>
                   `
                 : ''}

--- a/client/elements/suttaplex/card/sc-suttaplex-css.js
+++ b/client/elements/suttaplex/card/sc-suttaplex-css.js
@@ -494,5 +494,13 @@ export const parallelItemCss = html`
       width: 16px;
       height: 16px;
     }
+
+    .volPage-row {
+      display: contents;
+    }
+
+    .vol-page {
+      margin-right: 1rem;
+    }
   </style>
 `;

--- a/client/elements/suttaplex/card/sc-suttaplex.js
+++ b/client/elements/suttaplex/card/sc-suttaplex.js
@@ -2,7 +2,12 @@
 import { html, css, LitElement, svg } from 'lit-element';
 import { API_ROOT, SUTTACENTRAL_VOICE_URL } from '../../../constants';
 import { icon } from '../../../img/sc-icon';
-import { transformId, pickVolPage, hasTwoPTSEditions } from '../../../utils/suttaplex';
+import {
+  transformId,
+  pickVolPage,
+  hasTwoPTSEditions,
+  formatVolPages,
+} from '../../../utils/suttaplex';
 import { LitLocalized } from '../../addons/sc-localization-mixin';
 import '../../menus/sc-menu-suttaplex-share';
 import './sc-parallel-list';
@@ -126,7 +131,8 @@ class SCSuttaplex extends LitLocalized(LitElement) {
   get briefVolPage() {
     const volpages = this.item.volpages.split(',');
     if (this.item.volpages && volpages.length > 1) {
-      return `${volpages[0]} –${volpages[volpages.length - 1]}`;
+      const volPagesEnd = formatVolPages(volpages[volpages.length - 1]);
+      return `${volpages[0]} –${volPagesEnd}`;
     }
     return this.item.volpages;
   }
@@ -141,7 +147,8 @@ class SCSuttaplex extends LitLocalized(LitElement) {
   get briefAltVolPage() {
     const volpages = this.item.alt_volpages.split(',');
     if (this.item.alt_volpages && volpages.length > 1) {
-      return `${volpages[0]} –${volpages[volpages.length - 1]}`;
+      const volPagesEnd = formatVolPages(volpages[volpages.length - 1]);
+      return `${volpages[0]} –${volPagesEnd}`;
     }
     return this.item.alt_volpages;
   }
@@ -247,6 +254,25 @@ class SCSuttaplex extends LitLocalized(LitElement) {
     `;
   }
 
+  get volPageTemplate() {
+    return html`
+      <span class="vol-page nerdy-row-element" title="${this.volPageTitle}">
+        ${icon.book}
+        <span class="visible">${this.briefVolPage}</span>
+        <span class="hidden" aria-hidden="true">${this.volPage}</span>
+      </span>
+      ${this.altVolPage && this.altVolPage !== this.volPage
+        ? html`
+            <span class="vol-page nerdy-row-element" title="${this.volPageTitle}">
+              ${icon.book}
+              <span class="visible">${this.briefAltVolPage}</span>
+              <span class="hidden" aria-hidden="true">${this.altVolPage}</span>
+            </span>
+          `
+        : ''}
+    `;
+  }
+
   get nerdyRowTemplate() {
     return html`
       <div class="suttaplex-nerdy-row">
@@ -263,43 +289,11 @@ class SCSuttaplex extends LitLocalized(LitElement) {
         `}
         ${this.item.volpages &&
         html`
-          ${!this.item.biblio
-            ? html`
-                <span class="vol-page nerdy-row-element" title="${this.volPageTitle}">
-                  ${icon.book}
-                  <span class="visible">${this.briefVolPage}</span>
-                  <span class="hidden" aria-hidden="true">${this.volPage}</span>
-                </span>
-                ${this.altVolPage && this.altVolPage !== this.volPage
-                  ? html`
-                      <span class="vol-page nerdy-row-element" title="${this.volPageTitle}">
-                        ${icon.book}
-                        <span class="visible">${this.briefAltVolPage}</span>
-                        <span class="hidden" aria-hidden="true">${this.altVolPage}</span>
-                      </span>
-                    `
-                  : ''}
-              `
-            : ''}
+          ${!this.item.biblio ? this.volPageTemplate : ''}
           ${this.item.biblio &&
           html`
             <details class="suttaplex-details">
-              <summary>
-                <span class="vol-page nerdy-row-element" title="${this.volPageTitle}">
-                  ${icon.book}
-                  <span class="visible">${this.briefVolPage}</span>
-                  <span class="hidden" aria-hidden="true">${this.volPage}</span>
-                </span>
-                ${this.altVolPage && this.altVolPage !== this.volPage
-                  ? html`
-                      <span class="vol-page nerdy-row-element" title="${this.volPageTitle}">
-                        ${icon.book}
-                        <span class="visible">${this.briefAltVolPage}</span>
-                        <span class="hidden" aria-hidden="true">${this.altVolPage}</span>
-                      </span>
-                    `
-                  : ''}
-              </summary>
+              <summary>${this.volPageTemplate}</summary>
               <p class="volpage-biblio-info" .innerHTML="${this.item.biblio}"></p>
             </details>
           `}

--- a/client/utils/suttaplex.js
+++ b/client/utils/suttaplex.js
@@ -94,3 +94,7 @@ export function volPagesToString(volpages) {
     return '';
   }
 }
+
+export function formatVolPages(volPages) {
+  return volPages.replace('PTS (1st ed)', '').replace('PTS (2nd ed)', '').replace('PTS', '');
+}

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -336,21 +336,25 @@ def make_yellow_brick_road(db: Database):
 
 def load_guides_file(db: Database, guides_file: Path):
     guides_content = json_load(guides_file)
+    db['guides'].truncate()
     db.collection('guides').import_bulk(guides_content)
 
 
 def load_pali_reference_edition_file(db: Database, pali_reference_edition_file: Path):
     pali_reference_content = json_load(pali_reference_edition_file)
+    db['pali_reference_edition'].truncate()
     db.collection('pali_reference_edition').import_bulk(pali_reference_content)
 
 
 def load_root_edition_file(db: Database, root_edition_file: Path):
     root_edition_content = json_load(root_edition_file)
+    db['root_edition'].truncate()
     db.collection('root_edition').import_bulk(root_edition_content)
 
 
 def load_text_extra_info_file(db: Database, text_extra_info_file: Path):
     text_extra_info_content = json_load(text_extra_info_file)
+    db['text_extra_info'].truncate()
     db.collection('text_extra_info').import_bulk(text_extra_info_content)
 
 


### PR DESCRIPTION
need to execute `make delete-database` `make load-data`

fixed:
1.The new data is used for the main suttaplex nerdy row, but the old data is still used for the parallels.
2.The vol/page references are not appearing on staging for the Vinaya.
3.The title attribute always be the simple "Volume and page".
