### PR TITLE
Modify the code to fit the new localization directory (development mode)

### DIFF
--- a/client/elements/addons/sc-localization-mixin.js
+++ b/client/elements/addons/sc-localization-mixin.js
@@ -6,6 +6,7 @@ const FALLBACK_LANGUAGE = 'en';
 // I don't want to make call for /api/languages
 // because it would block the rendering
 const SUPPORTED_TRANSLATIONS = ['en', 'de', 'pl', 'pt', 'zh'];
+const USE_PRODUCTION_LOCALIZATION = true;
 
 const localizationCache = {};
 
@@ -96,14 +97,13 @@ export const LitLocalized = base =>
         if (!this.localizedStringsPath) {
           return;
         }
-        if (
-          process.env.NODE_ENV === 'development' &&
-          !this.localizedStringsPath.includes('build')
-        ) {
-          this.localizedStringsPath = this.localizedStringsPath.replace(
-            '/localization/elements',
-            '/localization/elements/build'
-          );
+        if (!USE_PRODUCTION_LOCALIZATION) {
+          if (!this.localizedStringsPath.includes('build')) {
+            this.localizedStringsPath = this.localizedStringsPath.replace(
+              '/localization/elements',
+              '/localization/elements/build'
+            );
+          }
         }
         const path = `${this.localizedStringsPath}_${lang}.json`;
 

--- a/client/elements/addons/sc-localization-mixin.js
+++ b/client/elements/addons/sc-localization-mixin.js
@@ -96,6 +96,15 @@ export const LitLocalized = base =>
         if (!this.localizedStringsPath) {
           return;
         }
+        if (
+          process.env.NODE_ENV === 'development' &&
+          !this.localizedStringsPath.includes('build')
+        ) {
+          this.localizedStringsPath = this.localizedStringsPath.replace(
+            '/localization/elements',
+            '/localization/elements/build'
+          );
+        }
         const path = `${this.localizedStringsPath}_${lang}.json`;
 
         if (path in localizationCache) {

--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -522,7 +522,7 @@ class SCTopSheetViews extends LitLocalized(LitElement) {
 
     if (isActive) {
       const dictChangeMessage = this.localizeEx(
-        'lookupDictionaryEnabled',
+        'dictionary:lookupDictionaryEnabled',
         'lookupDictionary',
         this.chineseLookupLanguage
       );
@@ -566,7 +566,7 @@ class SCTopSheetViews extends LitLocalized(LitElement) {
     selPaliScriptsElement.classList.add(`${selectedScript.toLowerCase()}-script`);
     scTopsheetViews.actions.choosePaliTextScript(selectedScript);
     const scriptChangeMessage = scTopsheetViews.localizeEx(
-      'scriptChanged',
+      'dictionary:scriptChanged',
       'paliScript',
       selectedScript
     );

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -16,7 +16,7 @@ cssselect==1.1.0
 pytest==6.2.4
 pytest-flask==1.2.0
 pytest-sugar==0.9.4
-pyppeteer==0.2.5
+pyppeteer==0.2.6
 python-arango==7.2.0
 regex==2021.7.6
 requests==2.26.0
@@ -25,7 +25,7 @@ Sphinx==4.1.1
 sphinxcontrib-websupport==1.2.4
 stripe==2.60.0
 termcolor==1.1.0
-tqdm==4.61.2
+tqdm==4.62.3
 uWSGI==2.0.19.1
 Werkzeug==2.0.1
 Flask-Caching==1.10.1


### PR DESCRIPTION
Related issues: #2017 #2317

In development mode, the localization file under `client/localization/elements` is used by default, but here is only the English version. If you want to view other localization content in development mode, you need to modify the `__loadLanguage` method of `sc-localization-mixin.js` line `100`: 
`if (!USE_PRODUCTION_LOCALIZATION) {`  to `if (USE_PRODUCTION_LOCALIZATION) {`


In production mode, Blake has copied the localization files to the relevant directory by modifying the configuration file.