### PR TITLE
Implement comments for segmented texts.

### DIFF
--- a/client/elements/styles/sc-layout-bilara-styles.js
+++ b/client/elements/styles/sc-layout-bilara-styles.js
@@ -46,6 +46,11 @@ export const plainStyles = html`
       display: none;
     }
 
+    .verse-line .translation {
+      display: block;
+      margin-left: 2em;
+    }
+
     /* Set styles for tooltip marker. First we hide the actual content. These settings ensure the beginning, i.e. the :before content, is visible and the rest is hidden. Height is important to maintain even line-height. */
     .comment,
     .variant {
@@ -74,6 +79,11 @@ export const plainPaliStyles = html`
     section,
     article {
       max-width: 720px;
+    }
+
+    .verse-line .root {
+      display: block;
+      text-indent: 2em;
     }
 
     .comment,
@@ -146,6 +156,11 @@ export const plainPlusStyles = html`
 
       grid-column: 2;
       grid-row: 1;
+    }
+
+    .verse-line .translation,
+    .verse-line .root {
+      text-indent: 2em;
     }
 
     @media only screen and (max-width: 600px) {
@@ -236,6 +251,11 @@ export const sideBySideStyles = html`
       grid-column-gap: var(--sc-size-lg);
     }
 
+    .verse-line .translation,
+    .verse-line .root {
+      text-indent: 2em;
+    }
+
     .translation {
       grid-column: 1;
     }
@@ -308,6 +328,11 @@ export const sideBySidePlusStyles = html`
 
       grid-template-columns: 60px 1fr 1fr;
       grid-column-gap: var(--sc-size-lg);
+    }
+
+    .verse-line .translation,
+    .verse-line .root {
+      text-indent: 2em;
     }
 
     .reference {
@@ -422,6 +447,11 @@ export const lineByLineStyles = html`
       display: grid;
 
       grid-template-columns: minmax(200px, 720px);
+    }
+
+    .verse-line .translation,
+    .verse-line .root {
+      text-indent: 2em;
     }
 
     .reference {

--- a/client/elements/styles/sc-typography-bilara-styles.js
+++ b/client/elements/styles/sc-typography-bilara-styles.js
@@ -63,12 +63,6 @@ export const typographyBilaraStyles = css`
     list-style-type: none;
   }
 
-  .verse-line .translation,
-  .verse-line .root {
-    display: block;
-    margin-left: 2em;
-  }
-
   /* lookup */
 
   .spanFocused {
@@ -99,7 +93,7 @@ export const typographyBilaraStyles = css`
     padding: var(--sc-size-sm) var(--sc-size-md);
 
     color: var(--sc-secondary-text-color);
-    border-width: 0 0 0 8px;
+    border-width: 1px 0 0 8px;
     border-style: solid;
     border-color: transparent;
     border-radius: var(--sc-size-sm);

--- a/client/elements/styles/sc-typography-bilara-styles.js
+++ b/client/elements/styles/sc-typography-bilara-styles.js
@@ -109,6 +109,8 @@ export const typographyBilaraStyles = css`
     font-variant-caps: normal;
 
     text-align: left;
+
+    text-indent: 0;
   }
   .comment {
     border-color: var(--sc-primary-accent-color);

--- a/client/elements/styles/sc-typography-bilara-styles.js
+++ b/client/elements/styles/sc-typography-bilara-styles.js
@@ -63,7 +63,8 @@ export const typographyBilaraStyles = css`
     list-style-type: none;
   }
 
-  .verse-line .text {
+  .verse-line .translation,
+  .verse-line .root {
     display: block;
     margin-left: 2em;
   }

--- a/client/elements/styles/sc-typography-common-styles.js
+++ b/client/elements/styles/sc-typography-common-styles.js
@@ -285,7 +285,7 @@ export const typographyCommonStyles = css`
 
   .speaker {
     font-style: italic;
-    text-indent: 2em;
+    text-indent: 3em;
     display: block;
   }
 

--- a/client/elements/styles/sc-typography-common-styles.js
+++ b/client/elements/styles/sc-typography-common-styles.js
@@ -285,7 +285,8 @@ export const typographyCommonStyles = css`
 
   .speaker {
     font-style: italic;
-    text-indent: 3em;
+    text-indent: 2em;
+    display: block;
   }
 
   .pe {

--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -228,9 +228,15 @@ class SCTextBilara extends SCTextCommon {
   _addCommentSpan(value) {
     const span = document.createElement('span');
     span.className = 'comment';
-    span.dataset.tooltip = value;
+    span.dataset.tooltip = this._stripHTML(value);
     span.innerHTML = value;
     return span;
+  }
+
+  _stripHTML(htmlText) {
+    const tmp = document.createElement('DIV');
+    tmp.innerHTML = htmlText;
+    return tmp.textContent || tmp.innerText || '';
   }
 
   _recalculateCommentSpanHeight() {

--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -162,6 +162,7 @@ class SCTextBilara extends SCTextCommon {
         this._addSCReference();
       }
       this._addVariantText();
+      this._addCommentText();
       this._paliLookupStateChanged();
       this._chineseLookupStateChanged();
       this._showHighlightingChanged();
@@ -171,6 +172,7 @@ class SCTextBilara extends SCTextCommon {
 
     setTimeout(() => {
       this._changeTextView();
+      this._recalculateCommentSpanHeight();
     }, 0);
     this.actions.changeSuttaMetaText('');
     this.actions.changeSuttaPublicationInfo({
@@ -213,6 +215,27 @@ class SCTextBilara extends SCTextCommon {
     });
   }
 
+  _addCommentText() {
+    if (!this.suttaComment || this._articleElement().length === 0) {
+      return;
+    }
+    Object.entries(this.suttaComment).forEach(([key, value]) => {
+      const translationSpan = this.shadowRoot.querySelector(`#${CSS.escape(key)} .translation`);
+      if (translationSpan) {
+        translationSpan.appendChild(this._addCommentSpan(value));
+      }
+    });
+  }
+
+  _addCommentSpan(value) {
+    const span = document.createElement('span');
+    span.className = 'comment';
+    span.dataset.tooltip = value;
+    const text = document.createTextNode(value);
+    span.appendChild(text);
+    return span;
+  }
+
   _recalculateCommentSpanHeight() {
     const gutterWidth = 5;
     this.commentSpanRectInfo.clear();
@@ -244,14 +267,6 @@ class SCTextBilara extends SCTextCommon {
       element.removeAttribute('style');
       element.onmouseover = null;
       element.onmouseleave = null;
-    });
-  }
-
-  _getCommentSpanRectInfo() {
-    this.commentSpanRectInfo.clear();
-    const Comments = this.shadowRoot.querySelectorAll('.comment');
-    Comments.forEach(element => {
-      this.commentSpanRectInfo.set(element.id, element.getBoundingClientRect());
     });
   }
 
@@ -315,6 +330,13 @@ class SCTextBilara extends SCTextCommon {
     if (changedProps.has('showHighlighting')) {
       this._showHighlightingChanged();
       this._updateURLParams();
+    }
+    if (changedProps.has('currentStyles')) {
+      if (this._isPlusStyle()) {
+        this._recalculateCommentSpanHeight();
+      } else {
+        this._resetCommentSpan();
+      }
     }
   }
 
@@ -761,28 +783,6 @@ class SCTextBilara extends SCTextCommon {
     const text = document.createTextNode(subKey);
     anchor.appendChild(text);
     return anchor;
-  }
-
-  _addCommentText() {
-    if (!this.suttaComment || this._articleElement().length === 0) {
-      return;
-    }
-    Object.entries(this.suttaComment).forEach(([key, value]) => {
-      const translationSpan = this.shadowRoot.querySelector(`#${CSS.escape(key)} .translation`);
-      if (translationSpan) {
-        translationSpan.appendChild(this._addCommentSpan(value));
-      }
-    });
-  }
-
-  _addCommentSpan(value) {
-    const span = document.createElement('span');
-    span.className = 'comment';
-    span.title = 'translator’s note';
-    span.dataset.tooltip = value;
-    const text = document.createTextNode(value);
-    span.appendChild(text);
-    return span;
   }
 
   _addVariantText() {

--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -228,6 +228,7 @@ class SCTextBilara extends SCTextCommon {
   _addCommentSpan(value) {
     const span = document.createElement('span');
     span.className = 'comment';
+    span.dataset.tooltip = value;
     span.innerHTML = value;
     return span;
   }

--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -228,8 +228,7 @@ class SCTextBilara extends SCTextCommon {
   _addCommentSpan(value) {
     const span = document.createElement('span');
     span.className = 'comment';
-    span.dataset.tooltip = value;
-    span.appendChild(document.createTextNode(value));
+    span.innerHTML = value;
     return span;
   }
 

--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -221,9 +221,7 @@ class SCTextBilara extends SCTextCommon {
     }
     Object.entries(this.suttaComment).forEach(([key, value]) => {
       const translationSpan = this.shadowRoot.querySelector(`#${CSS.escape(key)} .translation`);
-      if (translationSpan) {
-        translationSpan.appendChild(this._addCommentSpan(value));
-      }
+      translationSpan?.appendChild(this._addCommentSpan(value));
     });
   }
 
@@ -231,8 +229,7 @@ class SCTextBilara extends SCTextCommon {
     const span = document.createElement('span');
     span.className = 'comment';
     span.dataset.tooltip = value;
-    const text = document.createTextNode(value);
-    span.appendChild(text);
+    span.appendChild(document.createTextNode(value));
     return span;
   }
 


### PR DESCRIPTION
If want to test, need to manually copy the comment file to the `sc-flask` container.
e.g. `docker cp /download/sc_bilara_data/comment sc-flask:/opt/sc/sc-flask/sc-data/sc_bilara_data`
and then execute `make load-data-no-pull`