### PR TITLE
Make the service worker not load pointless files.

### DIFF
--- a/client/webpack.common.js
+++ b/client/webpack.common.js
@@ -70,7 +70,7 @@ module.exports = {
       ],
       navigateFallback: '/index.html',
       navigateFallbackDenylist: [/^\/img\/.*/, /^\/ebook\/.*/, /^\/api\/.*/, /^\/files\/.*/],
-      exclude: [/\.(woff(2)?|ttf|epub)$/, /node_modules\//, /img\/.*(?<!\.svg)$/],
+      exclude: [/\.(woff(2)?|ttf|epub|otf)$/, /node_modules\//, /img\/.*(?<!\.svg)$/],
     }),
     new BundleAnalyzerPlugin(),
   ],

--- a/client/webpack.prod.js
+++ b/client/webpack.prod.js
@@ -11,7 +11,9 @@ module.exports = merge(require('./webpack.common'), {
     moduleIds: 'deterministic',
   },
   plugins: [
-    new CleanWebpackPlugin(),
+    new CleanWebpackPlugin({
+      cleanAfterEveryBuildPatterns: ['*.LICENSE.txt'],
+    }),
     new CopyPlugin({
       patterns: [
         'manifest.json',


### PR DESCRIPTION
`otf` files are currently excluded.
*.LICENSE.txt will be automatically cleared after webpack builds the bundle.

However, the localization file seems to be unable to determine which language should only be loaded. 