### PR TITLE
Use `UrlSearchParams` to instead of regex.

### DIFF
--- a/client/elements/addons/sc-functions-miscellaneous.js
+++ b/client/elements/addons/sc-functions-miscellaneous.js
@@ -1,12 +1,8 @@
 // eslint-disable-next-line import/prefer-default-export
-export function getURLParam(url, name) {
+export function getURLParam(name) {
   try {
-    const reg = new RegExp(`(^|&)${name}=([^&]*)(&|$)`);
-    const r = url.split('?')[1].match(reg);
-    if (r != null) {
-      return r[2];
-    }
-    return '';
+    const searchParams = new URLSearchParams(window.location.search);
+    return searchParams.get(name);
   } catch (e) {
     return '';
   }

--- a/client/elements/addons/sc-static-page.js
+++ b/client/elements/addons/sc-static-page.js
@@ -22,7 +22,6 @@ export class SCStaticPage extends LitLocalized(LitElement) {
 
   connectedCallback() {
     super.connectedCallback();
-    // this._fetchLanguageList();
     const { currentRoute } = store.getState();
     if (!this.getUrlLangParam && currentRoute.path !== '/') {
       this._updateUrlParams();

--- a/client/elements/addons/sc-static-page.js
+++ b/client/elements/addons/sc-static-page.js
@@ -80,7 +80,7 @@ export class SCStaticPage extends LitLocalized(LitElement) {
   }
 
   get getUrlLangParam() {
-    return getURLParam(window.location.href, 'lang');
+    return getURLParam('lang');
   }
 
   async changeSiteLanguage(lang) {

--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -364,7 +364,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
   }
 
   _setViewState() {
-    const view = getURLParam(window.location.href, 'view');
+    const view = getURLParam('view');
     if (view && ['normal', 'dense', 'table'].includes(view.toLowerCase())) {
       if (view === 'normal') {
         this.displayParallelTableView = false;

--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -535,12 +535,12 @@ class SCTextBilara extends SCTextCommon {
   }
 
   _setTextViewState() {
-    const notes = getURLParam(window.location.href, 'notes');
-    const root = getURLParam(window.location.href, 'root');
-    const layout = getURLParam(window.location.href, 'layout');
-    const script = getURLParam(window.location.href, 'script');
-    const highlight = getURLParam(window.location.href, 'highlight');
-    const reference = getURLParam(window.location.href, 'reference');
+    const notes = getURLParam('notes');
+    const root = getURLParam('root');
+    const layout = getURLParam('layout');
+    const script = getURLParam('script');
+    const highlight = getURLParam('highlight');
+    const reference = getURLParam('reference');
     const { textOptions } = store.getState();
 
     if (notes && ['none', 'asterisk', 'sidenotes'].includes(notes.toLowerCase())) {

--- a/client/elements/text/sc-text-legacy.js
+++ b/client/elements/text/sc-text-legacy.js
@@ -654,8 +654,8 @@ class SCTextLegacy extends SCTextCommon {
   }
 
   _setTextViewState() {
-    const highlight = getURLParam(window.location.href, 'highlight');
-    const reference = getURLParam(window.location.href, 'reference');
+    const highlight = getURLParam('highlight');
+    const reference = getURLParam('reference');
     const { textOptions } = store.getState();
 
     if (highlight && ['true', 'false'].includes(highlight.toLowerCase())) {


### PR DESCRIPTION
Affected pages:
- Static pages (parameter: lang)
- Suttaplex page (parameter: view)
- Segmented text page (parameters: notes/layout/script/highlight/reference)
- Legacy text page (parameters: highlight/reference)

The effect of the replacement should be the same as before.

Related issue : https://github.com/suttacentral/suttacentral/issues/2413