### PR TITLE
Fix: "search:search" just says search:search in breadcrumbs.

### DIFF
--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -494,7 +494,6 @@ class SCPageSearch extends LitLocalized(LitElement) {
     this.waitTimeAfterNewWordExpired = true;
     this.loadingResults = true;
     this.actions.changeLinearProgressActiveState(this.loadingResults);
-    this._updateNav();
   }
 
   connectedCallback() {
@@ -840,6 +839,7 @@ class SCPageSearch extends LitLocalized(LitElement) {
       })
     );
     this.actions.changeToolbarTitle(toolbarTitle);
+    this._updateNav();
   }
 
   _computeItemDifficulty(difficulty) {


### PR DESCRIPTION
`"search:hint" just says search:hint`

This is caused by the missing `search:hint` key in the relevant localization file.

e.g.
https://github.com/suttacentral/sc-data/blob/master/sc_bilara_data/root/en/site/interface_root-en-site.json
https://github.com/suttacentral/sc-data/blob/master/sc_bilara_data/translation/de/site/interface_translation-de-site.json