### PR TITLE
URLs must be case insensitive.

### DIFF
--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -462,6 +462,12 @@ class SCPageSelector extends LitLocalized(LitElement) {
     if (params.suttaId) {
       params.suttaId = params?.suttaId.toLowerCase();
     }
+    if (params.word) {
+      params.word = params?.word.toLowerCase();
+    }
+    if (params.query) {
+      params.query = params?.query.toLowerCase();
+    }
     this.actions.changeRoute(route, params, location.pathname);
   }
 


### PR DESCRIPTION
There was a related PR before, https://github.com/suttacentral/suttacentral/pull/2305 for the text page URL, 

the current PR is for the dictionary and search page URL.