### PR TITLE
Fix: when clicking on a TOC item, the page title changes to "SuttaCen…

### DIFF
--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -384,7 +384,7 @@ class SCPageSelector extends LitLocalized(LitElement) {
   }
 
   updated() {
-    if (this.currentRoute.name !== 'SUTTA') {
+    if (this.currentRoute.name.toUpperCase() !== 'SUTTA') {
       this._createMetaData();
     }
     this._updateNav();


### PR DESCRIPTION
Fix: When clicking on a Table of Contents item, the page title changes to "SuttaCentral—discourses"