### PR TITLE
Introduce sc-map element

### DIFF
--- a/client/elements/sc-map.js
+++ b/client/elements/sc-map.js
@@ -1,0 +1,52 @@
+/* eslint-disable import/prefer-default-export */
+import { LitElement, html, css } from 'lit';
+
+import { LitLocalized } from './addons/sc-localization-mixin';
+
+export class SCMap extends LitLocalized(LitElement) {
+  static get properties() {
+    return {
+      zoom: Number,
+      longitude: Number,
+      latitude: Number,
+    };
+  }
+
+  constructor() {
+    super();
+    this.zoom = 13;
+    this.longitude = 0;
+    this.latitude = 0;
+
+    this.mapID = 'z1fKgOqM_IYc.k-W6AbJIxLu8';
+  }
+
+  static get styles() {
+    return css`
+      .google-maps {
+        height: 480px;
+        margin: var(--sc-size-md) 0;
+      }
+
+      .google-maps iframe {
+        width: 100%;
+        height: 480px;
+
+        border: none;
+      }
+    `;
+  }
+
+  render() {
+    return html`
+      <div class="google-maps">
+        <iframe
+          src="https://www.google.com/maps/d/embed?mid=${this.mapID}&ll=${this.latitude},${this
+            .longitude}&z=${this.zoom}"
+        ></iframe>
+      </div>
+    `;
+  }
+}
+
+customElements.define('sc-map', SCMap);

--- a/client/elements/sc-page-dictionary.js
+++ b/client/elements/sc-page-dictionary.js
@@ -9,6 +9,12 @@ import { LitLocalized } from './addons/sc-localization-mixin';
 import { dictionarySimpleItemToHtml } from './sc-dictionary-common';
 import { store } from '../redux-store';
 
+import(
+  /* webpackMode: "lazy" */
+  /* webpackPrefetch: true */
+  './sc-map.js'
+);
+
 class SCPageDictionary extends LitLocalized(LitElement) {
   static get styles() {
     return css`

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -15,6 +15,12 @@ import(
   './suttaplex/card/sc-suttaplex.js'
 );
 
+import(
+  /* webpackMode: "lazy" */
+  /* webpackPrefetch: true */
+  './sc-map.js'
+);
+
 class SCPageSearch extends LitLocalized(LitElement) {
   render() {
     return html`
@@ -297,18 +303,6 @@ class SCPageSearch extends LitLocalized(LitElement) {
         p + ol,
         p + ul {
           margin: 0.5em 0 1em;
-        }
-
-        .google-maps {
-          height: 480px;
-          margin: var(--sc-size-md-larger) 0;
-        }
-
-        .google-maps iframe {
-          width: 100%;
-          height: 480px;
-
-          border: none;
         }
 
         .d-none {

--- a/client/elements/styles/sc-dict-styles.js
+++ b/client/elements/styles/sc-dict-styles.js
@@ -177,18 +177,6 @@ export const dictStyles = css`
     color: var(--sc-icon-color);
   }
 
-  .google-maps {
-    height: 480px;
-    margin: var(--sc-size-md) 0;
-  }
-
-  .google-maps iframe {
-    width: 100%;
-    height: 480px;
-
-    border: none;
-  }
-
   .info {
     display: none;
   }


### PR DESCRIPTION
This is a preliminary change for map migration (suttacentral/suttacentral#939), **lifting the map implementation from the data repo to the client code**. It consists of two PRs which should happen in order:

1. suttacentral/suttacentral#2474 (this PR)
2. suttacentral/sc-data#143

This should bring no changes in functionality or visuals, except:

- In both places where a map can be shown (search page and dictionary page) the margins are now equal (namely `--sc-size-md`, while search used to be `--sc-size-md-larger`). I'm not sure if this is desired, but it does improve visual consistency and reduces code complexity.