### PR TITLE
Use `slice` instead of possibly deprecated `substr`

### DIFF
--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -77,7 +77,7 @@ export class SCTextBilara extends SCTextCommon {
 
     this._hashChangeHandler = () => {
       setTimeout(() => {
-        this._scrollToSection(window.location.hash.substr(1));
+        this._scrollToSection(window.location.hash.slice(1));
       }, 0);
     };
 

--- a/client/utils/routingService.js
+++ b/client/utils/routingService.js
@@ -66,7 +66,7 @@ export default class RoutingService {
 
     const [route, { params }] = hit;
 
-    const searchEntries = new URLSearchParams(this.location.search.substr(1)).entries();
+    const searchEntries = new URLSearchParams(this.location.search.slice(1)).entries();
     Array.from(searchEntries).forEach(([key, value]) => {
       if (!this.routes[route].tokens.includes(key)) {
         params[key] = value;


### PR DESCRIPTION
Because substr may not be supported by browsers in the future, and it happens to be used in key positions, it is replaced this time