### PR TITLE
style up the maps

### DIFF
--- a/client/elements/static/sc-static-map.js
+++ b/client/elements/static/sc-static-map.js
@@ -33,37 +33,46 @@ export class SCStaticMap extends SCStaticPage {
     unsafeCSS(typographyStaticStyles),
     css`
 
-  article{
-    max-width: 100%
-  }
-      .columns {
-        columns: 3 480px;
-      }
+  article
+{
+    max-width: 100%;
+}
 
-      .features-section {
-        break-inside: avoid;
-      }
+.columns
+{
+    columns: 3 480px;
+}
 
-      ul{
+.features-section
+{
+    break-inside: avoid;
+}
 
+li
+{
+    margin: .5em 0;
+}
 
-      }
-      li{
-        margin: .5em 0
-      }
+.marker-item
+{
+    list-style-image: var(--marker-icon);
+}
 
-      .marker-item {
-        list-style-image: var(--marker-icon);
-      }
+a
+{
+    font-family: var(--sc-sans-font);
 
-     a{
-        text-decoration: none;
-        border: 1px solid var(--sc-border-color);
-        border-radius: 1.5em;
-        padding: .2em 1em .1em 1.5em;
-        margin-left: -2em;
-        font-family: var(--sc-sans-font)
-      }
+    display: inline-block;
+
+    margin-left: -2em;
+    padding: .2em 1em .1em 1.5em;
+
+    text-decoration: none;
+
+    border: 1px solid var(--sc-border-color);
+    border-radius: 1.5em;
+}
+
     `,
   ];
 

--- a/client/elements/static/sc-static-map.js
+++ b/client/elements/static/sc-static-map.js
@@ -32,17 +32,37 @@ export class SCStaticMap extends SCStaticPage {
     unsafeCSS(typographyCommonStyles),
     unsafeCSS(typographyStaticStyles),
     css`
+
+  article{
+    max-width: 100%
+  }
       .columns {
-        columns: 2;
+        columns: 3 480px;
       }
 
       .features-section {
         break-inside: avoid;
-        display: inline-block;
+      }
+
+      ul{
+
+
+      }
+      li{
+        margin: .5em 0
       }
 
       .marker-item {
         list-style-image: var(--marker-icon);
+      }
+
+     a{
+        text-decoration: none;
+        border: 1px solid var(--sc-border-color);
+        border-radius: 1.5em;
+        padding: .2em 1em .1em 1.5em;
+        margin-left: -2em;
+        font-family: var(--sc-sans-font)
       }
     `,
   ];

--- a/client/localization/elements/static-map_en.json
+++ b/client/localization/elements/static-map_en.json
@@ -1,4 +1,4 @@
 {
-  "static-map:1": "SuttaCentral Map",
+  "static-map:1": "The Buddha’s India",
   "static-map:2": "Map features"
 }


### PR DESCRIPTION
So this makes a few tweaks to the styles on the map static page.

- make columns responsive
- make map and columns as wide as the screen, no need to keep them in a text-sized container
- use pill design for feature items
- use sans-serif font for pills
- change name to "the Buddha's India"

I also in a separate commit corrected the names of the features. there were a lot of unnecessary spelling variations, and in some cases the variants were all wrong. I've eliminated all variants and ensured that those that remain are actually found in SC. I only checked the entries with variants, though, so there will probably be mistakes in the remaining items.