### PR TITLE
Fix sc-chrome-headless build error

### DIFF
--- a/server/docker/Dockerfile-chrome-headless
+++ b/server/docker/Dockerfile-chrome-headless
@@ -47,7 +47,7 @@ RUN apt-get update && apt-get install -y \
 	fonts-kacst \
 	fonts-symbola \
 	fonts-noto \
-  	fonts-freefont-ttf \
+	fonts-freefont-ttf \
 	--no-install-recommends \
 	&& apt-get purge --auto-remove -y curl gnupg \
 	&& rm -rf /var/lib/apt/lists/*

--- a/server/docker/Dockerfile-chrome-headless
+++ b/server/docker/Dockerfile-chrome-headless
@@ -21,7 +21,7 @@
 #
 
 # Base docker image
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 LABEL name="chrome-headless" \
 			maintainer="Justin Ribeiro <justin@justinribeiro.com>" \
 			version="2.0" \
@@ -47,7 +47,7 @@ RUN apt-get update && apt-get install -y \
 	fonts-kacst \
 	fonts-symbola \
 	fonts-noto \
-	ttf-freefont \
+  	fonts-freefont-ttf \
 	--no-install-recommends \
 	&& apt-get purge --auto-remove -y curl gnupg \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Recently, there was a build sc-chrome-headless error when running suttacentral CI. This PR fixes this error.