### PR TITLE
draft version of badges with explainer

### DIFF
--- a/client/elements/addons/sc-badge.js
+++ b/client/elements/addons/sc-badge.js
@@ -9,17 +9,14 @@ export class SCBadge extends LitElement {
 
   static styles = css`
     :host {
-      display: inline-block;
-      padding: 0.25em 0.4em;
-      font-size: 75%;
-      font-weight: 700;
+      padding: 0.25em 0.75em;
+      font-size: var(--sc-skolar-font-size-xxs);
+      font-weight: 500;
+      font-stretch: condensed;
       line-height: 1;
       color: #fff;
-      text-align: center;
       white-space: nowrap;
-      vertical-align: baseline;
-      border-radius: 0.25rem;
-      margin-left: 0.2em;
+      border-radius: 0.6rem;
     }
 
     :host([color='primary']) {

--- a/client/elements/suttaplex/card/sc-suttaplex-css.js
+++ b/client/elements/suttaplex/card/sc-suttaplex-css.js
@@ -55,7 +55,12 @@ export const suttaplexCss = css`
 
   details ul {
     right: 0px;
-    padding: 0px;
+    padding: 8px 12px 8px 24px;
+    font-size: var(--sc-skolar-font-size-xs);
+  }
+
+  .suttaplex-share-menu-list{
+    padding: 0
   }
 
   summary {
@@ -103,12 +108,6 @@ export const suttaplexCss = css`
     padding: var(--sc-size-sm) var(--sc-size-md);
     border-radius: 2px;
     margin-bottom: 1px;
-  }
-
-  .section-details.main-translations {
-    border-top: 1px solid var(--sc-border-color);
-    margin-top: var(--sc-size-md);
-    padding-top: var(--sc-size-sm);
   }
 
   .compact .section-details.main-translations {
@@ -289,8 +288,8 @@ export const suttaplexTxCss = css`
     align-items: center;
     flex-wrap: nowrap;
     cursor: pointer;
-    padding: 0 var(--sc-size-sm);
-    margin: 0;
+    padding: 0 8px;
+    margin: 0 -8px;
     border-radius: var(--sc-size-sm);
   }
 
@@ -314,6 +313,7 @@ export const suttaplexTxCss = css`
     padding: 4px;
     border-radius: 50%;
     display: flex;
+    flex: 0 0 auto;
     justify-content: center;
     align-items: center;
     fill: var(--sc-primary-color);
@@ -326,10 +326,10 @@ export const suttaplexTxCss = css`
     flex-direction: row;
     flex-wrap: wrap;
     align-items: baseline;
+    gap: var(--sc-size-xs) var(--sc-size-md);
   }
 
   .tx-creator {
-    margin-right: var(--sc-size-md);
     font-family: var(--sc-serif-font);
     font-size: var(--sc-skolar-font-size-md);
     font-weight: 400;
@@ -343,8 +343,9 @@ export const suttaplexTxCss = css`
   }
 
   .badges {
-    margin-left: 0.4em;
     display: flex;
+    gap: var(--sc-size-xs);
+    align-self: center;
   }
 `;
 

--- a/client/elements/suttaplex/card/sc-suttaplex.js
+++ b/client/elements/suttaplex/card/sc-suttaplex.js
@@ -383,6 +383,8 @@ export class SCSuttaplex extends LitLocalized(LitElement) {
       <div class="section-details main-translations">
         ${!this.isCompact
           ? html`
+          <details>
+              <summary>
               <h3>
                 <b>
                   ${this.localize(`suttaplex:${translationKey}`, {
@@ -390,7 +392,15 @@ export class SCSuttaplex extends LitLocalized(LitElement) {
                   })}
                 </b>
                 ${this.localize('suttaplex:inYourLanguage')}
+              </summary>
+              <ul>
+              <li><b>Aligned</b> translations are matched segment by segment with the root text. These are produced by SuttaCentral with our Bilara translation application. <br><small><i>Click through to the translation, then click the “Views” button on the toolbar to see text and translation line-by-line or side-by-side.</i></small></li>
+              <li><b>Annotated</b> translations have notes on the text and translation. <br><small><i>Click through to the translation, then click the “Views” button on the toolbar to select options for reading notes.</i></small> </li>
+              <li><b>Legacy</b> translations have been adapted for SuttaCentral from various sources. They lack features such as alignment and annotations. </li>
+              </ul>
+              </details>
               </h3>
+
             `
           : ''}
         <div>


### PR DESCRIPTION
Here I added an **initial draft**:

- tweaks the badge styles a little
- adds a widget for explaining the badges

Just a couple of notes on the styles. 

- Be careful about adding useless styles, you had `inline-block` and then `vertical-align` and other things, but it was a `flex` element and these have no effect. Best to check in the inspect panel to make sure that styles are clean, not useless or overriding one another. 
- Don't use `margin` to make space between `flex` elements, use `gap` instead. Some of the suttaplex  (and probably elsewhere) uses `margin` because it was built before `gap ` was widely available, so we should update these.
- Always use variables for colors and font sizes. 
- For padding and other spacing, use variables where it makes sense, otherwise other units as appropriate.
- Don't use % for font sizes. If you can't use the variables, use `em` or `rem`.

Per our discussion, let us also add a `legacy` badge to all legacy HTML texts.

