### PR TITLE
fix: legacy texts without footer display the info text of previously viewed sutta.

### DIFF
--- a/client/elements/addons/sc-auto-complete-list.js
+++ b/client/elements/addons/sc-auto-complete-list.js
@@ -313,6 +313,10 @@ export class SCAutoCompleteList extends LitLocalized(LitElement) {
       return;
     }
 
+    if (this.searchQuery && this.searchQuery.length > 512) {
+      this.searchQuery = this.searchQuery.substring(0, 500);
+    }
+
     this.searchResult.length = 0;
     this.items.length = 0;
 

--- a/client/elements/text/sc-text-legacy.js
+++ b/client/elements/text/sc-text-legacy.js
@@ -301,6 +301,17 @@ export class SCTextLegacy extends SCTextCommon {
     } catch (e) {
       console.error(e);
     }
+
+    if (!metaText && this.sutta) {
+      metaText = `Sutta Id: ${this.sutta?.uid}
+      <br />
+      Sutta Title: ${this.sutta?.title}
+      <br />
+      Author: ${this.author}
+      <br/>
+      Language: ${this.lang}`
+    }
+
     return metaText;
   }
 


### PR DESCRIPTION
1. Tuning instant search.
2. fix: legacy texts without footer display the info text of previously viewed sutta.