### PR TITLE
Clicking outside of "views" overlay doesn't always close it.

### DIFF
--- a/client/elements/addons/sc-site-footer.js
+++ b/client/elements/addons/sc-site-footer.js
@@ -179,6 +179,12 @@ export class ScSiteFooter extends LitLocalized(LitElement) {
       </footer>
     `;
   }
+
+  firstUpdated() {
+    this.addEventListener('click', e => {
+      this.parentNode.querySelector('#action_items')?.hideTopSheets?.();
+    });
+  }
 }
 
 customElements.define('sc-site-footer', ScSiteFooter);

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -481,24 +481,22 @@ export class SCPageSelector extends LitLocalized(LitElement) {
 
   _changeRoute(location) {
     const [route, params] = this.router.match(location.pathname);
-    if (params) {
-      if (params.categoryId) {
-        params.categoryId = params?.categoryId.toLowerCase();
-      }
-      if (params.langIsoCode) {
-        params.langIsoCode = params?.langIsoCode.toLowerCase();
-      }
-      if (params.authorUid) {
-        params.authorUid = params?.authorUid.toLowerCase();
-      }
-      if (params.suttaId) {
-        params.suttaId = params?.suttaId.toLowerCase();
-      }
-      if (params.word) {
-        params.word = params?.word.toLowerCase();
-      }
+    const normalizedParams = this._normalizeParams(params);
+    this.actions.changeRoute(route, normalizedParams, location.pathname);
+  }
+
+  _normalizeParams(params) {
+    if (!params) {
+      return;
     }
-    this.actions.changeRoute(route, params, location.pathname);
+    const keys = ['categoryId', 'langIsoCode', 'authorUid', 'suttaId', 'word'];
+    const normalized = {};
+    keys.forEach(key => {
+      if (params[key]) {
+        normalized[key] = params[key].toLowerCase();
+      }
+    });
+    return normalized;
   }
 
   get routeDefinition() {
@@ -626,40 +624,30 @@ export class SCPageSelector extends LitLocalized(LitElement) {
   }
 
   _changeToolbarTitle() {
-    switch (this.currentRoute.name) {
-      case 'search':
-        this.actions.changeToolbarTitle(this.localize('interface:searchResults'));
-        break;
-      case 'define':
-        this.actions.changeToolbarTitle(this.localize('interface:dictionaryResults'));
-        break;
-      case 'home':
-        this.actions.changeToolbarTitle('SuttaCentral');
-        break;
-      case 'navigation':
-        return;
-      case 'suttaplex':
-        return;
-      case 'sutta':
-        return;
-      case 'publicationEditionMatter':
-        return;
-      case 'palitipitaka':
-        this.actions.changeToolbarTitle('Pāḷi Tipiṭaka');
-        break;
-      case 'searchFilter':
-        this.actions.changeToolbarTitle('Search Filter');
-        break;
-      default:
+    const titleMap = {
+        'search': this.localize('interface:searchResults'),
+        'define': this.localize('interface:dictionaryResults'),
+        'home': 'SuttaCentral',
+        'navigation': '',
+        'suttaplex': '',
+        'sutta': '',
+        'publicationEditionMatter': '',
+        'palitipitaka': 'Pāḷi Tipiṭaka',
+        'searchFilter': 'Search Filter',
+    };
+
+    let title = titleMap[this.currentRoute.name];
+    if (title === undefined) {
         const key = `interface:${this.currentRoute.name}Title`;
         if (this.__resources[key]) {
-          const pageNameTitle = this.localize(key);
-          this.actions.changeToolbarTitle(pageNameTitle);
+            title = this.localize(key);
         } else {
-          this.actions.changeToolbarTitle('');
+            title = '';
         }
     }
-  }
+
+    this.actions.changeToolbarTitle(title);
+}
 
   _updateNav() {
     if (staticPages.includes(this.currentRoute.name)) {
@@ -745,6 +733,12 @@ export class SCPageSelector extends LitLocalized(LitElement) {
 
   #setSearchOptionsButtonDisplayState() {
     reduxActions.changeDisplaySearchOptionsButtonState(['search'].includes(this.currentRoute.name));
+  }
+
+  firstUpdated() {
+    this.addEventListener('click', e => {
+      this.parentNode.querySelector('#action_items')?.hideTopSheets?.();
+    });
   }
 }
 

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -487,13 +487,13 @@ export class SCPageSelector extends LitLocalized(LitElement) {
 
   _normalizeParams(params) {
     if (!params) {
-      return;
+      return {};
     }
     const keys = ['categoryId', 'langIsoCode', 'authorUid', 'suttaId', 'word'];
-    const normalized = {};
+    const normalized = { ...params };
     keys.forEach(key => {
-      if (params[key]) {
-        normalized[key] = params[key].toLowerCase();
+      if (normalized[key] && typeof normalized[key] === 'string') {
+        normalized[key] = normalized[key].toLowerCase();
       }
     });
     return normalized;

--- a/client/elements/styles/sc-layout-bilara-styles.js
+++ b/client/elements/styles/sc-layout-bilara-styles.js
@@ -34,6 +34,10 @@ export const commonStyles = css`
   .refFocused {
     background-color: var(--sc-primary-color) !important;
   }
+
+  .sutta-title {
+    word-break: break-word;
+  }
 `;
 
 export const plainStyles = html`
@@ -47,8 +51,11 @@ export const plainStyles = html`
       display: none;
     }
 
-    .verse-line .translation {
+    .verse-line {
       display: block;
+    }
+
+    .verse-line .translation {
       hyphens: none;
       margin-left: 2em;
     }

--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -85,7 +85,6 @@ export class SCTextBilara extends SCTextCommon {
     };
 
     this._onClickHandler = () => {
-      this._hideTopSheets();
       this.actions.changeDisplaySettingMenuState(false);
     };
 
@@ -284,10 +283,6 @@ export class SCTextBilara extends SCTextCommon {
     if (span) {
       span.textContent = suttaTitle;
     }
-  }
-
-  _hideTopSheets() {
-    this.scActionItems?.hideTopSheets();
   }
 
   _segmentedTextContentElement() {

--- a/client/elements/text/sc-text-legacy.js
+++ b/client/elements/text/sc-text-legacy.js
@@ -143,7 +143,6 @@ export class SCTextLegacy extends SCTextCommon {
     super.connectedCallback();
     window.addEventListener('hashchange', this._hashChangeHandler);
     this.addEventListener('click', () => {
-      this._hideTopSheets();
       this.actions.changeDisplaySettingMenuState(false);
     });
     this.inputElement = this.querySelector('#simple_text_content');
@@ -155,10 +154,6 @@ export class SCTextLegacy extends SCTextCommon {
     this._updateURLSearchParams();
     this.scActionItems = document.querySelector('sc-site-layout').querySelector('#action_items');
     this.scActionItems?.hideSpeakerButton();
-  }
-
-  _hideTopSheets() {
-    this.scActionItems?.hideTopSheets();
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
1. Clicking outside of "views" overlay doesn't always close it. #3001.
2. Headings need word-break: break-word to prevent forced wide pages #3004.
3. Verse segments have large gap when references are activated #3005