### PR TITLE
Update filter overlay documentation

### DIFF
--- a/client/elements/addons/sc-top-sheet-search-filter.js
+++ b/client/elements/addons/sc-top-sheet-search-filter.js
@@ -70,6 +70,10 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
         --md-sys-color-primary: var(--sc-primary-accent-color);
         --md-sys-color-on-primary: white;
       }
+
+      p {
+        margin: 10px 10px
+      }
     `,
   ];
 
@@ -80,12 +84,13 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
           <legend>
             Refine your search with filters
           </legend>
+          <p>Filters must always appear first in a search before keywords. Pāli diacritcs are ignored in search terms.</p>
           <table>
             <tr>
-              <th colspan="2">PTS volume/page search</th>
+              <th colspan="2">PTS volume and page search</th>
             </tr>
             <tr>
-              <td>Find texts using legacy PTS volume/page references.</td>
+              <td>Find texts using PTS volume/page references.</td>
               <td>
                 volpage:SN ii 4<br>
                 volpage:M II 246<br>
@@ -108,10 +113,10 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
             <tr>
               <td>Filter results by <code>author</code>.</td>
               <td>author:sujato cat<br>
-                  author:sujato Katze<br>
-                  author:sujato Buddha OR Sāvatthī<br>
-                  author:sujato Buddha AND Sāvatthī
-              </td>
+              author:sabbamitta Katze<br>
+              author:sujato Buddha OR Sāvatthī<br>
+              author:sujato Buddha AND Sāvatthī
+          </td>
             </tr>
 
             <tr>
@@ -124,7 +129,7 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
             </tr>
 
             <tr>
-              <td>List all related suttas by <code>title</title>.</td>
+              <td>Search only in the <code>title</title>.</td>
               <td>title:intention</td>
             </tr>
 
@@ -134,9 +139,11 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
             <tr>
               <td>Search <code>in</code> a specific collection with SuttaCentral IDs.</td>
               <td>in:dn cat<br>
-                  in:an dog<br>
-                  in:an Buddha OR Sāvatthī<br>
-                  in:an Buddha AND Sāvatthī
+                  in:an4 dog<br>
+                  in:sutta moat</br>
+                  in:abhidhamma feelings</br>
+                  in:kn flame</br>
+                  in:an Buddha OR Sāvatthī
               </td>
             </tr>
 
@@ -144,30 +151,30 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
               <th colspan="2">ebt search</th>
             </tr>
             <tr>
-              <td>Narrow search to “Early Buddhist Texts” (<code>ebt</code>). This is a shortcut and not a definitive list of what is early. Equivalent to the following.<br>
-                <code>in:dn, da, mn, ma, sn, sa, sa-2, sa-3, an, ea, ea-2, kp, iti, ud, snp,
+              <td>Narrow search to “Early Buddhist Texts” (<code>ebt</code>). This is a shortcut and not a definitive list of what is early. Equivalent to the following:<br>
+                <code>dn, da, mn, ma, sn, sa, sa-2, sa-3, an, ea, ea-2, kp, iti, ud, snp,
                   dhp, thig, thag, pli-tv, lzh-mg, lzh-mi, lzh-dg, lzh-sarv, lzh-mu, lzh-ka,
                   lzh-upp, san-mg, san-lo, up, ea-ot, d, sf</code>
               </td>
-              <td>in:ebt free</td>
+              <td>in:ebt elephant</td>
             </tr>
 
             <tr>
               <th colspan="2">ebs search</th>
             </tr>
             <tr>
-              <td>Narrow search to “Early Buddhist Suttas” (<code>ebs</code>). This is a shortcut and not a definitive list of what is early. Equivalent to the following.<br>
-                <code>in:dn, da, mn, ma, sn, sa, sa-2, sa-3, an, ea, ea-2, kp, iti, ud, snp, dhp, thig, thag, sf</code>
+              <td>Narrow search to “Early Buddhist Suttas” (<code>ebs</code>). This is a shortcut and not a definitive list of what is early. Equivalent to the following:<br>
+                <code>dn, da, mn, ma, sn, sa, sa-2, sa-3, an, ea, ea-2, kp, iti, ud, snp, dhp, thig, thag, sf</code>
               </td>
-              <td>in:ebs free</td>
+              <td>in:ebs lion</td>
             </tr>
 
             <tr>
               <th colspan="2">ebct search</th>
             </tr>
             <tr>
-              <td>Narrow search to “Early Buddhist Chinese Texts” (<code>ebct</code>). This is a shortcut and not a definitive list of what is early. Equivalent to the following.<br>
-                <code>in:da, ma, sa, sa-2, sa-3, ea, ea-2, lzh-mg, lzh-mi, lzh-dg, lzh-sarv, lzh-mu, lzh-ka,
+              <td>Narrow search to “Early Buddhist Chinese Texts” (<code>ebct</code>). This is a shortcut and not a definitive list of what is early. Equivalent to the following:<br>
+                <code>da, ma, sa, sa-2, sa-3, ea, ea-2, lzh-mg, lzh-mi, lzh-dg, lzh-sarv, lzh-mu, lzh-ka,
                   lzh-upp, ea-ot, d</code>
               </td>
               <td>in:ebct 四念处</td>

--- a/client/elements/addons/sc-top-sheet-search-filter.js
+++ b/client/elements/addons/sc-top-sheet-search-filter.js
@@ -90,7 +90,7 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
               <th colspan="2">PTS volume and page search</th>
             </tr>
             <tr>
-              <td>Find texts using PTS volume/page references.</td>
+              <td>Find texts using PTS volume and page references.</td>
               <td>
                 volpage:SN ii 4<br>
                 volpage:M II 246<br>

--- a/client/elements/addons/sc-top-sheet-search-filter.js
+++ b/client/elements/addons/sc-top-sheet-search-filter.js
@@ -72,7 +72,7 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
       }
 
       p {
-        margin: 10px 10px
+        margin: 10px 10px;
       }
     `,
   ];
@@ -84,7 +84,7 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
           <legend>
             Refine your search with filters
           </legend>
-          <p>Filters must always appear first in a search before keywords. Pāli diacritcs are ignored in search terms.</p>
+          <p>Filters must always appear first in a search before keywords. Pāli diacritics are ignored in search terms.</p>
           <table>
             <tr>
               <th colspan="2">PTS volume and page search</th>
@@ -129,7 +129,7 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
             </tr>
 
             <tr>
-              <td>Search only in the <code>title</title>.</td>
+              <td>Search only in the <code>title</code>.</td>
               <td>title:intention</td>
             </tr>
 

--- a/client/elements/addons/sc-top-sheet-search-filter.js
+++ b/client/elements/addons/sc-top-sheet-search-filter.js
@@ -114,7 +114,7 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
               <td>Filter results by <code>author</code>.</td>
               <td>author:sujato cat<br>
               author:sabbamitta Katze<br>
-              author:sujato Buddha OR Sāvatthī<br>
+              author:sujato kassapa OR moggallana<br>
               author:sujato Buddha AND Sāvatthī
           </td>
             </tr>
@@ -143,7 +143,7 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
                   in:sutta moat</br>
                   in:abhidhamma feelings</br>
                   in:kn flame</br>
-                  in:an Buddha OR Sāvatthī
+                  in:an kassapa OR moggallana
               </td>
             </tr>
 
@@ -151,7 +151,7 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
               <th colspan="2">ebt search</th>
             </tr>
             <tr>
-              <td>Narrow search to “Early Buddhist Texts” (<code>ebt</code>). This is a shortcut and not a definitive list of what is early. Equivalent to the following:<br>
+              <td>Narrow search to “Early Buddhist Texts” (<code>ebt</code>). This is a shortcut and not a definitive list of what is early. Searches within the following:<br>
                 <code>dn, da, mn, ma, sn, sa, sa-2, sa-3, an, ea, ea-2, kp, iti, ud, snp,
                   dhp, thig, thag, pli-tv, lzh-mg, lzh-mi, lzh-dg, lzh-sarv, lzh-mu, lzh-ka,
                   lzh-upp, san-mg, san-lo, up, ea-ot, d, sf</code>
@@ -163,7 +163,7 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
               <th colspan="2">ebs search</th>
             </tr>
             <tr>
-              <td>Narrow search to “Early Buddhist Suttas” (<code>ebs</code>). This is a shortcut and not a definitive list of what is early. Equivalent to the following:<br>
+              <td>Narrow search to “Early Buddhist Suttas” (<code>ebs</code>). This is a shortcut and not a definitive list of what is early. Searches within the following:<br>
                 <code>dn, da, mn, ma, sn, sa, sa-2, sa-3, an, ea, ea-2, kp, iti, ud, snp, dhp, thig, thag, sf</code>
               </td>
               <td>in:ebs lion</td>
@@ -173,7 +173,7 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
               <th colspan="2">ebct search</th>
             </tr>
             <tr>
-              <td>Narrow search to “Early Buddhist Chinese Texts” (<code>ebct</code>). This is a shortcut and not a definitive list of what is early. Equivalent to the following:<br>
+              <td>Narrow search to “Early Buddhist Chinese Texts” (<code>ebct</code>). This is a shortcut and not a definitive list of what is early. Searches within the following:<br>
                 <code>da, ma, sa, sa-2, sa-3, ea, ea-2, lzh-mg, lzh-mi, lzh-dg, lzh-sarv, lzh-mu, lzh-ka,
                   lzh-upp, ea-ot, d</code>
               </td>


### PR DESCRIPTION
This makes minor changes to the filter documentation overlay.

* the word "legacy" was removed from the description of the PTS refrences because the term legacy has a specific meaning on SC.
* remove `/` from `volpage:` description since a slash means either or.
* changed some examples for clarity
* added collection examples
* changed group description for clarity.

This was tested on my local install.