### PR TITLE
add missing localization and remove title attributes

### DIFF
--- a/client/elements/addons/sc-bottom-sheet.js
+++ b/client/elements/addons/sc-bottom-sheet.js
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { LitLocalized } from './sc-localization-mixin';
 import { icon } from '../../img/sc-icon';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 export class SCBottomSheet extends LitLocalized(LitElement) {
   static properties = {
@@ -132,6 +133,7 @@ export class SCBottomSheet extends LitLocalized(LitElement) {
       border-radius: 4px;
       background-color: var(--sc-on-primary-secondary-text-color);
       box-shadow: var(--sc-shadow-elevation-8dp);
+      padding: 10px;
     }
 
     .bottom-sheet-icon-label {
@@ -422,37 +424,27 @@ export class SCBottomSheet extends LitLocalized(LitElement) {
               <div class="help-display-inner">
                 <ul>
                   <li>
-                    Source:
-                    <cite>New Concise Pali-English Dictionary</cite>, compiled by SuttaCentral from
-                    Buddhadatta’s <cite>Concise Pali-English Dictionary</cite>, updated and
-                    corrected from Margaret Cone’s <cite>Dictionary of Pali</cite>.
+                  ${unsafeHTML(this.localize('bottomsheet:help1'))}
                   </li>
-                  <li>Pali words are analyzed by machine and results are not always accurate.</li>
-                  <li>Click on a head word to go to full dictionary entry.</li>
+                  <li>${this.localize('bottomsheet:help2')}</li>
+                  <li>${this.localize('bottomsheet:help3')}</li>
                   <li>
-                    Navigate using keyboard.
+                    ${this.localize('bottomsheet:help4')}
                     <ul>
                       <li>
-                        Next =
+                      ${this.localize('bottomsheet:help5')} =
                         <kbd>Alt</kbd>
                         +
                         <kbd>n</kbd>
                       </li>
                       <li>
-                        Back =
+                      ${this.localize('bottomsheet:help6')} =
                         <kbd>Alt</kbd>
                         +
                         <kbd>b</kbd>
                       </li>
                     </ul>
-                    If this doesn’t work for you, check the
-                    <a
-                      href="https://en.wikipedia.org/wiki/Access_key#Access_in_different_browsers"
-                      target="_blank"
-                    >
-                      HTML access key for your browser
-                    </a>
-                    .
+                    ${unsafeHTML(this.localize('bottomsheet:help7'))}
                   </li>
                 </ul>
               </div>

--- a/client/elements/addons/sc-site-footer.js
+++ b/client/elements/addons/sc-site-footer.js
@@ -152,7 +152,7 @@ export class ScSiteFooter extends LitLocalized(LitElement) {
               </li>
                <li>
                 <a class="block-link" href="https://buddhism.net/"
-                  >Buddhism.net — making the teachings of the Buddha accessible</a>
+                  >${this.localize('footer:buddhismnet')}</a>
               </li>
               <li>
                 <a class="block-link" href="https://suttacentral.github.io/awesome/"

--- a/client/elements/static/sc-static-home.js
+++ b/client/elements/static/sc-static-home.js
@@ -103,7 +103,6 @@ export class SCStaticHomePage extends SCStaticPage {
     return html`
       <section class="video">
         <video
-          title=${this.localize('home:2')}
           width="640"
           height="360"
           controls
@@ -211,7 +210,6 @@ export class SCStaticHomePage extends SCStaticPage {
         <a
           href="https://voice.suttacentral.net/scv/index.html#/sutta"
           class='block-link'
-          title=${this.localize('home:16')}
         >
           <header>
             <span>${icon.speaker}</span>
@@ -239,7 +237,7 @@ export class SCStaticHomePage extends SCStaticPage {
   #buddhaNexusCardTemplate() {
     return html`
       <article class="card secondary-accent">
-        <a href="https://buddhanexus.net/" class="block-link" title=${this.localize('home:21')}>
+        <a href="https://buddhanexus.net/" class="block-link">
           <header>
             <span>
               <picture>
@@ -267,7 +265,6 @@ export class SCStaticHomePage extends SCStaticPage {
         <a
           href="https://discourse.suttacentral.net/"
           class="block-link"
-          title=${this.localize('home:24')}
         >
           <header>
             <span>${icon.people}</span>
@@ -297,18 +294,17 @@ export class SCStaticHomePage extends SCStaticPage {
         <a
           href="https://buddhism.net/"
           class="block-link"
-          title=${this.localize('home:30')}
         >
           <header>
             <span class="buddhismnet-image-container"><img src='/img/home-page/bn.png' alt='Buddhism.net' /></span>
             <h3>
               <span>Buddhism.net</span>
-              <span class="sc-related-item-subtitle">making the teachings of the Buddha accessible</span>
+              <span class="sc-related-item-subtitle">${unsafeHTML(this.localize('home:31'))}</span>
             </h3>
           </header>
 
           <div class="related-projects-content">
-            <p>At Buddhism.net, we hope to help you 1) learn Buddhism, 2) develop a practice, and 3) discover teachers and communities. Buddhism.net is cross-sectarian. We focus on early Buddhism, the common root of all modern forms of Buddhism. We aim to offer you a solid foundation in early Buddhism, which will be immensely helpful to you regardless of which form of Buddhism you adopt.</p>
+            <p>${unsafeHTML(this.localize('home:32'))}</p>
           </div>
         </a>
         <md-ripple></md-ripple>


### PR DESCRIPTION
## Localization

* bottomsheet help text + padding css:

![image](https://github.com/suttacentral/suttacentral/assets/82448383/67f6baa9-52f8-42ec-8666-5412be7f0023)

* Buddhism.net text in footer
* Buddhism.net card on homepage:

![image](https://github.com/suttacentral/suttacentral/assets/82448383/184d1bbe-1407-4277-81e8-fea2cb3f29eb)

Note: When I did this I also changed the subhead and text. The subhead was too long for the design. And I felt that the text was just lifted from their homepage, so I made it fit better in this context. Here is the original if you want to keep it:

> making the teachings of the Buddha accessible  
> At Buddhism.net, we hope to help you 1) learn Buddhism, 2) develop a practice, and 3) discover teachers and communities. Buddhism.net is cross-sectarian. We focus on early Buddhism, the common root of all modern forms of Buddhism. We aim to offer you a solid foundation in early Buddhism, which will be immensely helpful to you regardless of which form of Buddhism you adopt.

My new version appears in the screenshot.

## title attributes

I removed the code for the following from `home` as they are titles that add no significant value and are useless on mobile. This is what they look like in the json file:

```
  "home:2": "SuttaCentral promotional video 2020",
  "home:16": "Visit SuttaCentral Voice",
  "home:21": "Visit BuddhaNexus",
  "home:24": "Visit SuttaCentral forum",
  "home:30": "Visit Bilara translation webapp",
```

## Warnings:

These changes will require accepting a new PR on `bilara-data`

The old Bilara card on the home page was hard coded in, in the sense that the template for that card is called ` #bilaraCardTemplate() {`.

The code might be more robust if all the card templates were simply renamed to `#card1`, `#card2~ etc.

Because I recycled segments `home:31` and `home:31` , in cases where the homepage has been translated, that text will be wrong. I guess somehow that has to be dealt with.

