### PR TITLE
Remove Unused Numpy Dependency

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -38,7 +38,6 @@ lxml==4.9.1
 marisa-trie==0.7.8
 MarkupSafe==2.1.1
 mistune==2.0.4
-numpy==1.23.5
 packaging==21.3
 pluggy==1.0.0
 py==1.11.0


### PR DESCRIPTION
The numpy requirement doesn't seem to be used anywhere, and since this is a fairly large import, its best to not include it unless its really needed.

