### PR TITLE
fix link style on donate-now

### DIFF
--- a/client/elements/static/sc-static-donate-now.js
+++ b/client/elements/static/sc-static-donate-now.js
@@ -14,6 +14,8 @@ import { icon } from '../../img/sc-icon';
 
 import { layoutSimpleStyles } from '../styles/sc-layout-simple-styles';
 import { typographyCommonStyles } from '../styles/sc-typography-common-styles';
+import { SCUtilityStyles } from '../styles/sc-utility-styles';
+
 
 export class SCStaticDonateNow extends LitLocalized(LitElement) {
   static properties = {
@@ -32,6 +34,7 @@ export class SCStaticDonateNow extends LitLocalized(LitElement) {
   static styles = [
     layoutSimpleStyles,
     typographyCommonStyles,
+    SCUtilityStyles,
     css`
       :host {
         --md-filled-button-label-text-font: var(--sc-serif-font);
@@ -107,10 +110,6 @@ export class SCStaticDonateNow extends LitLocalized(LitElement) {
         font-family: var(--sc-sans-font);
 
         margin-top: 64px;
-      }
-
-      aside p a {
-        color: var(--sc-primary-accent-color);
       }
 
       .icon {


### PR DESCRIPTION
Fixes https://github.com/suttacentral/suttacentral/issues/2979

I have tested this on my local machine.

https://suttacentral.net/donate-now

This is the last remaining link problem with the dark theme. This is before the fix:

![image](https://github.com/suttacentral/suttacentral/assets/82448383/9afe2ab0-cb80-452a-b399-0a8560cb6f12)

Now after the fix it matches all the other links on the site:
![image](https://github.com/suttacentral/suttacentral/assets/82448383/6c24525a-1d7c-4f3c-8f8c-0f7cd6236e4c)
