### PR TITLE
Initial removal of tool tips

### DIFF
--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -546,7 +546,7 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
               <select id="selPaliScripts">
                 ${scriptIdentifiers.map(
                   script => html`
-                    <option value=${script.script} title=${script.language}>
+                    <option value=${script.script}>
                       ${script.language}
                     </option>
                   `

--- a/client/elements/menus/sc-action-items-universal.js
+++ b/client/elements/menus/sc-action-items-universal.js
@@ -106,7 +106,6 @@ export class SCActionItemsUniversal extends LitLocalized(LitElement) {
       <md-icon-button
         class="button-theme"
         id="search_glass"
-        title=${this.localize('search:searchTooltip')}
         @click=${this.openInstantSearchDialog}
       >
         ${icon.search}

--- a/client/elements/menus/sc-menu-more.js
+++ b/client/elements/menus/sc-menu-more.js
@@ -426,7 +426,6 @@ export class SCMenuMore extends LitLocalized(LitElement) {
       <md-menu-item
         class="more-menu-md-menu-item"
         href=${this.#computeSCVoiceLink()}
-        title="Listen to suttas"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/client/elements/menus/sc-menu-static-pages-nav.js
+++ b/client/elements/menus/sc-menu-static-pages-nav.js
@@ -157,7 +157,6 @@ export class SCMenuStaticPagesNav extends LitLocalized(LitElement) {
               <a
                 href="https://discourse.suttacentral.net/c/meta/updates"
                 class="external"
-                title="See updates on SuttaCentral forum"
                 target="_blank"
                 rel="noopener"
               >

--- a/client/elements/static/sc-static-introduction.js
+++ b/client/elements/static/sc-static-introduction.js
@@ -30,34 +30,38 @@ export class SCStaticIntroduction extends SCStaticPage {
           <p>${unsafeHTML(this.localize('introduction:3'))}</p>
           <p>${unsafeHTML(this.localize('introduction:4'))}</p>
           <p>${unsafeHTML(this.localize('introduction:5'))}</p>
-          <picture>
-            <source
-              srcset="/img/static-pages/Life_of_Buddha_Burmese_Manuscript_22_Volume_1_Wellcom.avif"
-              type="image/avif"
-            />
-            <img
-              alt=${this.localize('introduction:6')}
-              class="image-home-full"
-              src="/img/static-pages/Life_of_Buddha_Burmese_Manuscript_22_Volume_1_Wellcom.jpg"
-              title=${this.localize('introduction:7')}
-              width="640px"
-            />
-          </picture>
+          <figure>
+            <picture>
+              <source
+                srcset="/img/static-pages/Life_of_Buddha_Burmese_Manuscript_22_Volume_1_Wellcom.avif"
+                type="image/avif"
+              />
+              <img
+                alt=${this.localize('introduction:6')}
+                class="image-home-full"
+                src="/img/static-pages/Life_of_Buddha_Burmese_Manuscript_22_Volume_1_Wellcom.jpg"
+                width="640px"
+              >
+            </picture>
+            <figcaption>${this.localize('introduction:7')}</figcaption>
+          </figure>
           <h2>${unsafeHTML(this.localize('introduction:8'))}</h2>
           <p>${unsafeHTML(this.localize('introduction:9'))}</p>
           <p>${unsafeHTML(this.localize('introduction:10'))}</p>
           <p>${unsafeHTML(this.localize('introduction:11'))}</p>
           <h2>${unsafeHTML(this.localize('introduction:12'))}</h2>
           <p>
-            <picture>
-              <source srcset="/img/static-pages/birchbark_w400.avif" type="image/avif" />
-              <img
-                alt=${this.localize('introduction:13')}
-                class="image-home"
-                src="/img/static-pages/birchbark_w400.jpg"
-                title=${this.localize('introduction:14')}
-              />
-            </picture>
+            <figure>
+              <picture>
+                <source srcset="/img/static-pages/birchbark_w400.avif" type="image/avif" />
+                <img
+                  alt=${this.localize('introduction:13')}
+                  class="image-home"
+                  src="/img/static-pages/birchbark_w400.jpg"
+                />
+              </picture>
+              <figcaption>${this.localize('introduction:14')}</figcaption>
+            </figure>
             ${unsafeHTML(this.localize('introduction:15'))}
             <i lang="pi">${unsafeHTML(this.localize('introduction:16'))}</i>
             ${unsafeHTML(this.localize('introduction:17'))}
@@ -88,16 +92,18 @@ export class SCStaticIntroduction extends SCStaticPage {
           </ul>
           <h2>${unsafeHTML(this.localize('introduction:34'))}</h2>
           <p>
-            <picture>
-              <source srcset="/img/static-pages/dn20.avif" type="image/avif" />
-              <img
-                alt=${this.localize('introduction:35')}
-                class="image-home"
-                src="/img/static-pages/dn20.jpg"
-                title=${this.localize('introduction:36')}
-                width="640px"
-              />
-            </picture>
+            <figure>
+              <picture>
+                <source srcset="/img/static-pages/dn20.avif" type="image/avif" />
+                <img
+                  alt=${this.localize('introduction:35')}
+                  class="image-home"
+                  src="/img/static-pages/dn20.jpg"
+                  width="640px"
+                />
+              </picture>
+              <figcaption>${this.localize('introduction:36')}</figcaption>
+            </figure>
             ${unsafeHTML(this.localize('introduction:37'))}
           </p>
           <p>${unsafeHTML(this.localize('introduction:38'))}</p>

--- a/client/elements/static/sc-static-licensing.js
+++ b/client/elements/static/sc-static-licensing.js
@@ -48,7 +48,6 @@ export class SCStaticLicensing extends SCStaticPage {
               <a
                 href="https://creativecommons.org/licenses/by/3.0/us/"
                 tager="_blank"
-                title="${this.localize('licensing:17')}"
               >
                 Creative Commons Attribution (CC BY 3.0 US)
               </a>

--- a/client/elements/styles/sc-typography-static-styles.js
+++ b/client/elements/styles/sc-typography-static-styles.js
@@ -96,4 +96,15 @@ export const typographyStaticStyles = css`
 
     color: var(--sc-on-primary-primary-text-color);
   }
+
+  figcaption {
+    font-family: var(--sc-sans-font);
+    font-size: var(--sc-font-size-s);
+
+    text-align: center;
+
+    color: var(--sc-on-primary-secondary-text-color);
+    margin-top: -16px;
+    margin-bottom: 32px
+  }
 `;


### PR DESCRIPTION
I have tested the pages I think are affected on my local build.

This whole PR is based on the fact that tooltips are rarely good UX and that translating tooltips into 20+ languages makes no sense. So I removed them from the code where possible.

### What I have left in
* If the title text was computed, I almost always left it in.
* If the title text served any purpose at all I left it in (even if it's not a good solution to the problem since it won't show for screen readers or mobile users) So for example I removed the title on the search icon (it's 2024, people should know what that is) but left it there on the sharing icon (What is that shape anyway?)
* I also left some things there in the parallels and suttaplex card since it looked complicated.

And I am leaving all of the `bilara-data` files untouched until you confirm that you approve these changes. After that is done, I can do a big cleanup of segments that are no longer needed in the localization files.

### What I did

/home/learning/suttacentral/client/elements/addons/sc-top-sheet-views.js
This title is just a duplicate of the option. No point.
![image](https://github.com/suttacentral/suttacentral/assets/82448383/db10b6be-6af7-489f-ade9-2eb5b6f891bf)


```
<option value=${script.script} title=${script.language}>
```

-----------
client/elements/menus/sc-action-items-universal.js
This already seems to not be working. It is the title of the search icon at the very top of every page. It is *not* for the icon in the algolia search.
![image](https://github.com/suttacentral/suttacentral/assets/82448383/e70a646c-2251-4350-b935-6c1595f1e83d)


```
<md-icon-button
        class="button-theme"
        id="search_glass"
        title=${this.localize('search:searchTooltip')}
        @click=${this.openInstantSearchDialog}
      >
```
It will need to be removed from many files, e.g.
```
C:\GitHub\bilara-data\root\en\site\search_root-en-site.json:
   23:   "search:searchTooltip": "Search SuttaCentral",

C:\GitHub\bilara-data\translation\zh\site\search_translation-zh-site.json:
   19:   "search:searchTooltip": "搜索技巧 ",
```

----
/home/learning/suttacentral/client/elements/menus/sc-menu-more.js
This has never been localized.
![image](https://github.com/suttacentral/suttacentral/assets/82448383/6db98bde-0d62-407b-8604-1b4beb80569c)

```
<md-menu-item
        class="more-menu-md-menu-item"
        href=${this.#computeSCVoiceLink()}
        title="Listen to suttas"
        target="_blank"
        rel="noopener noreferrer"
      >
```

**Unresolved**: There is something complicated going on with the key `interface:joinDiscussion`

There is this code that appears to try to make the tooltip into the name of the sutta:
```
  getDiscourseTitle(routeName) {
    const title = routeName === 'sutta' ? 'joinDiscussion' : 'discussSuttas';
    return this.localize(`interface:${title}`);
  }
```

But it doesn't seem to work anywhere. I recommend ripping this out, but I was afraid to do this myself, lol. If we did, it would eliminate the translation segment `interface:joinDiscussion`.

***

/home/learning/suttacentral/client/elements/menus/sc-menu-static-pages-nav.js
This was never localized
![image](https://github.com/suttacentral/suttacentral/assets/82448383/55286284-92ec-4c3d-af3c-4498fac7bcf9)

```
              <a
                href="https://discourse.suttacentral.net/c/meta/updates"
                class="external"
                title="See updates on SuttaCentral forum"
                target="_blank"
                rel="noopener"
              >
```

I can't find where these are used but they clearly are:
```
C:\GitHub\bilara-data\translation\de\site\suttaplex_translation-de-site.json:
   26:   "suttaplex:listenSutta": "Dieses Sutta hören ",
   33:   "suttaplex:shareThisSutta": "Dieses Sutta teilen ",
```

---
/home/learning/suttacentral/client/elements/static/sc-static-introduction.js

I moved the title text into a caption in three places. This is the final outcome:
![image](https://github.com/suttacentral/suttacentral/assets/82448383/adb5081b-08e8-4890-9cd0-d1df4555247e)
![image](https://github.com/suttacentral/suttacentral/assets/82448383/401b3b2c-d401-476e-a414-84597a3a7b9e)
![image](https://github.com/suttacentral/suttacentral/assets/82448383/23999dd0-76a1-402a-b43d-c7ce200e7414)



I also added css for `figcaption`. I realize that negative margins are kind of dodgy, but I didn't know how to style images without captions differently than images with. Note that there is `figcaption` css on the editions pages, but I thought it better to add it into a sheet that was already being called. So I copied it from the editions pages css.

----

/home/learning/suttacentral/client/elements/static/sc-static-licensing.js
There is no need for this 
![image](https://github.com/suttacentral/suttacentral/assets/82448383/f76b8e85-44f6-461b-8416-af9af3147ea4)


It will have to be removed from all the translation files too.
```
  "licensing:17": "Creative Commons license",
```

