### PR TITLE
Enhance: Add a search button to the input field on SERP.

### DIFF
--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -152,7 +152,7 @@ class SCPageSearch extends LitLocalized(LitElement) {
         maxlength="100"
         @keypress=${this.#keypressHandler}
       >
-        <md-icon slot="trailingicon" @click=${this._startSearch}> ${icon.search} </md-icon>
+        <md-icon slot="trailing-icon" @click=${this._startSearch}> ${icon.search} </md-icon>
       </md-filled-text-field>
       ${
         extractSelectedLangsName(

--- a/server/server/search/instant_search.py
+++ b/server/server/search/instant_search.py
@@ -1593,7 +1593,7 @@ def extract_query_conditions(param):
     author = re.search("author:([\w-]+)", param)
     if author:
         result["author"] = author[1].strip()
-    collection = re.search("in:(\w+)", param)
+    collection = re.search("in:([\w-]+)", param)
     if collection:
         result["collection"] = collection[1].strip()
 

--- a/server/server/search/instant_search.py
+++ b/server/server/search/instant_search.py
@@ -25,6 +25,16 @@ RETURN d.uid
 
 LIST_AUTHORS = '''
 FOR a IN author_edition
+FILTER a.uid != 'test'
+
+LET translations = (
+    FOR d IN instant_search
+        SEARCH d.author_uid == a.uid
+        FILTER d.is_segmented == False AND d.author_uid != null
+        LIMIT 1
+    RETURN d.uid
+)
+FILTER length(translations) > 0
 SORT a.uid
 RETURN {
     uid: @query,


### PR DESCRIPTION
1. Enhance: Add a search button to the input field on SERP.
2. Fix: Filter (collection) parameters must be able to include dashes #3038
4. Ehance: When searching using `list authors`, authors with a translation number of 0 are not displayed.