### PR TITLE
I got VSCode Debugging to work on the server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__
 data/segmented_texts
 .vscode/
+.venv/
 *.sqlite3
 .idea
 .cache

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Server",
+      "type": "debugpy",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/server/server",
+      "envFile": "${workspaceFolder}/server/env/.base.env",
+      "env": {
+        "SERVER_ADDRESS": "http://localhost",
+        "ARANGO_HOST": "localhost",
+        "ENVIRONMENT": "development",
+      },
+      "module": "app"
+    }
+  ]
+}


### PR DESCRIPTION
[Screencast from 03-17-2024 03:46:55 PM.webm](https://github.com/suttacentral/suttacentral/assets/61610173/bfb1eb27-d226-414a-94f1-17137f2e7c32)

Setup required:
1. Setting up a python .venv
2. Installing the requirements.txt in the venv
3. Telling vscode to use that interpreter

To run:
1. `make run-dev` like normal to get the db up and running
2. Launch the `Debug Server` command from the attached launch.json

Note that when manually hitting API endpoint, you'll need to omit the `/api/` from the urls and will have to point to `localhost:5000`  When you hit the `localhost:8080` frontend, it will use the docker backend like normal. This is only for debugging backend calls manually.

Let me know what you think @ihongda - is this a reasonable solution?  Does it work on your machine?  I'm happy to add more documentation for the setup if this is something we want to encourage other devs to do as well.