### PR TITLE
Fix: Currency drop down on form on donate-now page drops up and hides behind header.

### DIFF
--- a/client/elements/static/sc-static-donate-now.js
+++ b/client/elements/static/sc-static-donate-now.js
@@ -94,6 +94,7 @@ export class SCStaticDonateNow extends LitLocalized(LitElement) {
         );
         margin-right: 10px;
         min-width: 120px;
+        z-index: 9999;
       }
 
       md-filled-select + md-filled-text-field {


### PR DESCRIPTION
1. Fix: Currency drop down on form on donate-now page drops up and hides behind header.