### PR TITLE
Fix: Currency drop down on form on donate-now page drops up and hides behind header.

### DIFF
--- a/client/elements/static/sc-static-donate-now.js
+++ b/client/elements/static/sc-static-donate-now.js
@@ -94,6 +94,10 @@ export class SCStaticDonateNow extends LitLocalized(LitElement) {
         );
         margin-right: 10px;
         min-width: 120px;
+      }
+
+      md-filled-select::part(menu) {
+        position: relative;
         z-index: 9999;
       }
 


### PR DESCRIPTION
Fix: Currency drop down on form on donate-now page drops up and hides behind header.