### PR TITLE
replace spaces in url Search params with `+` sign

### DIFF
--- a/client/elements/navigation/sc-navigation.js
+++ b/client/elements/navigation/sc-navigation.js
@@ -253,8 +253,8 @@ export class SCNavigation extends LitLocalized(LitElement) {
     document.dispatchEvent(
       new CustomEvent('metadata', {
         detail: {
-          pageTitle: `${this._getTitle()}—navigation`,
-          title: `${this._getTitle()}—navigation`,
+          pageTitle: `${this._getTitle()}—${this.localize('interface:navigationTitle')}`,
+          title: `${this._getTitle()}—${this.localize('interface:navigationTitle')}`,
           description,
         },
       })

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -194,8 +194,9 @@ export class SCPageSearch extends LitLocalized(LitElement) {
   }
 
   _startSearch() {
-    const searchQuery = this.shadowRoot.getElementById('search_input').value;
+    let searchQuery = this.shadowRoot.getElementById('search_input').value;
     if (searchQuery) {
+      searchQuery = searchQuery.replace(' ', '+')
       dispatchCustomEvent(this, 'sc-navigate', { pathname: `/search?query=${searchQuery}`});
       this.searchQuery = searchQuery;
       this.#startNewSearch();

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -196,7 +196,7 @@ export class SCPageSearch extends LitLocalized(LitElement) {
   _startSearch() {
     let searchQuery = this.shadowRoot.getElementById('search_input').value;
     if (searchQuery) {
-      searchQuery = searchQuery.replace(' ', '+')
+      searchQuery = searchQuery.replace(/ /g, '+')
       dispatchCustomEvent(this, 'sc-navigate', { pathname: `/search?query=${searchQuery}`});
       this.searchQuery = searchQuery;
       this.#startNewSearch();

--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -237,7 +237,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
         }, 100);
       }
 
-      const pageTitle = `${title || original_title}—Suttas and Parallels`;
+      const pageTitle = `${title || original_title}—${this.localize('interface:parallelsTitle')}`;
       document.dispatchEvent(
         new CustomEvent('metadata', {
           detail: {

--- a/server/server/search/view.py
+++ b/server/server/search/view.py
@@ -16,7 +16,9 @@ class InstantSearch(Resource):
         lang = request.args.get('language')
         limit = request.args.get('limit', 10)
         offset = request.args.get('offset', 0)
-        query = request.args.get('query', None)
+        query = request.args.get('query', None, type=str)
+        if query:
+            query = query.replace('+', ' ')
         restrict = request.args.get('restrict', None)
         if restrict == 'all':
             restrict = None
@@ -45,7 +47,9 @@ class InstantSearch(Resource):
         lang = request.args.get('language')
         limit = request.args.get('limit', 10)
         offset = request.args.get('offset', 0)
-        query = request.args.get('query', None)
+        query = request.args.get('query', None, type=str)
+        if query:
+            query = query.replace('+', ' ')
         restrict = request.args.get('restrict', None)
         if restrict == 'all':
             restrict = None


### PR DESCRIPTION
I believe this PR will accomplish the following issue: https://github.com/suttacentral/suttacentral/issues/3067

I have tested it on my local version. I honestly can't say how robust this is, but I think it might be fine.

EDIT: I have also added 2 localization segments unrelated to the search urls.

@buddhist-uni , do you have any thoughts?