### PR TITLE
Fix: "Adjacent Terms" on definition page gets cut off/overflows the window.

### DIFF
--- a/client/elements/addons/sc-top-sheet-search-filter.js
+++ b/client/elements/addons/sc-top-sheet-search-filter.js
@@ -108,6 +108,17 @@ export class SCTopSheetSearchFilter extends SCTopSheetCommon {
               </td>
             </tr>
             <tr>
+              <th colspan="2">Reference search</th>
+            </tr>
+            <tr>
+              <td>Find texts using the reference number.</td>
+              <td>
+                ref:PTS 1.1<br>
+                ref:sya13.544<br>
+                ref:vri13.346
+              </td>
+            </tr>
+            <tr>
               <th colspan="2">author search</th>
             </tr>
             <tr>

--- a/client/elements/sc-page-dictionary.js
+++ b/client/elements/sc-page-dictionary.js
@@ -95,7 +95,7 @@ export class SCPageDictionary extends LitLocalized(LitElement) {
 
     .related-terms ul {
       display: flex;
-
+      flex-wrap: wrap;
       gap: 16px;
 
       margin: 0;

--- a/client/elements/static/sc-static-search-filter.js
+++ b/client/elements/static/sc-static-search-filter.js
@@ -94,6 +94,17 @@ export class SCStaticSearchFilter extends SCStaticPage {
               </td>
             </tr>
             <tr>
+              <th colspan="2">Reference search</th>
+            </tr>
+            <tr>
+              <td>Find texts using the reference number.</td>
+              <td>
+                ref:PTS 1.1<br>
+                ref:sya13.544<br>
+                ref:vri13.346
+              </td>
+            </tr>
+            <tr>
               <th colspan="2">author search</th>
             </tr>
             <tr>

--- a/server/server/common/tests/test_ebook_download_link.py
+++ b/server/server/common/tests/test_ebook_download_link.py
@@ -1,14 +1,14 @@
 import requests
 
 download_links_of_collections = [
-  'https://github.com/suttacentral/editions/raw/main/en/sujato/dn/epub/Long-Discourses-sujato-2024-04-15.epub',
-  'https://github.com/suttacentral/editions/raw/main/en/sujato/dn/paperback/Long-Discourses-sujato-2024-04-15.zip',
-  'https://github.com/suttacentral/editions/raw/main/en/sujato/dn/html/Long-Discourses-sujato-2024-04-15.html',
-  'https://github.com/suttacentral/editions/raw/main/en/sujato/dn/paperback/Long-Discourses-sujato-2024-04-15-tex.zip',
+  'https://github.com/suttacentral/editions/raw/main/en/sujato/dn/epub/Long-Discourses-sujato-2024-04-22.epub',
+  'https://github.com/suttacentral/editions/raw/main/en/sujato/dn/paperback/Long-Discourses-sujato-2024-04-22.zip',
+  'https://github.com/suttacentral/editions/raw/main/en/sujato/dn/html/Long-Discourses-sujato-2024-04-22.html',
+  'https://github.com/suttacentral/editions/raw/main/en/sujato/dn/paperback/Long-Discourses-sujato-2024-04-22-tex.zip',
 
-  'https://github.com/suttacentral/editions/raw/main/en/sujato/mn/epub/Middle-Discourses-sujato-2024-04-15.epub',
+  'https://github.com/suttacentral/editions/raw/main/en/sujato/mn/epub/Middle-Discourses-sujato-2024-04-22.epub',
   'https://github.com/suttacentral/editions/raw/main/en/sujato/mn/paperback/Middle-Discourses-sujato-2023-10-30.zip',
-  'https://github.com/suttacentral/editions/raw/main/en/sujato/mn/html/Middle-Discourses-sujato-2024-04-15.html',
+  'https://github.com/suttacentral/editions/raw/main/en/sujato/mn/html/Middle-Discourses-sujato-2024-04-22.html',
   'https://github.com/suttacentral/editions/raw/main/en/sujato/mn/paperback/Middle-Discourses-sujato-2023-10-30-tex.zip',
 
   'https://github.com/suttacentral/editions/raw/main/en/sujato/sn/epub/Linked-Discourses-sujato-2024-04-15.epub',
@@ -36,9 +36,9 @@ download_links_of_collections = [
   'https://github.com/suttacentral/editions/raw/main/en/sujato/iti/html/So-It-Was-Said-sujato-2024-04-15.html',
   'https://github.com/suttacentral/editions/raw/main/en/sujato/iti/paperback/So-It-Was-Said-sujato-2024-04-15-tex.zip',
 
-  'https://github.com/suttacentral/editions/raw/main/en/sujato/snp/epub/Anthology-of-Discourses-sujato-2024-04-15.epub',
+  'https://github.com/suttacentral/editions/raw/main/en/sujato/snp/epub/Anthology-of-Discourses-sujato-2024-04-22.epub',
   'https://github.com/suttacentral/editions/raw/main/en/sujato/snp/paperback/Anthology-of-Discourses-sujato-2023-10-30.zip',
-  'https://github.com/suttacentral/editions/raw/main/en/sujato/snp/html/Anthology-of-Discourses-sujato-2024-04-15.html',
+  'https://github.com/suttacentral/editions/raw/main/en/sujato/snp/html/Anthology-of-Discourses-sujato-2024-04-22.html',
   'https://github.com/suttacentral/editions/raw/main/en/sujato/snp/paperback/Anthology-of-Discourses-sujato-2023-10-30-tex.zip',
 
   'https://github.com/suttacentral/editions/raw/main/en/sujato/thag/epub/Verses-of-the-Senior-Monks-sujato-2024-04-15.epub',


### PR DESCRIPTION
1. Fix: "Adjacent Terms" on definition page gets cut off/overflows the window.
2. Add a description of the `ref:` filter.