### PR TITLE
Fix: Change styling of summary marker to not show in Safari

### DIFF
--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -120,6 +120,10 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
         color: var(--sc-icon-color);
       }
 
+      summary::-webkit-details-marker {
+        display: none;
+      }
+
       label {
         display: block;
         margin-top: 24px;


### PR DESCRIPTION
I believe this change fixes the issue with the summary marker of the details element appearing in Safari.

Safari doesn't yet support the `::marker` pseudo-element.

I added the `-webkit-details-maker`.

Fixes #3145.

I wasn't able to run the project locally, but I tested custom a stylesheet on Safari. Screenshots:

Before:

<img width="830" alt="Screenshot 2024-06-04 at 12 02 17 PM" src="https://github.com/suttacentral/suttacentral/assets/40775995/ed8335a9-3b32-4fa0-b159-41456f61cae5">

After:

<img width="830" alt="Screenshot 2024-06-04 at 12 02 35 PM" src="https://github.com/suttacentral/suttacentral/assets/40775995/3084080a-a16d-4070-b419-3fe3812bb662">
