### PR TITLE
Fix: Unsupported browser page still links to legacy site.

### DIFF
--- a/client/elements/text/sc-text-stepper.js
+++ b/client/elements/text/sc-text-stepper.js
@@ -76,6 +76,10 @@ export class SCTextStepper extends LitLocalized(LitElement) {
       justify-content: flex-end;
     }
 
+    .button-left, .button-right {
+      position: relative;
+    }
+
     .button-right .text-title {
       padding-left: 1em;
     }

--- a/client/index.html
+++ b/client/index.html
@@ -167,11 +167,6 @@
         <h3>IE will not be supported.</h3>
         <hr />
         <div class="margin-md">
-          <a href="https://legacy.suttacentral.net">
-            Proceed to the legacy version of SuttaCentral
-          </a>
-        </div>
-        <div class="margin-md">
           <button class="link" onclick="appendSiteContent()">
             Try using the modern version anyway
           </button>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,13 +8,10 @@
       "name": "suttacentral",
       "version": "2.5.2",
       "dependencies": {
-        "@material/web": "1.5.0",
+        "@material/web": "1.5.1",
         "@micro-sentry/browser": "7.1.0",
         "@orama/orama": "^2.0.21",
-        "@orama/plugin-match-highlight": "^2.0.21",
-        "@orama/stemmers": "^2.0.21",
-        "@orama/stopwords": "^2.0.21",
-        "@stripe/stripe-js": "^4.0.0",
+        "@stripe/stripe-js": "^4.1.0",
         "@webcomponents/webcomponentsjs": "^2.8.0",
         "algoliasearch": "4.24.0",
         "d3-queue": "^3.0.7",
@@ -26,7 +23,6 @@
         "path-to-regexp": "^6.2.2",
         "pwa-helpers": "^0.9.1",
         "redux": "^4.2.1",
-        "turbolinks": "^5.2.0",
         "viewerjs": "^1.11.6",
         "web-animations-js": "^2.3.2",
         "workbox-sw": "7.1.0"
@@ -2803,9 +2799,9 @@
       }
     },
     "node_modules/@material/web": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@material/web/-/web-1.5.0.tgz",
-      "integrity": "sha512-aM2TVCU8Ozh3QS5cckRalmWkNCKK3Y6uhB3skIozP6jIqYX1PDhme/URrHGcWk44k2qqmR7R+X8GEBAu8N/NCQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@material/web/-/web-1.5.1.tgz",
+      "integrity": "sha512-S9iQV1Biq6JhNpAkqXcsFdVrLW0BC1Tez8C36MEQ/VuhT3YLQySbJkUiG+1U+J1jUqlsG8fT5XsEFbhomCY39w==",
       "dependencies": {
         "lit": "^2.7.4 || ^3.0.0",
         "tslib": "^2.4.0"
@@ -2933,30 +2929,6 @@
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-2.0.21.tgz",
       "integrity": "sha512-XZpyjyNw4Mcpg94+gUvxmyyiFTZAdXvJ1aFPqHABarofu86oNwZL5tQUIj84xa1lrQiaeSxNKNBw0w4y5We5Yg==",
-      "engines": {
-        "node": ">= 16.0.0"
-      }
-    },
-    "node_modules/@orama/plugin-match-highlight": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/@orama/plugin-match-highlight/-/plugin-match-highlight-2.0.21.tgz",
-      "integrity": "sha512-KP3kPZdhYI3RZe0tJTpujq2GKeBRa+ACZ1zQYUxPDWfuPcAvgQzbPS5Isp6ht2Nbso2U+DK1jgLDOCSt97mpyg==",
-      "dependencies": {
-        "@orama/orama": "2.0.21"
-      }
-    },
-    "node_modules/@orama/stemmers": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/@orama/stemmers/-/stemmers-2.0.21.tgz",
-      "integrity": "sha512-4v0PzDFqqNjjqNuT3BAFpgzpX0QrJ8AX5QvAlyTbnk9Q2jl+Z79BfaSyPNzcr64jYgM/uA1jN3DrbgEv+Gw4zg==",
-      "engines": {
-        "node": ">= 16.0.0"
-      }
-    },
-    "node_modules/@orama/stopwords": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/@orama/stopwords/-/stopwords-2.0.21.tgz",
-      "integrity": "sha512-WEb624Rp0GARQrQUGAdPaWATB6y2Qaqf+ocdsYnfHrDk6gZ199DJvZIA2e0osufWTDWisGKv6oN3u5H+1jF5kA==",
       "engines": {
         "node": ">= 16.0.0"
       }
@@ -3327,9 +3299,9 @@
       "dev": true
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-4.0.0.tgz",
-      "integrity": "sha512-R5zewuzTVPGn4dXkavbgDk8vSILkT5hRlzga10p6JzngR17qKi1fgc27kl58TmaVvgBZGngTRNH2j9kYdvfPGA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-4.1.0.tgz",
+      "integrity": "sha512-HhstGRUz/4JdbZpb26OcOf8Qb/cFR02arvHvgz4sPFLSnI6ZNHC53Jc6JP/FGNwxtrF719YyUnK0gGy4oyhucQ==",
       "engines": {
         "node": ">=12.16"
       }
@@ -14909,11 +14881,6 @@
       "engines": {
         "node": ">=0.6.x"
       }
-    },
-    "node_modules/turbolinks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/turbolinks/-/turbolinks-5.2.0.tgz",
-      "integrity": "sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -29,13 +29,10 @@
   },
   "dependencies": {
     "algoliasearch": "4.24.0",
-    "@material/web": "1.5.0",
+    "@material/web": "1.5.1",
     "@micro-sentry/browser": "7.1.0",
     "@orama/orama": "^2.0.21",
-    "@orama/stemmers": "^2.0.21",
-    "@orama/stopwords": "^2.0.21",
-    "@orama/plugin-match-highlight": "^2.0.21",
-    "@stripe/stripe-js": "^4.0.0",
+    "@stripe/stripe-js": "^4.1.0",
     "@webcomponents/webcomponentsjs": "^2.8.0",
     "element-internals-polyfill": "^1.3.11",
     "d3-queue": "^3.0.7",
@@ -46,7 +43,6 @@
     "path-to-regexp": "^6.2.2",
     "pwa-helpers": "^0.9.1",
     "redux": "^4.2.1",
-    "turbolinks": "^5.2.0",
     "viewerjs": "^1.11.6",
     "web-animations-js": "^2.3.2",
     "workbox-sw": "7.1.0"


### PR DESCRIPTION
1. Fix: Unsupported browser page still links to legacy site.
2. Upgrade frontend dependencies and remove unnecessary packages.
3. Fixed the issue that the ripple range of the next previous button is incorrect.