### PR TITLE
make noai version

### DIFF
--- a/client/elements/addons/sc-site-footer.js
+++ b/client/elements/addons/sc-site-footer.js
@@ -144,11 +144,6 @@ export class ScSiteFooter extends LitLocalized(LitElement) {
                 >
               </li>
               <li>
-                <a class="block-link" href="https://buddhanexus.net"
-                  >${this.localize('footer:buddhaNexus')}</a
-                >
-              </li>
-              <li>
                 <a class="block-link" href="https://readingfaithfully.org/"
                   >${this.localize('footer:readingfaithfully')}</a
                 >
@@ -177,6 +172,14 @@ export class ScSiteFooter extends LitLocalized(LitElement) {
               <a class="block-link" href="/licensing">${this.localize('footer:licensing')}</a>
             </li>
             <li><a class="block-link" href="/About">${this.localize('footer:about')}</a></li>
+          </ul>
+        </section>
+        <section class="footer-bottom">
+          <ul>
+            <li>
+            <b>By humans, for humans</b><br>
+            All work on this website was created by humans, not by AI. 
+            </li>
           </ul>
         </section>
       </footer>

--- a/client/elements/static/sc-static-home.js
+++ b/client/elements/static/sc-static-home.js
@@ -239,24 +239,29 @@ export class SCStaticHomePage extends SCStaticPage {
     `;
   }
 
-  #buddhaNexusCardTemplate() {
+  #readingFaithfullyCardTemplate() {
     return html`
       <article class="card secondary-accent">
-        <a href="https://buddhanexus.net/" class="block-link">
+        <a href="https://readingfaithfully.org/" class="block-link">
           <header>
             <span>
               <picture>
-                <source srcset="/img/home-page/buddhanexus_logo.avif" type="image/avif" />
-                <img src="/img/home-page/buddhanexus_logo.png" alt="Buddhanexus logo" />
+                <source srcset="/img/home-page/reading-faithfully_logo-300.avif" type="image/avif" />
+                <img src="/img/home-page/reading-faithfully_logo-300.png" alt="Buddhanexus logo" />
               </picture>
             </span>
             <h3>
-              <span>BuddhaNexus</span>
-              <span class="sc-related-item-subtitle">${unsafeHTML(this.localize('home:22'))}</span>
+              <span>Reading Faithfully</span>
+              <span class="sc-related-item-subtitle">Devotional and Contemplative Sutta Reading</span>
             </h3>
           </header>
           <div class="related-projects-content">
-            <p>${unsafeHTML(this.localize('home:23'))}</p>
+            <p>Lovingly and expertly crafted to guide a Buddhist devotee into a deeper personal relationship with the Dhamma through the practice of reading the Buddha’s words. </p>
+            <ul>
+              <li>How to mindfully develop a sutta reading practice</li>
+              <li>Daily sutta readings</li>
+              <li>Full of helpful advice and tools</li>
+            </ul>
           </div>
         </a>
         <md-ripple></md-ripple>
@@ -427,7 +432,7 @@ export class SCStaticHomePage extends SCStaticPage {
         <section class="sc-related">
           <div class="related-projects-heading">${this.#relatedProjectsHeaderTemplate()}</div>
           <div class="sc-related-items-wrapper">
-            ${this.#scVoiceCardTemplate()} ${this.#buddhaNexusCardTemplate()}
+            ${this.#scVoiceCardTemplate()} ${this.#readingFaithfullyCardTemplate()}
             ${this.#scForumCardTemplate()} ${this.#bilaraCardTemplate()}
           </div>
         </section>

--- a/client/elements/static/sc-static-licensing.js
+++ b/client/elements/static/sc-static-licensing.js
@@ -59,11 +59,12 @@ export class SCStaticLicensing extends SCStaticPage {
                 <li>${unsafeHTML(this.localize('licensing:21'))}</li>
               </ul>
             </li>
-            <li>${unsafeHTML(this.localize('licensing:22'))}</li>
           </ul>
           <h3>${unsafeHTML(this.localize('licensing:23'))}</h3>
           <p>${unsafeHTML(this.localize('licensing:24'))}</p>
           <p>${unsafeHTML(this.localize('licensing:25'))}</p>
+          <h3>AI</h3>
+          <p>SuttaCentral does not make use of artifically-generated data. We politely request that our content not be scraped or used in any way for the creation of datasets for generative AI or similar. This request applies to those who create applications directly, and those who build apps downstream of AI models that have scraped SuttaCentral’s data. </p>
         </article>
       </main>
     `;

--- a/client/elements/static/sc-static-pali-tipitaka.js
+++ b/client/elements/static/sc-static-pali-tipitaka.js
@@ -306,55 +306,55 @@ export class SCStaticPaliTipitaka extends SCStaticPage {
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd2">
-                                <root>Uposathakkhandhaka</root>
+                                <root>Uposathak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('mahavagga:uposathakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd3">
-                                <root>Vassūpanāyikakkhandhaka</root>
+                                <root>Vassūpanāyikak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('mahavagga:vassupanayikakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd4">
-                                <root>Pavāraṇākkhandhaka</root>
+                                <root>Pavāraṇāk­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('mahavagga:pavaranakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd5">
-                                <root>Cammakkhandhaka</root>
+                                <root>Cammak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('mahavagga:cammakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd6">
-                                <root>Bhesajjakkhandhaka</root>
+                                <root>Bhesajjak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('mahavagga:bhesajjakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd7">
-                                <root>Kathinakkhandhaka</root>
+                                <root>Kathinak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('mahavagga:kathinakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd8">
-                                <root>Cīvarakkhandhaka</root>
+                                <root>Cīvarak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('mahavagga:civarakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd9">
-                                <root>Campeyyakkhandhaka</root>
+                                <root>Campeyyak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('mahavagga:campeyyakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd10">
-                                <root>Kosambakakkhandhaka</root>
+                                <root>Kosambakak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('mahavagga:kosambakakkhandhaka'))}</translation>
                               </a>
                             </li>
@@ -368,73 +368,73 @@ export class SCStaticPaliTipitaka extends SCStaticPage {
                           <ul class="vertical fifth">
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd11">
-                                <root>Kammakkhandhaka</root>
+                                <root>Kammak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:kammakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd12">
-                                <root>Pārivāsikakkhandhaka</root>
+                                <root>Pārivāsikak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:parivasikakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd13">
-                                <root>Samuccayakkhandhaka</root>
+                                <root>Samuccayak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:samuccayakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd14">
-                                <root>Samathakkhandhaka</root>
+                                <root>Samathak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:samathakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd15">
-                                <root>Khuddakavatthukkhandhaka</root>
+                                <root>Khuddakavatthuk­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:khuddakavatthukkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd16">
-                                <root>Senāsanakkhandhaka</root>
+                                <root>Senāsanak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:senasanakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd17">
-                                <root>Saṁghabhedakakkhandhaka</root>
+                                <root>Saṁghabhedakak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:samghabhedakakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd18">
-                                <root>Vattakkhandhaka</root>
+                                <root>Vattak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:vattakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd19">
-                                <root>Pātimokkhaṭṭhapanakkhandhaka</root>
+                                <root>Pātimokkhaṭṭhapanak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:patimokkhatthapanakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd20">
-                                <root>Bhikkhunikkhandhaka</root>
+                                <root>Bhikkhunik­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:bhikkhunikkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd21">
-                                <root>Pañcasatikakkhandhaka</root>
+                                <root>Pañcasatikak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:pancasatikakkhandhaka'))}</translation>
                               </a>
                             </li>
                             <li>
                               <a href="https://suttacentral.net/pli-tv-kd22">
-                                <root>Sattasatikakkhandhaka</root>
+                                <root>Sattasatikak­khandhaka</root>
                                 <translation>${unsafeHTML(this.localize('culavagga:sattasatikakkhandhaka'))}</translation>
                               </a>
                             </li>
@@ -970,7 +970,7 @@ export class SCStaticPaliTipitaka extends SCStaticPage {
                           </ul>
                         </li>
                         <li>
-                          <a href="https://suttacentral.net/sn-salayatanavaggasamyutta">
+                          <a href="https://suttacentral.net/sn-salayatanavaggasamyutta" style="height:5.2rem">
                             <root>Saḷāyatanavaggasaṁyutta</root>
                             <translation>${unsafeHTML(this.localize('samyuttanikaya:salayatanavaggasamyutta'))}</translation>
                           </a>

--- a/client/index.html
+++ b/client/index.html
@@ -46,6 +46,9 @@
     />
     <meta name="twitter:image:alt" content="SuttaCentral" />
 
+    <!-- AI -->
+    <meta name="robots" content="noai, noimageai">
+
     <!-- Open Graph general (Facebook, Pinterest & Google+) -->
     <meta property="og:title" content="SuttaCentral" />
     <meta


### PR DESCRIPTION
This update clarifies that we do not use AI content, and adds `noai` meta tag. (Also fixes display bugs on Pali Tipitaka overview). 

Updated pages require localization. 