### PR TITLE
Only one tab to focus on newly opened panels

### DIFF
--- a/client/elements/menus/sc-action-items.js
+++ b/client/elements/menus/sc-action-items.js
@@ -336,12 +336,16 @@ export class SCActionItems extends LitLocalized(LitElement) {
 
   #showSuttaInfo() {
     const isSegmentedText = !this.suttaMetaText;
+    let infoPanel = null;
     if (isSegmentedText) {
-      this.scSiteLayout.querySelector('#bilara-sutta-info').show?.();
+      infoPanel = this.scSiteLayout.querySelector('#bilara-sutta-info');
     } else {
-      this.scSiteLayout.querySelector('#sutta-info').show?.();
+      infoPanel = this.scSiteLayout.querySelector('#sutta-info');
     }
+    infoPanel.show?.();
     this.shadowRoot.querySelector('#btnInfo')?.classList.add(this.activeClass);
+    infoPanel.setAttribute?.("tabindex", "0");
+    infoPanel.focus?.();
   }
 
   #onBtnViewCompactClick(e) {
@@ -428,8 +432,11 @@ export class SCActionItems extends LitLocalized(LitElement) {
   }
 
   #showSettingMenu() {
-    this.scSiteLayout.querySelector('#setting_menu')?.show?.();
+    const settingMenu = this.scSiteLayout.querySelector('#setting_menu');
+    settingMenu.show?.();
     this.shadowRoot.querySelector('#btnTools')?.classList.add(this.activeClass);
+    settingMenu.setAttribute?.("tabindex", "0");
+    settingMenu.focus?.();
   }
 
   #hideSuttaParallels() {
@@ -468,13 +475,20 @@ export class SCActionItems extends LitLocalized(LitElement) {
   }
 
   #showSuttaParallels() {
-    this.scSiteLayout.querySelector('#sutta_parallels')?.show?.();
+    const parallelsPanel = this.scSiteLayout.querySelector('#sutta_parallels');
+    parallelsPanel.show?.();
     this.shadowRoot.querySelector('#btnShowParallels')?.classList.add(this.activeClass);
+    parallelsPanel.setAttribute?.("tabindex", "0");
+    parallelsPanel.focus?.();
   }
 
   #showSuttaToC() {
-    this.scSiteLayout.querySelector('#sutta_toc')?.show?.();
+    const suttaToC = this.scSiteLayout.querySelector('#sutta_toc');
+    if (!suttaToC) return false;
+    suttaToC.show();
     this.shadowRoot.querySelector('#btnShowToC')?.classList.add(this.activeClass);
+    suttaToC.setAttribute("tabindex", "0");
+    suttaToC.focus();
   }
 
   #onBtnShowParallelsClick() {

--- a/client/elements/menus/sc-action-items.js
+++ b/client/elements/menus/sc-action-items.js
@@ -433,10 +433,12 @@ export class SCActionItems extends LitLocalized(LitElement) {
 
   #showSettingMenu() {
     const settingMenu = this.scSiteLayout.querySelector('#setting_menu');
-    settingMenu.show?.();
+    if (!settingMenu) return;
+    settingMenu.show();
     this.shadowRoot.querySelector('#btnTools')?.classList.add(this.activeClass);
-    settingMenu.setAttribute?.("tabindex", "0");
-    settingMenu.focus?.();
+    const horizontalMenu = settingMenu.shadowRoot.firstElementChild;
+    horizontalMenu.setAttribute("tabindex", "0");
+    horizontalMenu.focus();
   }
 
   #hideSuttaParallels() {


### PR DESCRIPTION
Fixes #3255 (and compliments #3271)

Unfortunately, the panel itself isn't focusable. I could focus on the first child within the panel that is focusable, but unfortunely that is sometimes "below the fold", causing the i.e. Info panel to scroll down.

The solution here is to instead immediately focus on the last of the action buttons so that one hit of the tab key will always focus on the next focusable element within the panel.

cc @ihongda and @thesunshade