### PR TITLE
Remove !important from main style tags

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -111,9 +111,9 @@
       }
 
       button {
-        background: none !important;
+        background: none;
         border: none;
-        padding: 0 !important;
+        padding: 0 ;
         color: rgba(206, 132, 0, 1);
         font-family: 'Skolar Sans PE', 'Noto Sans', sans-serif;
         cursor: pointer;


### PR DESCRIPTION
@ihongda, I'm doing this at the request of Ven. P who is working on the browser extension. They say that these `!important` tags are making it hard to do styling.

I have played around and I can't see that these definitions do anything at all on the site. So I'm going to guess that it's ok to remove the `!important`s.

That's all this PR does.