### PR TITLE
Improve SCBadge visibility handling, remove unexpected refreshes on search page.

### DIFF
--- a/client/elements/addons/sc-badge.js
+++ b/client/elements/addons/sc-badge.js
@@ -7,6 +7,7 @@ export class SCBadge extends LitLocalized(LitElement) {
     text: { type: String },
     color: { type: String },
     background: { type: String },
+    visible: { type: String },
   };
 
   constructor() {
@@ -15,6 +16,7 @@ export class SCBadge extends LitLocalized(LitElement) {
     this.text = '';
     this.color = 'primary';
     this.background = '';
+    this.visible = 'true';
   }
 
   static styles = css`
@@ -75,6 +77,10 @@ export class SCBadge extends LitLocalized(LitElement) {
     :host([text='annotated']):before {
       content: '✓ ';
       color: var(--sc-primary-accent-color);
+    }
+
+    :host([visible='false']) {
+      display: none;
     }
   `;
 

--- a/client/elements/navigation/sc-navigation-linden-leaves.js
+++ b/client/elements/navigation/sc-navigation-linden-leaves.js
@@ -187,6 +187,11 @@ export class SCNavigationLindenLeaves extends LitLocalized(LitElement) {
     ul li:first-child {
       display: none;
     }
+
+    .last-leaves {
+      margin-left: 10px;
+      margin-right: 10px;
+    }
   `;
 
   static properties = {
@@ -250,13 +255,19 @@ export class SCNavigationLindenLeaves extends LitLocalized(LitElement) {
           (nav, i) => html`
             ${nav?.title &&
             html`
-              <li @click=${() => this._navClick(nav)}>
-                <a class="nav-link" data-uid=${nav.uid} href=${nav.url}>
-                  ${this.tryLocalize(`interface:${nav.title.toLowerCase()}`, nav.title)}
-                  <md-ripple></md-ripple>
-                </a>
-                ${i < length - 1 ? icon.chevron_right : ''}
-              </li>
+              ${i < length - 1 ? html`
+                <li @click=${() => this._navClick(nav)}>
+                  <a class="nav-link" data-uid=${nav.uid} href=${nav.url}>
+                    ${this.tryLocalize(`interface:${nav.title.toLowerCase()}`, nav.title)}
+                    <md-ripple></md-ripple>
+                  </a>
+                  ${i < length - 1 ? icon.chevron_right : ''}
+                </li>
+              ` : html`
+                <li>
+                  <p class="last-leaves">${this.tryLocalize(`interface:${nav.title.toLowerCase()}`, nav.title)}</p>
+                </li>
+              `}
             `}
           `
         )}

--- a/client/elements/publication/sc-publication-edition.js
+++ b/client/elements/publication/sc-publication-edition.js
@@ -292,18 +292,8 @@ export class SCPublicationEdition extends LitLocalized(LitElement) {
     return html`
       <h2>This translation</h2>
       <p>
-        This translation was part of a project to translate the four Pali Nikāyas with the following
-        aims:
+        ${this.editionInfo.publication?.text_description}
       </p>
-      <ul>
-        <li>plain, approachable English;</li>
-        <li>consistent terminology;</li>
-        <li>accurate rendition of the Pali;</li>
-        <li>free of copyright.</li>
-      </ul>
-      ${this.editionUid === 'pli-tv-vi' ? '' : html`
-        <p>It was made during 2016–2018 while Bhikkhu Sujato was staying in Qimei, Taiwan.</p>
-      `}
     `;
   }
 

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -402,7 +402,7 @@ export class SCPageSearch extends LitLocalized(LitElement) {
     const RootLang = this.expansionReturns[0][item.root_lang]?.[1];
     return html`
       <a><sc-badge text="Root language: ${RootLang || item.root_lang}" color="gray"></sc-badge></a>
-      <a><sc-badge text=${badgeText} color="gray"></sc-badge></a>
+      <a><sc-badge text=${badgeText} color="gray" visible=${item.is_root ? 'false' : 'true'}></sc-badge></a>
     `;
   }
 
@@ -774,7 +774,7 @@ export class SCPageSearch extends LitLocalized(LitElement) {
     if (this.searchParams !== state.searchParams) {
       this.searchParams = state.searchParams;
     }
-    if (this.displayedLanguages !== state.displayedLanguages) {
+    if (this.displayedLanguages !== state.searchOptions.displayedLanguages) {
       this.displayedLanguages = state.searchOptions.displayedLanguages;
       this.requestUpdate();
     }

--- a/client/elements/sc-site-layout.js
+++ b/client/elements/sc-site-layout.js
@@ -19,6 +19,8 @@ import { getURLParam } from './addons/sc-functions-miscellaneous';
 import { reduxActions } from './addons/sc-redux-actions';
 import { API_ROOT } from '../constants';
 
+import { typographyI18nStyles } from './styles/sc-typography-i18n-styles';
+
 const microSentryClient = new BrowserMicroSentryClient({
   dsn: 'https://c7d8c1d86423434b8965874d954ba735@sentry.io/358981',
 });
@@ -118,6 +120,7 @@ export class SCSiteLayout extends LitLocalized(LitElement) {
     return html`
       <style>
         ${SCSiteLayoutStyles}
+        ${typographyI18nStyles}
       </style>
 
       <div id="universal_toolbar">

--- a/client/elements/styles/sc-publication-styles.js
+++ b/client/elements/styles/sc-publication-styles.js
@@ -79,7 +79,7 @@ export const SCPublicationStyles = css`
 
     vertical-align: middle;
 
-    min-inline-size: max-content;
+    min-inline-size: -webkit-max-content;
   }
 
   table a .icon {

--- a/client/elements/styles/sc-typography-i18n-styles.js
+++ b/client/elements/styles/sc-typography-i18n-styles.js
@@ -144,4 +144,8 @@ export const typographyI18nStyles = css`
 
     overflow-wrap: break-word;
   }
+
+  [lang='ko'] * {
+    font-synthesis: none;
+  }
 `;


### PR DESCRIPTION
Fix: alignment problems on Editions page in Safari #3293
Fix: font styling does not work well for some languages #3240
Fix: final item of breadcrumbs should always be plain text #3235
Fix: publications pulls wrong data for Vinaya #3232
Fix: a problem where navigation links on the search page refresh unexpectedly.
In the search results, if it is the root text, the `aligned` badge is not displayed.

## Summary by Sourcery

Fix multiple UI and data retrieval issues, enhance SCBadge visibility handling, and refine breadcrumb navigation display.

Bug Fixes:
- Fix alignment issues on the Editions page in Safari.
- Correct font styling for certain languages.
- Ensure the final item of breadcrumbs is always plain text.
- Resolve incorrect data retrieval for Vinaya publications.
- Prevent unexpected refreshes of navigation links on the search page.

Enhancements:
- Improve visibility handling of SCBadge by adding a 'visible' attribute.
- Refine navigation breadcrumb display to ensure the last item is plain text.