### PR TITLE
change hardcoded white to var(--sc-inverted-text-color)

### DIFF
--- a/client/elements/addons/sc-bottom-sheet.js
+++ b/client/elements/addons/sc-bottom-sheet.js
@@ -224,7 +224,7 @@ export class SCBottomSheet extends LitLocalized(LitElement) {
       color: rgb(34, 33, 32);
       background-color: var(--sc-primary-color-light);
 
-      text-decoration-color: white;
+      text-decoration-color: var(--sc-inverted-text-color);
       text-decoration-thickness: 0.15em;
       text-underline-offset: 0.15em;
 
@@ -234,7 +234,7 @@ export class SCBottomSheet extends LitLocalized(LitElement) {
     .entry a:hover {
       background-color: var(--sc-primary-accent-color-light);
 
-      text-decoration-color: white;
+      text-decoration-color: var(--sc-inverted-text-color);
       text-decoration-thickness: 0.15em;
       text-underline-offset: 0.15em;
     }

--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -187,8 +187,8 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
       
       kbd {
         padding: 3px 6px 2px;
-        background-color: gray;
-        color: white;
+        background-color: var(--sc-icon-color);
+        color: var(--sc-inverted-text-color);
         border-radius: 3px;
         margin: 5px;
       }

--- a/client/elements/menus/sc-menu-language-base-css.js
+++ b/client/elements/menus/sc-menu-language-base-css.js
@@ -39,7 +39,7 @@ export const languageBaseMenuCss = css`
     letter-spacing: 0.5px;
     text-transform: uppercase;
 
-    color: white;
+    color: var(--sc-inverted-text-color);
     background-color: var(--sc-icon-color);
 
     --notchSize: 4px;

--- a/client/elements/navigation/sc-navigation-linden-leaves.js
+++ b/client/elements/navigation/sc-navigation-linden-leaves.js
@@ -94,7 +94,7 @@ export class SCNavigationLindenLeaves extends LitLocalized(LitElement) {
 
       white-space: nowrap;
 
-      color: white;
+      color: var(--sc-inverted-text-color);
 
       align-items: center;
     }
@@ -110,7 +110,7 @@ export class SCNavigationLindenLeaves extends LitLocalized(LitElement) {
       text-decoration: none;
 
       opacity: 0.8;
-      color: white;
+      color: var(--sc-inverted-text-color);
       border-radius: 16px;
 
       align-items: center;
@@ -135,7 +135,7 @@ export class SCNavigationLindenLeaves extends LitLocalized(LitElement) {
     li:last-child a:hover {
       cursor: default;
 
-      color: white;
+      color: var(--sc-inverted-text-color);
       border-bottom: none;
     }
 

--- a/client/elements/navigation/sc-navigation-styles.js
+++ b/client/elements/navigation/sc-navigation-styles.js
@@ -157,7 +157,7 @@ export const navigationNormalModeStyles = html`
     .show-root-language::before {
       content: attr(lang);
       background-color: var(--sc-icon-color);
-      color: white;
+      color: var(--sc-inverted-text-color);
       font-weight: 800;
       font-stretch: condensed;
       padding: 0 4px 1px 4px;
@@ -202,7 +202,7 @@ export const navigationNormalModeStyles = html`
       padding: 0 8px 0 4px;
       box-sizing: border-box;
 
-      color: white;
+      color: var(--sc-inverted-text-color);
       background-color: var(--sc-primary-color-dark);
 
       justify-content: center;

--- a/client/elements/static/sc-static-donations.js
+++ b/client/elements/static/sc-static-donations.js
@@ -33,7 +33,7 @@ export class SCStaticDonations extends SCStaticPage {
         }
 
         .link-button {
-          color: white;
+          color: var(--sc-inverted-text-color);
           border: none;
           background-color: var(--sc-primary-accent-color);
         }

--- a/client/elements/static/sc-static-pirivenas-project.js
+++ b/client/elements/static/sc-static-pirivenas-project.js
@@ -19,7 +19,7 @@ export class SCStaticPirivenasProject extends SCStaticPage {
     return html`
       <style>
         .link-button {
-          color: white;
+          color: var(--sc-inverted-text-color);
           border: none;
           background-color: var(--sc-primary-accent-color);
         }

--- a/client/elements/styles/sc-menu-static-pages-nav-styles.js
+++ b/client/elements/styles/sc-menu-static-pages-nav-styles.js
@@ -78,7 +78,7 @@ export const SCMenuStaticPagesNavStyles = css`
     text-decoration: none;
 
     opacity: 0.8;
-    color: white;
+    color: var(--sc-inverted-text-color);
     border-radius: var(--sc-big-border-radius);
     text-shadow: 0 0 1px rgba(0, 0, 0, 0.1);
 
@@ -90,7 +90,7 @@ export const SCMenuStaticPagesNavStyles = css`
     transition: var(--sc-link-transition);
 
     opacity: 1;
-    color: white;
+    color: var(--sc-inverted-text-color);
     background-color: var(--sc-primary-color-light-transparent);
   }
 

--- a/client/elements/styles/sc-static-home-styles.js
+++ b/client/elements/styles/sc-static-home-styles.js
@@ -241,7 +241,7 @@ export const staticHomeStyles = css`
     text-align: right;
     letter-spacing: 0.5px;
 
-    color: white;
+    color: var(--sc-inverted-text-color);
     background-color: rgba(0, 0, 0, 0.5);
 
     backdrop-filter: blur(2px);
@@ -382,7 +382,7 @@ export const staticHomeStyles = css`
     height: 80px;
     padding: 1rem;
 
-    color: white;
+    color: var(--sc-inverted-text-color);
 
     justify-content: space-between;
   }


### PR DESCRIPTION
I'm assuming they were coded to white in haste at some point after all the color variables were set.

This does not solve any existing problems, but the change would make it possible for a greater variety of custom themes.

I have tested these on my local build.

ALSO: It changes the hard coded `<kbd>` color from `gray` to `var(--sc-icon-color)`