### PR TITLE
Enhance: Vinaya parallels improvements #3244

### DIFF
--- a/client/elements/suttaplex/card/sc-parallel-item.js
+++ b/client/elements/suttaplex/card/sc-parallel-item.js
@@ -37,10 +37,23 @@ export class SCParallelItem extends LitLocalized(LitElement) {
     };
   }
 
+  firstUpdated() {
+    this.updateLanguageNames();
+  }
+
+  updateLanguageNames() {
+    if (this.expansionData[0].lzh && this.expansionData[0].lzh[1] === "Literary Chinese") {
+      this.expansionData[0].lzh[1] = "Chinese";
+    }
+    if (this.expansionData[0].xct && this.expansionData[0].xct[1] === "Classical Tibetan") {
+      this.expansionData[0].xct[1] = "Tibetan";
+    }
+  }
+
   get heading() {
     const uidLanguage = this.parallelItem?.uid?.substring(0, 3);
     if (Object.keys(this.rootLangMappings).includes(uidLanguage)) {
-      return transformId(this.parallelItem.to, this.expansionData, 1);
+      return (this.parallelItem.translated_title || this.parallelItem.original_title);
     }
     if (this.parallelItem.translated_title) {
       return this.parallelItem.translated_title;
@@ -49,6 +62,14 @@ export class SCParallelItem extends LitLocalized(LitElement) {
       return this.parallelItem.original_title;
     }
     return this.acronymOrUid;
+  }
+
+  get itemFullLanguage() {
+    const uidLanguage = this.parallelItem?.uid?.substring(0, 3);
+    if (Object.keys(this.rootLangMappings).includes(uidLanguage)) {
+      return this.rootLangMappings[uidLanguage];
+    }
+    return '';
   }
 
   get headingTitle() {
@@ -111,7 +132,6 @@ export class SCParallelItem extends LitLocalized(LitElement) {
       return `${scAcronym}${idPart}`;
     }
     scAcronym = transformId(this.parallelItem.to, this.expansionData, 0);
-
     return scAcronym;
   }
 
@@ -193,6 +213,13 @@ export class SCParallelItem extends LitLocalized(LitElement) {
                     </div>
                   `
                 : ''}
+              ${Object.keys(this.rootLangMappings).includes(this.parallelItem?.uid?.substring(0, 3))
+              ? html`
+                  <div class="nerdy-row-element" title=${this.itemFullLanguage}>
+                    ${this.itemFullLanguage}
+                  </div>
+                `
+              : ''}
               ${this.volpagesAvailable
                 ? html`
                     <div

--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -113,7 +113,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
   }
 
   isSuttaplex(item) {
-    return item.type === 'leaf';
+    return item.type === 'leaf' || item.type === 'root';
   }
 
   isPatimokkha() {

--- a/server/server/api/views/views.py
+++ b/server/server/api/views/views.py
@@ -725,7 +725,21 @@ class Parallels(Resource):
         for entry in data:
             data[entry] = sorted(data[entry], key=sort_parallels_type_key)
 
+        if self.is_vinaya(uid):
+            for entry in data:
+                data[entry] = sorted(data[entry], key=self.sort_by_root_lang)
+            print(data)
+
         return data, 200
+
+    def sort_by_root_lang(self, item):
+        return 0 if item['to']['root_lang'] == 'pli' else 1
+
+    def is_vinaya(self, uid):
+        db = get_db()
+        uid = re.sub(r'\d+$', '', uid)
+        full_path = db.aql.execute(SUTTA_PATH, bind_vars={'uid': uid}).next()
+        return '/pitaka/vinaya' in full_path['full_path']
 
 
 class ParallelsLite(Resource):


### PR DESCRIPTION
## Summary by Sourcery

Enhance the Vinaya parallels feature by improving language name handling and adding a custom sorting mechanism for Vinaya parallels based on root language. Update the UI to display full language names when available.

Enhancements:
- Improve language name handling by updating 'Literary Chinese' to 'Chinese' and 'Classical Tibetan' to 'Tibetan' in the expansion data.
- Add a method to determine the full language name based on the UID language mapping.
- Enhance the sorting of Vinaya parallels by implementing a custom sort function based on root language.
- Sort Pali entries at the top of Vinaya parallels.
- Display titles, vol-page, and other information in Vinaya parallels just as in Sutta parallels.