### PR TITLE
Fix: URLs not behaving as 'expected' .

### DIFF
--- a/client/elements/styles/sc-publication-styles.js
+++ b/client/elements/styles/sc-publication-styles.js
@@ -78,8 +78,6 @@ export const SCPublicationStyles = css`
     margin-right: 8px;
 
     vertical-align: middle;
-
-    min-inline-size: -webkit-max-content;
   }
 
   table a .icon {

--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -13,6 +13,7 @@ import '../addons/sc-error-icon';
 import { RefreshNavNew, setNavigation } from '../navigation/sc-navigation-common';
 import { transformId, getParagraphRange } from '../../utils/suttaplex';
 import '@material/web/button/filled-button';
+import { dispatchCustomEvent } from '../../utils/customEvent';
 
 class SCSuttaplexList extends LitLocalized(LitElement) {
   static properties = {
@@ -541,8 +542,21 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
   }
 
   firstUpdated() {
+    this._correctAndRedirectRootURL();
     this.scActionItems = document.querySelector('sc-site-layout').querySelector('#action_items');
     this.scActionItems?.hideSpeakerButton();
+  }
+
+  _correctAndRedirectRootURL() {
+    ['sutta', 'vinaya', 'abhidhamma'].forEach(this._redirectToPitaka.bind(this));
+  }
+  
+  _redirectToPitaka(section) {
+    const currentUrl = window.location.href;
+    if (currentUrl.includes(`/${section}`) && !currentUrl.includes('/pitaka')) {
+      const link = currentUrl.replace(`/${section}`, `/pitaka/${section}`);
+      dispatchCustomEvent(this, 'sc-navigate', { pathname: link });
+    }
   }
 }
 


### PR DESCRIPTION
1. URLs not behaving as 'expected' #3310
2. Alignment problems on Editions page in Safari #3293

## Summary by Sourcery

Fix URL redirection issues by adding a method to correct and redirect root URLs for specific sections, and resolve alignment problems on the Editions page in Safari by adjusting CSS styles.

Bug Fixes:
- Fix URL redirection issues by ensuring URLs for 'sutta', 'vinaya', and 'abhidhamma' sections include '/pitaka' in the path.
- Resolve alignment problems on the Editions page in Safari by removing the 'min-inline-size' CSS property.