### PR TITLE
Enhance: Add prev/next to bare suttaplex cards.

### DIFF
--- a/client/elements/styles/sc-publication-styles.js
+++ b/client/elements/styles/sc-publication-styles.js
@@ -78,6 +78,8 @@ export const SCPublicationStyles = css`
     margin-right: 8px;
 
     vertical-align: middle;
+
+    min-width: max-content;
   }
 
   table a .icon {

--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -14,6 +14,7 @@ import { RefreshNavNew, setNavigation } from '../navigation/sc-navigation-common
 import { transformId, getParagraphRange } from '../../utils/suttaplex';
 import '@material/web/button/filled-button';
 import { dispatchCustomEvent } from '../../utils/customEvent';
+import './sc-suttaplex-stepper.js';
 
 class SCSuttaplexList extends LitLocalized(LitElement) {
   static properties = {
@@ -196,6 +197,8 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
         this.rangeCategoryId = responseData[0].uid;
       }
       this.priorityAuthorUid = responseData[0].priority_author_uid;
+      this.previous = responseData[0].previous;
+      this.next = responseData[0].next;
       this.suttaplexData = [];
       partitionAsync(
         responseData,
@@ -538,6 +541,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
           ? this.tableViewTemplate(this.parallelsLite)
           : this.normalViewTemplate()
       )}
+      ${this.displayStepper}
     `;
   }
 
@@ -557,6 +561,25 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
       const link = currentUrl.replace(`/${section}`, `/pitaka/${section}`);
       dispatchCustomEvent(this, 'sc-navigate', { pathname: link });
     }
+  }
+
+  _shouldDisplayStepper() {
+    if (!this.suttaplexData) {
+      return false;
+    }
+    return this.suttaplexData.length === 1 && (this.next || this.previous);
+  }
+
+  get displayStepper() {
+    return this._shouldDisplayStepper()
+      ? html`
+          <sc-suttaplex-stepper
+            .next=${this.next}
+            .previous=${this.previous}
+            .lang=${this.langIsoCode}
+          ></sc-suttaplex-stepper>
+        `
+      : '';
   }
 }
 

--- a/client/elements/suttaplex/sc-suttaplex-stepper.js
+++ b/client/elements/suttaplex/sc-suttaplex-stepper.js
@@ -70,8 +70,6 @@ export class SCSuttaplexStepper extends LitLocalized(LitElement) {
       background-color: var(--sc-primary-color-light);
     }
 
-
-
     .button-right {
       justify-content: flex-end;
     }

--- a/client/elements/suttaplex/sc-suttaplex-stepper.js
+++ b/client/elements/suttaplex/sc-suttaplex-stepper.js
@@ -1,0 +1,209 @@
+import { LitElement, html, css } from 'lit';
+import { icon } from '../../img/sc-icon';
+import { LitLocalized } from '../addons/sc-localization-mixin';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+
+export class SCSuttaplexStepper extends LitLocalized(LitElement) {
+  static properties = {
+    next: { type: Object },
+    previous: { type: Object },
+    lang: { type: String },
+  };
+
+  constructor() {
+    super();
+    this.localizedStringsPath = '/localization/elements/interface';
+  }
+
+  static styles = css`
+    @media print {
+      :host {
+        display: none;
+      }
+    }
+
+    .bar {
+      display: flex;
+      overflow: hidden;
+
+      margin: 0 2%;
+      padding: 0;
+
+      border-radius: 48px;
+
+      gap: 4%;
+      justify-content: space-around;
+    }
+
+    @media only screen and (max-width: 600px) {
+      .bar {
+        flex-direction: column;
+        ;
+
+        height: 13rem;
+      }
+    }
+
+    a {
+      text-decoration: none;
+    }
+
+    .button {
+      display: flex;
+
+      width: 100%;
+      min-width: 10rem;
+      height: 6rem;
+
+      border-radius: 48px;
+      background-color: var(--sc-tertiary-background-color);
+    }
+
+    .button:hover {
+      transition: var(--sc-link-transition);
+      text-decoration: none;
+
+      background-color: var(--sc-primary-color-light-transparent);
+    }
+
+    button:active {
+      background-color: var(--sc-primary-color-light);
+    }
+
+
+
+    .button-right {
+      justify-content: flex-end;
+    }
+
+    .button-left, .button-right {
+      position: relative;
+    }
+
+    .button-right .text-title {
+      padding-left: 1em;
+    }
+
+    .button-left .text-title {
+      padding-right: 1em;
+    }
+
+    .action {
+      font-family: var(--sc-sans-font);
+      font-size: var(--sc-font-size-s);
+      font-stretch: expanded;
+
+      opacity: .55;
+      color: var(--sc-on-primary-primary-text-color);
+
+      font-variant-caps: all-small-caps;
+    }
+
+    .text-title {
+      font-family: var(--sc-sans-font);
+      font-size: var(--sc-font-size-l);
+      font-stretch: condensed;
+
+      overflow: hidden;
+
+      white-space: nowrap;
+      text-overflow: ellipsis;
+
+      color: var(--sc-on-tertiary-primary-text-color);
+    }
+
+    .link .text-title {
+      box-sizing: border-box;
+
+      transition: var(--sc-link-transition);
+    }
+
+    .text {
+      display: flex;
+
+      margin: auto 0;
+    }
+
+    .text-element {
+      display: inline-grid;
+
+      text-overflow: ellipsis;
+    }
+
+    .text-element-right {
+      text-align: end;
+    }
+
+    .icon {
+      font-size: var(--sc-font-size-l);
+
+      width: var(--sc-size-md-larger);
+      min-width: var(--sc-size-md-larger);
+      margin-top: 1em;
+      margin-right: .5em;
+      margin-left: .5em;
+
+      fill: var(--sc-icon-color);
+    }
+
+    @media (min-width: 1280px) {
+      .arrow_right {
+        margin-left: 1em;
+      }
+
+      .arrow_left {
+        margin-right: 1em;
+      }
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="bar">
+        <div class="button-container">
+          ${this.previous?.uid
+            ? html`
+                <a href=${this._getUrl(this.previous)}>
+                  <div class="button button-left">
+                    <div class="text">
+                      ${icon.arrow_left}
+                      <div class="text-element">
+                        <span class="action">${unsafeHTML(this.localize('interface:previous'))}</span>
+                        <span class="text-title">${this.previous.name}</span>
+                      </div>
+                    </div>
+                    <md-ripple></md-ripple>
+                  </div>
+                </a>
+              `
+            : ''}
+        </div>
+
+        <div class="button-container">
+          ${this.next?.uid
+            ? html`
+                <a href=${this._getUrl(this.next)}>
+                  <div class="button button-right">
+                    <div class="text">
+                      <div class="text-element text-element-right">
+                        <span class="action">${unsafeHTML(this.localize('interface:next'))}</span>
+                        <span class="text-title">${this.next.name}</span>
+                      </div>
+                      ${icon.arrow_right}
+                    </div>
+                    <md-ripple></md-ripple>
+                  </div>
+                </a>
+              `
+            : ''}
+        </div>
+      </div>
+    `;
+  }
+
+  _getUrl(object) {
+    return `/${object.uid}`;
+  }
+}
+
+customElements.define('sc-suttaplex-stepper', SCSuttaplexStepper);

--- a/client/elements/text/sc-text-stepper.js
+++ b/client/elements/text/sc-text-stepper.js
@@ -70,8 +70,6 @@ export class SCTextStepper extends LitLocalized(LitElement) {
       background-color: var(--sc-primary-color-light);
     }
 
-
-
     .button-right {
       justify-content: flex-end;
     }

--- a/server/server/common/queries.py
+++ b/server/server/common/queries.py
@@ -697,6 +697,14 @@ FOR v, e, p IN 0..6 OUTBOUND CONCAT('super_nav_details/', @uid) super_nav_detail
         biblio: biblio,
         priority_author_uid: priority_author,
         verseNo: references,
+        previous: {
+            name: null,
+            uid: null,
+        },
+        next: {
+            name: null,
+            uid: null,
+        },
     }
 '''
 
@@ -1513,8 +1521,10 @@ FOR doc IN 1..10 INBOUND DOCUMENT('super_nav_details', @uid) super_nav_details_e
 
 LET possibleRoot = REGEX_REPLACE(@uid, "\\\\d+(\\\\.\\\\d+)?", "")
 
+LET possibleRoot2 = REGEX_REPLACE(@uid, "(\\d+\\.\\d+)$", "")
+
 FOR docs IN 1..10 OUTBOUND DOCUMENT('super_nav_details', root_doc.uid) super_nav_details_edges OPTIONS {order: 'dfs'}
-    FILTER docs.type == 'leaf' AND (STARTS_WITH(docs.uid, LOWER(root_doc.uid)) OR STARTS_WITH(docs.uid, LOWER(root_doc.acronym)) OR STARTS_WITH(docs.uid, LOWER(possibleRoot)))
+    FILTER docs.type == 'leaf' AND (STARTS_WITH(docs.uid, LOWER(root_doc.uid)) OR STARTS_WITH(docs.uid, LOWER(root_doc.acronym)) OR STARTS_WITH(docs.uid, LOWER(possibleRoot))  OR STARTS_WITH(docs.uid, LOWER(possibleRoot2)))
     RETURN docs.uid
 '''
 


### PR DESCRIPTION
## Summary by Sourcery

Add navigation functionality to suttaplex cards by implementing a stepper component that allows users to move to previous and next cards. Update server logic to support this feature by calculating neighboring suttaplex card identifiers.

New Features:
- Introduce a stepper component to navigate between previous and next suttaplex cards in the UI.

Enhancements:
- Enhance the server-side logic to calculate and provide previous and next suttaplex card identifiers.

Related issue: 
Add prev/next to bare suttaplex cards #913