### PR TITLE
Adjust the site menu corner radius.

### DIFF
--- a/client/elements/menus/sc-action-items-universal.js
+++ b/client/elements/menus/sc-action-items-universal.js
@@ -23,7 +23,7 @@ export class SCActionItemsUniversal extends LitLocalized(LitElement) {
 
       z-index: 100;
 
-      --md-menu-container-shape: 24px;
+      --md-menu-container-shape: 12px;
     }
 
     #sc-menu-more:focus {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Reduce the corner radius of the site menu from 24px to 12px for a more streamlined appearance.