### PR TITLE
Enhance: send selected text to search field.

### DIFF
--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -9,6 +9,7 @@ import { SCTextCommon } from './sc-text-common';
 import '../lookups/sc-lookup-pli';
 import '../lookups/sc-lookup-lzh2en';
 import '../addons/sc-bottom-sheet';
+import './sc-text-context-menu';
 
 import { typographyCommonStyles } from '../styles/sc-typography-common-styles';
 import { typographyBilaraStyles } from '../styles/sc-typography-bilara-styles';
@@ -122,17 +123,16 @@ export class SCTextBilara extends SCTextCommon {
         ${paliScriptsStyles}
       </style>
       ${this.currentStyles} ${this.referencesDisplayStyles} ${this.notesDisplayStyles}
-
       <main>
         <div id="segmented_text_content" class="html-text-content">
           ${unsafeHTML(this.markup || ' ')}
         </div>
       </main>
-
       <sc-pali-lookup id="pali_lookup"></sc-pali-lookup>
       <sc-chinese-lookup id="chinese_lookup"></sc-chinese-lookup>
       <slot></slot>
       <sc-bottom-sheet></sc-bottom-sheet>
+      <sc-text-context-menu></sc-text-context-menu>
     `;
   }
 
@@ -140,6 +140,7 @@ export class SCTextBilara extends SCTextCommon {
     this.scActionItems = document.querySelector('sc-site-layout').querySelector('#action_items');
     window.addEventListener('hashchange', this._hashChangeHandler);
     this.addEventListener('click', this._onClickHandler);
+    document.addEventListener('mouseup', this.handleTextSelection.bind(this));
     this._updateView();
     this._updateURLSearchParams();
     this.scActionItems?.showSpeakerButton();

--- a/client/elements/text/sc-text-common.js
+++ b/client/elements/text/sc-text-common.js
@@ -16,4 +16,30 @@ export class SCTextCommon extends LitLocalized(LitElement) {
     this.chosenTextView = '';
     this.lang = '';
   }
+
+  handleTextSelection(event) {
+    const selectedText = window.getSelection().toString().trim();
+    const contextMenu = this.querySelector('#context-menu');
+    const scTextContextMenu = this.querySelector('sc-text-context-menu');
+    console.log('selectedTextA', selectedText);
+    if (selectedText) {
+      scTextContextMenu.keyword = selectedText;
+      const range = window.getSelection().getRangeAt(0).getBoundingClientRect();
+      console.log('range', range);
+      const top = range.top + window.scrollY;
+      const left = range.left + window.scrollX;
+
+      contextMenu.style.top = `${top + range.height}px`;
+      contextMenu.style.left = `${left}px`;
+      contextMenu.style.display = 'block';
+    } else {
+      contextMenu.style.display = 'none';
+    }
+
+    setTimeout(() => {
+      if (!window.getSelection().toString().trim()) {
+        contextMenu.style.display = 'none';
+      }
+    }, 100);
+  }
 }

--- a/client/elements/text/sc-text-context-menu.js
+++ b/client/elements/text/sc-text-context-menu.js
@@ -1,0 +1,77 @@
+import { LitElement, html, css } from 'lit';
+import { icon } from '../../img/sc-icon';
+
+export class SCTextContextMenu extends LitElement {
+  static styles = [
+    css`
+      :host {
+        display: block;
+      }
+    `
+  ];
+
+  static properties = {
+    keyword: { type: String },
+  };
+
+  constructor() {
+    super();
+    this.keyword = '';
+  }
+
+  render() {
+    return html`
+      <style>
+        #context-menu {
+          display: none;
+          position: absolute;
+          z-index: 1000;
+          background-color: var(--sc-tertiary-background-color);
+          border: 1px solid var(--sc-border-color);
+          border-radius: 5px;
+          padding: 5px;
+          box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+        }
+
+        #context-menu a {
+          display: flex;
+          color: var(--sc-primary-text-color);
+          text-decoration: none;
+        }
+
+        #context-menu a strong {
+          margin-left: 3px;
+          margin-right: 3px;
+        }
+
+        #context-menu:hover {
+          background-color: var(--sc-primary-color-light);
+        }
+      </style>
+
+      <div id="context-menu"> 
+        <a href='/search?query=${this.keyword}' target="_blank">
+          ${icon.search}
+          Search <strong> "${this.reduced_keyword}" </strong> In SuttaCentral
+          <md-ripple></md-ripple>
+        </a> 
+      </div>
+    `;
+  }
+
+  createRenderRoot() {
+    return this;
+  }
+
+  updated(changedProperties) {
+    if (changedProperties.has('keyword')) {
+      this.requestUpdate();
+      this.reduced_keyword = this.keyword;
+      if (this.keyword.length > 30) {
+        this.reduced_keyword = this.keyword.slice(0, 30) + '...';
+      }
+    }
+  }
+}
+
+customElements.define('sc-text-context-menu', SCTextContextMenu);

--- a/client/elements/text/sc-text-legacy.js
+++ b/client/elements/text/sc-text-legacy.js
@@ -4,6 +4,7 @@ import { html } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 import { SCTextCommon } from './sc-text-common';
+import './sc-text-context-menu';
 import { layoutSimpleStyles } from '../styles/sc-layout-simple-styles';
 import { typographyCommonStyles } from '../styles/sc-typography-common-styles';
 import { typographyLegacyStyles } from '../styles/sc-typography-legacy-styles';
@@ -110,6 +111,7 @@ export class SCTextLegacy extends SCTextCommon {
 
       <sc-chinese-lookup id="chinese_lookup"></sc-chinese-lookup>
       <sc-bottom-sheet></sc-bottom-sheet>
+      <sc-text-context-menu></sc-text-context-menu>
     `;
   }
 
@@ -154,6 +156,7 @@ export class SCTextLegacy extends SCTextCommon {
     this._updateURLSearchParams();
     this.scActionItems = document.querySelector('sc-site-layout').querySelector('#action_items');
     this.scActionItems?.hideSpeakerButton();
+    document.addEventListener('mouseup', this.handleTextSelection.bind(this));
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
## Summary by Sourcery

Implement a feature to send selected text to a search field by introducing a context menu that appears upon text selection, enabling users to search the selected text on SuttaCentral. Enhance the application by adding a new custom element 'sc-text-context-menu' to handle the context menu's display and functionality.

New Features:
- Introduce a context menu that appears when text is selected, allowing users to search the selected text on SuttaCentral.

Enhancements:
- Add a new custom element 'sc-text-context-menu' to manage the display and functionality of the context menu.