### PR TITLE
Fix: Weird results for dictionaries when searching Chinese #2209

### DIFF
--- a/client/elements/sc-dictionary-common.js
+++ b/client/elements/sc-dictionary-common.js
@@ -31,6 +31,12 @@ export function dictionarySimpleItemToHtml(dicItem) {
             </ul>
           ` : ''
         }
+        ${
+          dicItem.pronunciation
+            ? `
+              <label class="pronunciation-label">Pronunciation</label>
+              <p class="pronunciation-text">${dicItem.pronunciation}</p>` : ''
+        }
       </dd>
     </dl>
   `;

--- a/client/elements/sc-page-dictionary.js
+++ b/client/elements/sc-page-dictionary.js
@@ -45,6 +45,7 @@ export class SCPageDictionary extends LitLocalized(LitElement) {
       dppn: 'Dictionary of Pali Proper Names',
       pts: 'PTS Pali English Dictionary',
       dpd: 'Digital Pāḷi Dictionary',
+      ddb: 'Digital Dictionary of Buddhism'
     };
     this.adjacent = true;
     this.dictionaryAdjacent = [];
@@ -207,6 +208,21 @@ export class SCPageDictionary extends LitLocalized(LitElement) {
       height: 30px;
       width: 30px;
     }
+
+    .pronunciation-label {
+      margin-top: 1em;
+      font-weight: bold;
+      font-size: 1.1em;
+      margin-bottom: 0.5em;
+      display: block;
+    }
+
+    .pronunciation-text {
+      font-size: 1em;
+      color: #333;
+      margin-top: 0;
+      margin-bottom: 1em;
+    }
   `;
 
   render() {
@@ -307,11 +323,18 @@ export class SCPageDictionary extends LitLocalized(LitElement) {
     if (changedProps.has('dictionaryWord')) {
       this._loadNewResult();
     }
+
+    if (this._containsChineseCharacters(this.dictionaryWord)) {
+      this.shadowRoot.querySelector('.related-terms').style.display = 'none';
+    }
   }
 
   async _loadNewResult() {
-    await this._fetchAdjacent();
-    await this._fetchSimilar();
+    if (!this._containsChineseCharacters(this.dictionaryWord)) {
+      await this._fetchAdjacent();
+      await this._fetchSimilar();
+    }
+    
     this._fetchDictionary();
   }
 
@@ -435,6 +458,11 @@ export class SCPageDictionary extends LitLocalized(LitElement) {
         },
       })
     );
+  }
+
+  _containsChineseCharacters(str) {
+    const chineseCharacterPattern = /[\u4e00-\u9fa5]/;
+    return chineseCharacterPattern.test(str);
   }
 }
 

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -93,6 +93,8 @@ export class SCPageSearch extends LitLocalized(LitElement) {
       dhammika: 'Nature and the Environment in Early Buddhism by S. Dhammika',
       dppn: 'Dictionary of Pali Proper Names',
       pts: 'PTS Pali English Dictionary',
+      dpd: 'Digital Pāḷi Dictionary',
+      ddb: 'Digital Dictionary of Buddhism'
     };
     this.suttaplex = [];
     this.expansionReturns = [];

--- a/server/server/common/queries.py
+++ b/server/server/common/queries.py
@@ -1187,7 +1187,8 @@ LET dict_simple = (
             definition: dict.definition,
             xr: dict.xr,
             dictname: dict.dictname,
-            text: null
+            text: null,
+            pronunciation: dict.pronunciation
         }
 )
 
@@ -1203,6 +1204,7 @@ LET dict_complex = (
             xr: null,
             dictname: dict.dictname,
             text: dict.text,
+            pronunciation: dict.pronunciation
         }
 )
 


### PR DESCRIPTION
## Summary by Sourcery

Fix the display issue for related terms when searching for Chinese characters and enhance dictionary entries to include pronunciation information.

Bug Fixes:
- Fix incorrect display of related terms when searching for Chinese characters in the dictionary.

Enhancements:
- Add support for displaying pronunciation information in dictionary entries.