### PR TITLE
Fix: Double blank dictionary results are returned for uppādetv match partial.

### DIFF
--- a/server/server/common/queries.py
+++ b/server/server/common/queries.py
@@ -1251,7 +1251,7 @@ RETURN APPEND(dic_complex, dic_simple)
 DICTIONARY_FUZZY_SEARCH_RESULT_FULL = '''
 LET dic_complex = (
     FOR doc IN dictionaries_complex
-        FILTER doc.to == @language AND (doc.word LIKE @fuzzy_word OR doc.word_ascii LIKE @fuzzy_word)
+        FILTER doc.to == @language AND (doc.word LIKE @fuzzy_word OR doc.word_ascii LIKE @fuzzy_word)  AND doc.definition != null
         RETURN {
             dictname: doc.dictname,
             lang_to: doc.to,
@@ -1267,7 +1267,7 @@ LET dic_complex = (
 
 LET dic_simple = (
     FOR doc IN dictionaries_simple
-        FILTER doc.to == @language AND doc.entry LIKE @fuzzy_word
+        FILTER doc.to == @language AND doc.entry LIKE @fuzzy_word AND doc.definition != null
         RETURN {
             dictname: doc.dictname,
             lang_to: doc.to,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure dictionary entries with null definitions are excluded from fuzzy search results.