### PR TITLE
Limit the AND keyword to prevent high CPU usage

### DIFF
--- a/server/server/search/instant_search.py
+++ b/server/server/search/instant_search.py
@@ -247,8 +247,11 @@ def construct_search_query_aql(
             and 'NOT' not in query_param['query']
             and ' ' in query_param['query']
         ):
-            query_param['query'] = query_param['query'].replace(' ', ' AND ')
-            query = query.replace(' ', ' AND ')
+            keyword_count = query_param['query'].count(' ')
+            # Limit the AND keyword to prevent high CPU usage
+            if keyword_count < 5:
+                query_param['query'] = query_param['query'].replace(' ', ' AND ')
+                query = query.replace(' ', ' AND ')
 
         if (query_param['query'].startswith("'") or query_param['query'].startswith('"')):
             query_param['query'] = query_param['query'][1:-1]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Limit the use of the AND keyword in search queries to prevent high CPU usage by checking the number of spaces in the query and only replacing them with AND if there are fewer than five.