### PR TITLE
Navigate word lookup in sc-bottom-sheet.js using arrow keys

### DIFF
--- a/client/elements/addons/sc-bottom-sheet.js
+++ b/client/elements/addons/sc-bottom-sheet.js
@@ -2,6 +2,7 @@ import { LitElement, html, css } from 'lit';
 import { LitLocalized } from './sc-localization-mixin';
 import { icon } from '../../img/sc-icon';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { ignorableKeydownEvent } from '../sc-keyboard-shortcuts';
 
 export class SCBottomSheet extends LitLocalized(LitElement) {
   static properties = {
@@ -408,6 +409,10 @@ export class SCBottomSheet extends LitLocalized(LitElement) {
     this.lookup = {};
     this.defineURL = '';
     this.chinesePunctuation = '，,!！?？;；:：（()）[]【 】。「」﹁﹂"、‧《》〈〉﹏—『』';
+    this._keydownHandlers = {
+      'ArrowLeft': this._handleArrowLeftKeydown.bind(this),
+      'ArrowRight': this._handleArrowRightKeydown.bind(this),
+    };
   }
 
   render() {
@@ -433,12 +438,16 @@ export class SCBottomSheet extends LitLocalized(LitElement) {
                     <ul>
                       <li>
                       ${this.localize('bottomsheet:help5')} =
+                        <kbd>←</kbd>
+                        ${this.localize('bottomsheet:or')}
                         <kbd>Alt</kbd>
                         +
                         <kbd>n</kbd>
                       </li>
                       <li>
                       ${this.localize('bottomsheet:help6')} =
+                        <kbd>→</kbd>
+                        ${this.localize('bottomsheet:or')}
                         <kbd>Alt</kbd>
                         +
                         <kbd>b</kbd>
@@ -484,6 +493,30 @@ export class SCBottomSheet extends LitLocalized(LitElement) {
   show() {
     this.style.display = 'block';
     this.style.animation = 'bottomSheetShow 200ms 1 ease-in normal forwards';
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener('keydown', this._handleKeydown.bind(this));
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.removeEventListener('keydown', this._handleKeydown.bind(this));
+  }
+
+  _handleKeydown(event) {
+    if(ignorableKeydownEvent(event)) return;
+    if(!(event.key in this._keydownHandlers)) return;
+    this._keydownHandlers[event.key]();
+  }
+
+  _handleArrowLeftKeydown(event) {
+    this._previous();
+  }
+
+  _handleArrowRightKeydown(event) {
+    this._next();
   }
 
   _previous() {

--- a/client/elements/addons/sc-bottom-sheet.js
+++ b/client/elements/addons/sc-bottom-sheet.js
@@ -2,6 +2,7 @@ import { LitElement, html, css } from 'lit';
 import { LitLocalized } from './sc-localization-mixin';
 import { icon } from '../../img/sc-icon';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { ignorableKeydownEvent } from '../sc-keyboard-shortcuts';
 
 export class SCBottomSheet extends LitLocalized(LitElement) {
   static properties = {
@@ -408,6 +409,13 @@ export class SCBottomSheet extends LitLocalized(LitElement) {
     this.lookup = {};
     this.defineURL = '';
     this.chinesePunctuation = '，,!！?？;；:：（()）[]【 】。「」﹁﹂"、‧《》〈〉﹏—『』';
+    this._keydownHandlers = {
+      'h': this._previous.bind(this),
+      'H': this._previous.bind(this),
+      'l': this._next.bind(this),
+      'L': this._next.bind(this),
+    };
+    this._handleKeydown = this._handleKeydown.bind(this);
   }
 
   render() {
@@ -433,12 +441,16 @@ export class SCBottomSheet extends LitLocalized(LitElement) {
                     <ul>
                       <li>
                       ${this.localize('bottomsheet:help5')} =
+                        <kbd>h</kbd>
+                        ${this.tryLocalize('bottomsheet:or', 'or')}
                         <kbd>Alt</kbd>
                         +
                         <kbd>n</kbd>
                       </li>
                       <li>
                       ${this.localize('bottomsheet:help6')} =
+                        <kbd>l</kbd>
+                        ${this.tryLocalize('bottomsheet:or', 'or')}
                         <kbd>Alt</kbd>
                         +
                         <kbd>b</kbd>
@@ -484,6 +496,22 @@ export class SCBottomSheet extends LitLocalized(LitElement) {
   show() {
     this.style.display = 'block';
     this.style.animation = 'bottomSheetShow 200ms 1 ease-in normal forwards';
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener('keydown', this._handleKeydown);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.removeEventListener('keydown', this._handleKeydown);
+  }
+
+  _handleKeydown(event) {
+    if (ignorableKeydownEvent(event)) return;
+    if (!(event.key in this._keydownHandlers)) return;
+    this._keydownHandlers[event.key]();
   }
 
   _previous() {

--- a/client/localization/elements/interface_en.json
+++ b/client/localization/elements/interface_en.json
@@ -4,6 +4,7 @@
   "badge:legacy": "legacy",
   "bottomsheet:close": "Close",
   "bottomsheet:help": "Help",
+  "bottomsheet:or": "or",
   "bottomsheet:help1": "Source: <cite>New Concise Pali-English Dictionary</cite>, compiled by SuttaCentral from Buddhadatta’s <cite>Concise Pali-English Dictionary</cite>, updated and corrected from Margaret Cone’s <cite>Dictionary of Pali</cite>.",
   "bottomsheet:help2": "Pali words are analyzed by machine and results are not always accurate.",
   "bottomsheet:help3": "Click on a head word to go to full dictionary entry",


### PR DESCRIPTION
For me the approach mentioned under help for navigating the bottom sheet using HTML access keys doesn't work. This PR should maintain the original functionality using HTML access keys and also provide functionality to navigate respectively left or right one word on the pressing of ← and →. I think this is more discoverable.

![suttacentralarrows](https://github.com/user-attachments/assets/c043145e-abfa-4ccc-af1a-4dc7d65bd7a4)
_Goes right one word on pressing right and left one word on pressing left._

![updated help display](https://github.com/user-attachments/assets/3be5faac-ccf8-47a1-ad0f-9e4f5c877f46)
_Updated help display._

Please let me know if this is a desired implementation or not and if I should add a unit test. And if desired maybe a good idea to also add a keydown handler for <kbd>p</kbd> (for previous word) and <kbd>n</kbd> (for next word)?

Also need to update the [translations files found here](https://github.com/search?q=repo%3Asuttacentral%2Fsc-data+bottomsheet%3Ahelp&type=code).

## Summary by Sourcery

New Features:
- Navigate between words in the bottom sheet using left (<kbd>←</kbd>) and right (<kbd>→</kbd>) arrow keys.