### PR TITLE
Add language badge to suttplex.

### DIFF
--- a/client/elements/addons/sc-badge.js
+++ b/client/elements/addons/sc-badge.js
@@ -22,7 +22,7 @@ export class SCBadge extends LitLocalized(LitElement) {
   static styles = css`
     :host {
       padding: 0.25em 0.75em;
-      font-size: var(--sc-font-size-xxs);
+      font-size: var(--sc-font-size-xs);
       font-weight: 550;
       font-stretch: condensed;
       line-height: 1;
@@ -90,6 +90,14 @@ export class SCBadge extends LitLocalized(LitElement) {
       return html` ${this.text} `;
     }
     return html` ${localizeString} `;
+  }
+
+  firstUpdated() {
+    if (this.color === 'language') {
+      this.style.setProperty('font-size', 'var(--sc-font-size-xs)');
+      this.style.setProperty('font-weight', 'bold');
+      this.style.setProperty('background-color', 'var(--sc-primary-color-light)');
+    }
   }
 }
 

--- a/client/elements/suttaplex/card/sc-suttaplex-tx.js
+++ b/client/elements/suttaplex/card/sc-suttaplex-tx.js
@@ -34,6 +34,9 @@ export class SCSuttaplexTx extends LitElement {
             ${icon.open_book}
             <div class="tx-details">
               <span class="tx-creator">${this.translation?.author}</span>
+              <span class="badges">
+                <sc-badge text="${this.translation?.lang?.toUpperCase()}" color="language"></sc-badge>
+              </span>
               <span class="tx-publication"> ${this.publicationInfoTemplate()} </span>
               <span class="badges"> ${this.badgeTemplate()} </span>
               <md-ripple></md-ripple>


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Display a language badge on each suttaplex card, indicating the language of the translation.