### PR TITLE
Enhance: Add text-wrap: balance to headings, adjust suttaplex styles.

### DIFF
--- a/client/elements/styles/sc-typography-common-styles.js
+++ b/client/elements/styles/sc-typography-common-styles.js
@@ -69,6 +69,7 @@ export const typographyCommonStyles = css`
   h1 {
     font-size: var(--sc-font-size-xxxxl);
     font-weight: 400;
+    text-wrap: balance;
   }
 
   h2 {

--- a/client/elements/suttaplex/card/sc-suttaplex-css.js
+++ b/client/elements/suttaplex/card/sc-suttaplex-css.js
@@ -436,6 +436,7 @@ export const suttaplexTxCss = css`
 
     gap: var(--sc-size-xs);
     align-self: center;
+    margin-bottom: var(--sc-size-xs);
   }
 `;
 


### PR DESCRIPTION
## Summary by Sourcery

Improve heading display by adding text wrapping and adjusting spacing in Suttaplex cards.

Enhancements:
- Add `text-wrap: balance` to `h1` elements to improve text distribution across lines.
- Add margin below the Suttaplex card title to improve spacing.