### PR TITLE
For prev/next buttons, if there is no translation name or root name, try using acronym instead

### DIFF
--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -218,7 +218,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
   _updateMetaData() {
     const { suttaplexData, isSuttaInRangeSutta, categoryId, rangeCategoryId } = this;
     if (this.suttaplexData?.length) {
-      const { title, original_title, blurb } = suttaplexData[0];
+      const { title, original_title, blurb, acronym } = suttaplexData[0];
       let description = this.localize('interface:metaDescriptionText');
       if (blurb) {
         description = blurb;
@@ -241,7 +241,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
         }, 100);
       }
 
-      const pageTitle = `${title || original_title}—${this.localize('interface:parallelsTitle')}`;
+      const pageTitle = `${title || original_title || acronym}—${this.localize('interface:parallelsTitle')}`;
       document.dispatchEvent(
         new CustomEvent('metadata', {
           detail: {

--- a/server/server/common/queries.py
+++ b/server/server/common/queries.py
@@ -1068,7 +1068,16 @@ LET root_name = (
         RETURN name.name
 )[0]
 
-RETURN translated_name ? translated_name : root_name
+LET acronym = (
+    FOR name IN super_nav_details
+        FILTER name.uid == @uid
+        LIMIT 1
+        RETURN name.acronym
+)[0]
+
+LET title = translated_name ? translated_name : acronym
+
+RETURN title ? title : root_name
 '''
 
 VAGGA_CHILDREN = '''


### PR DESCRIPTION
## Summary by Sourcery

For prev/next buttons, if there is no translation name or root name, use the acronym instead. This change ensures that the acronym is used as a fallback title in the suttaplex list and in the database query.

Enhancements:
- Use acronym as fallback title in suttaplex list if translation name and root name are not available.
- Modify database query to return acronym for super nav details.