### PR TITLE
fix: when in suttaplex page, do not display toc button.

### DIFF
--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -15,6 +15,7 @@ import { transformId, getParagraphRange } from '../../utils/suttaplex';
 import '@material/web/button/filled-button';
 import { dispatchCustomEvent } from '../../utils/customEvent';
 import './sc-suttaplex-stepper.js';
+import { reduxActions } from '../addons/sc-redux-actions';
 
 class SCSuttaplexList extends LitLocalized(LitElement) {
   static properties = {
@@ -71,6 +72,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
     this.displayParallelTableView = store.getState().displayParallelTableView;
     this.#showTableViewButton();
     this._setViewState();
+    reduxActions.showToc([]);
   }
 
   #showTableViewButton() {


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Hide the table of contents button when on a suttaplex page.