### PR TITLE
Fix sorting error caused by more than one dot in a uid

### DIFF
--- a/server/server/search/instant_search.py
+++ b/server/server/search/instant_search.py
@@ -1096,7 +1096,7 @@ def sort_by_sutta_numbering_rules(input_list):
             letter_part = ''.join([char for char in uid if char.isalpha()])
             number_part = ''.join([char for char in uid if char.isdigit() or char == '.'])
 
-        if '.' in number_part:
+        if '.' in number_part and number_part.count('.') == 1:
             integer_part, decimal_part = number_part.split('.')
             number_part = (int(integer_part), float(decimal_part))
         else:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixes a sorting error caused by UIDs containing multiple dots by ensuring the code only splits the number part of the UID when there is exactly one dot.