### PR TITLE
Wrote more detailed tests for the API

### DIFF
--- a/server/server/api/tests/test_endpoints.py
+++ b/server/server/api/tests/test_endpoints.py
@@ -1,0 +1,1052 @@
+import pytest
+import json
+
+from app import api, app
+
+
+class TestHomePageData:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_home_page_data(self, client):
+        url = "/homepage_data"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert 'epigraphs' in data
+        assert 'whyweread' in data
+        assert 'tipitaka' in data
+
+
+class TestSuttaFullPath:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_sutta_full_path(self, client):
+        url = "/suttafullpath/sn1.1"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert len(data) > 0
+        assert data['full_path'] == '/pitaka/sutta/linked/sn/sn-sagathavaggasamyutta/sn1/sn1-nalavagga'
+
+
+class TestMenu:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_menu(self, client):
+        url = "/menu"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for item in data:
+            assert 'uid' in item
+            assert 'root_name' in item
+            assert 'translated_name' in item
+            assert 'blurb' in item
+            assert 'acronym' in item
+            assert 'node_type' in item
+            assert 'root_lang_iso' in item
+            assert 'root_lang_name' in item
+            assert 'child_range' in item
+            assert 'yellow_brick_road' in item
+            assert 'yellow_brick_road_count' in item
+            assert 'children' in item
+
+    def test_submenu(self, client):
+        url = "/menu/sn"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for item in data:
+            assert 'uid' in item
+            assert 'root_name' in item
+            assert 'translated_name' in item
+            assert 'blurb' in item
+            assert 'acronym' in item
+            assert 'node_type' in item
+            assert 'root_lang_iso' in item
+            assert 'root_lang_name' in item
+            assert 'child_range' in item
+            assert 'yellow_brick_road' in item
+            assert 'yellow_brick_road_count' in item
+            assert 'children' in item
+
+
+class TestTipitakaMenu:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_tipitaka_menu(self, client):
+        url = "/tipitaka_menu"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for item in data:
+            assert 'uid' in item
+            assert 'root_name' in item
+            assert 'translated_name' in item
+            assert 'blurb' in item
+            assert 'acronym' in item
+            assert 'node_type' in item
+            assert 'yellow_brick_road' in item
+            assert 'yellow_brick_road_count' in item
+
+
+class TestDictionaryFull:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_dictionary_full(self, client):
+        url = "/dictionary_full/citta"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+
+        for item in data:
+            assert 'from' in item
+            assert 'to' in item
+            assert 'entry' in item
+            assert 'definition' in item
+            assert 'xr' in item
+            assert 'dictname' in item
+            assert 'text' in item
+            assert 'pronunciation' in item
+
+
+class TestParallels:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_parallels(self, client):
+        url = "/parallels/sn1.1"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert 'sn1.1' in data
+
+
+class TestParallelsLite:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_parallels(self, client):
+        url = "/parallels_lite/sn1.1"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+
+
+class TestRangeSuttaplexList:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_range_suttaplex(self, client):
+        url = "/range_suttaplex/an1.1"
+        response = client.get(url)
+
+        # print(f"Status Code: {response.status_code}")
+        # print(f"Response Contents: {response.data.decode('utf-8')}")
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        # 验证返回的数据结构
+        for sutta in data:
+            assert 'uid' in sutta
+            assert sutta['uid'] is not None
+            assert sutta['uid'].startswith('an1.')
+            assert 'translations' in sutta
+
+    def test_invalid_uid_format(self, client):
+        url = "/range_suttaplex/this-is-invalid-uid"
+        response = client.get(url)
+        data = json.loads(response.data)
+        assert len(data) > 0
+        assert data[0]['uid'] is None
+
+    def test_nonexistent_range(self, client):
+        url = "/range_suttaplex/an999.1-10"
+        response = client.get(url)
+        data = json.loads(response.data)
+        assert len(data) > 0
+        assert data[0]['uid'] is None
+
+    def test_response_includes_required_fields(self, client):
+        url = "/range_suttaplex/an1.1-10"
+        response = client.get(url)
+        assert response.status_code == 200
+        data = json.loads(response.data)
+
+        if len(data) > 0:
+            sutta = data[0]
+            required_fields = [
+                'acronym',
+                'volpages',
+                'alt_volpages',
+                'uid',
+                'blurb',
+                'difficulty',
+                'root_lang',
+                'root_lang_name',
+                'type',
+                'translated_title',
+                'translations',
+                'parallel_count',
+                'biblio',
+                'priority_author_uid',
+                'verseNo',
+                'previous',
+                'next'
+            ]
+            for field in required_fields:
+                assert field in sutta
+
+            translation_required_fields = [
+                'lang',
+                'lang_name',
+                'is_root',
+                'author',
+                'author_short',
+                'author_uid',
+                'publication_date',
+                'id',
+                'segmented',
+                'volpage',
+                'has_comment'
+            ]
+
+            for translation in sutta['translations']:
+                for field in translation_required_fields:
+                    assert field in translation
+
+
+class TestSuttaplexList:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_range_suttaplex(self, client):
+        url = "/suttaplex/an1.1-10"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        # 验证返回的数据结构
+        for sutta in data:
+            assert 'uid' in sutta
+            assert sutta['uid'] is not None
+            assert sutta['uid'].startswith('an1.')
+            assert 'translations' in sutta
+
+    def test_invalid_uid_format(self, client):
+        url = "/suttaplex/this-is-invalid-uid"
+        response = client.get(url)
+        data = json.loads(response.data)
+        assert len(data) > 0
+        assert data[0]['uid'] is None
+
+    def test_nonexistent_range(self, client):
+        url = "/suttaplex/an999.1-10"
+        response = client.get(url)
+        data = json.loads(response.data)
+        assert len(data) > 0
+        assert data[0]['uid'] is None
+
+    def test_response_includes_required_fields(self, client):
+        url = "/suttaplex/an1.1-10"
+        response = client.get(url)
+        assert response.status_code == 200
+        data = json.loads(response.data)
+
+        if len(data) > 0:
+            sutta = data[0]
+            required_fields = [
+                'acronym',
+                'volpages',
+                'alt_volpages',
+                'uid',
+                'blurb',
+                'difficulty',
+                'root_lang',
+                'root_lang_name',
+                'type',
+                'translated_title',
+                'translations',
+                'parallel_count',
+                'biblio',
+                'priority_author_uid',
+                'verseNo',
+                'previous',
+                'next'
+            ]
+            for field in required_fields:
+                assert field in sutta
+
+            translation_required_fields = [
+                'lang',
+                'lang_name',
+                'is_root',
+                'author',
+                'author_short',
+                'author_uid',
+                'publication_date',
+                'id',
+                'segmented',
+                'volpage',
+                'has_comment'
+            ]
+
+            for translation in sutta['translations']:
+                for field in translation_required_fields:
+                    assert field in translation
+
+
+class TestSegmentedSutta:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_segmented_sutta(self, client):
+        url = "/bilarasuttas/sn1.1"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert 'html_text' in data
+        assert 'root_text' in data
+        assert 'variant_text' in data
+        assert 'reference_text' in data
+        assert 'keys_order' in data
+
+    def test_basic_segmented_sutta_with_author(self, client):
+        url = "/bilarasuttas/sn1.1/sujato"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert 'html_text' in data
+        assert 'root_text' in data
+        assert 'translation_text' in data
+        assert 'variant_text' in data
+        assert 'reference_text' in data
+        assert 'keys_order' in data
+
+    def test_invalid_uid_format(self, client):
+        url = "/bilarasuttas/this-is-invalid-uid"
+        response = client.get(url)
+        data = json.loads(response.data)
+        assert data['msg'] == 'Not Found'
+
+
+class TestNavigationData:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_navigation_data(self, client):
+        url = "/navigation_data/sn1.1"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for item in data:
+            assert 'uid' in item
+            assert 'title' in item
+            assert 'url' in item
+            assert 'type' in item
+            assert 'index' in item
+
+
+class TestLanguage:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_language(self, client):
+        url = "/languages"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for item in data:
+            assert 'uid' in item
+            assert 'name' in item
+            assert 'iso_code' in item
+            assert 'is_root' in item
+            assert 'localized' in item
+            assert 'localized_percent' in item
+
+
+class TestTranslationCount:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_translation_count(self, client):
+        url = "/translation_count/en"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert 'division' in data
+        assert 'author' in data
+
+        assert isinstance(data['division'], list)
+        for item in data['division']:
+            assert 'uid' in item
+            assert 'name' in item
+            assert 'root_lang' in item
+            assert 'total' in item
+
+        assert isinstance(data['author'], list)
+        for item in data['author']:
+            assert 'author_uid' in item
+            assert 'name' in item
+            assert 'total' in item
+
+    def test_basic_translation_count_by_languages(self, client):
+        url = "/translation_count"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert 'ancient' in data
+        assert 'modern' in data
+
+        assert isinstance(data['ancient'], list)
+        for item in data['ancient']:
+            assert 'iso_code' in item
+            assert 'name' in item
+            assert 'total' in item
+
+        assert isinstance(data['modern'], list)
+        for item in data['modern']:
+            assert 'iso_code' in item
+            assert 'name' in item
+            assert 'percent' in item
+            assert 'total' in item
+
+
+class TestCurrencies:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_currencies(self, client):
+        url = "/currencies"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert 'default_currency_index' in data
+        assert 'currencies' in data
+
+        assert isinstance(data['currencies'], list)
+        assert len(data['currencies']) > 0
+        for item in data['currencies']:
+            assert 'name' in item
+            assert 'symbol' in item
+            assert 'american_express' in item
+            assert 'decimal' in item
+
+
+class TestParagraphs:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_paragraphs(self, client):
+        url = "/paragraphs"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for item in data:
+            assert 'uid' in item
+            assert 'description' in item
+
+
+class TestParagraphs:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_paragraphs(self, client):
+        url = "/epigraphs"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for item in data:
+            assert 'uid' in item
+            assert 'epigraph' in item
+
+
+class TestWhyweread:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_paragraphs(self, client):
+        url = "/whyweread"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+
+class TestGlossary:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_paragraphs(self, client):
+        url = "/glossary"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for item in data:
+            assert 'entry' in item
+            assert 'gloss' in item
+
+
+class TestDictionaryFullAdjacent:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_paragraphs(self, client):
+        url = "/dictionary_full/adjacent/evam"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+
+class TestDictionaryFullSimilar:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_paragraphs(self, client):
+        url = "/dictionary_full/similar/evam"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+    def test_noexistent_word(self, client):
+        url = "/dictionary_full/similar/this-is-nonexistent-word"
+        response = client.get(url)
+        data = json.loads(response.data)
+        assert len(data) == 1 and data[0] != ''
+
+
+class TestExpansion:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_paragraphs(self, client):
+        url = "/expansion"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for item in data:
+            assert isinstance(item, dict)
+
+
+class TestCollectionUrlList:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_collection_url_list(self, client):
+        url = "/pwa/collection/dn?languages=en&root_lang=false"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert 'menu' in data
+        assert 'suttaplex' in data
+        assert 'texts' in data
+
+        assert isinstance(data['menu'], list)
+        assert isinstance(data['suttaplex'], list)
+        assert isinstance(data['texts'], list)
+
+
+class PWASizes:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_pwa_sizes(self, client):
+        url = "/pwa/sizes"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+
+
+class TestExtractSuttaFromRangeSutta:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_extract_sutta_from_range_sutta(self, client):
+        url = "/extractsutta/an1.1"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert 'html_text' in data
+        assert 'root_text' in data
+        assert 'variant_text' in data
+        assert 'reference_text' in data
+        assert 'keys_order' in data
+
+    def test_extract_sutta_from_range_sutta_for_author(self, client):
+        url = "/extractsutta/an1.1/sujato"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert 'html_text' in data
+        assert 'root_text' in data
+        assert 'variant_text' in data
+        assert 'reference_text' in data
+        assert 'keys_order' in data
+
+
+class TestTransliterate:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_transliterate(self, client):
+        url = "/transliterate/ahom/The truth is beautiful"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, str)
+        assert data  == "𑜌𑜦𑜧 𑜄𑜞𑜤𑜌𑜫 𑜒𑜢𑜏𑜫 𑜈𑜦𑜧𑜒𑜧𑜨𑜄𑜣𑜇𑜤𑜎𑜫"
+
+
+class TestTransliteratedSutta:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_transliterated_sutta(self, client):
+        url = "/transliterated_sutta/sn1.1/ahom"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert 'sn1.1:0.1' in data
+        assert 'sn1.1:0.2' in data
+
+
+class TestPaliReferenceEdition:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_pali_reference_edition(self, client):
+        url = "/pali_reference_edition"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+
+class TestAvailableVoices:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_available_voices(self, client):
+        url = "/available_voices/sn1.1"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert 'uid' in item
+            assert 'voices' in item
+
+
+class TestRootEdition:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_root_edition(self, client):
+        url = "/root_edition"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+
+class TestGuides:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_guides(self, client):
+        url = "/guides"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert 'guide_uid' in item
+            assert 'text_uid' in item
+            assert 'lang' in item
+
+
+class TestShortcuts:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_shortcuts(self, client):
+        url = "/shortcuts"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert 'shortcuts' in item
+            assert 'uid' in item
+
+
+class TestCreatorBio:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_creator_bio(self, client):
+        url = "/creator_bio"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for item in data:
+            assert 'creator_uid' in item
+            assert 'creator_biography' in item
+
+
+class TestAbbreviationTexts:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_abbreviation_texts(self, client):
+        url = "/abbreviation_texts"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert 'name' in item
+            assert 'acronym' in item
+
+
+class TestAbbreviationEditions:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_abbreviation_editions(self, client):
+        url = "/abbreviation_editions"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert 'name' in item
+            assert 'acronym' in item
+            assert 'uid' in item
+
+
+class TestAbbreviationSchools:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_abbreviation_schools(self, client):
+        url = "/abbreviation_schools"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert 'name' in item
+            assert 'acronym' in item
+            assert 'uid' in item
+
+
+class TestFallenLeaves:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_fallen_leaves(self, client):
+        url = "/fallen_leaves"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert 'fallen_leaves' in item
+
+
+class TestMapData:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_map_data(self, client):
+        url = "/map_data"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert 'type' in item
+            assert 'features' in item
+            assert len(item['features']) > 0
+            for feature in item['features']:
+                assert 'type' in feature
+                assert 'geometry' in feature
+                assert 'properties' in feature
+
+
+
+class TestFetchPossibleNames:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_fetch_possible_names(self, client):
+        url = "/possible_names/en"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0

--- a/server/server/api/tests/test_publication_endpoints.py
+++ b/server/server/api/tests/test_publication_endpoints.py
@@ -1,0 +1,162 @@
+import pytest
+import json
+from app import api, app
+
+
+class TestPublication:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_publication(self, client):
+        url = "/publication"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for publication in data:
+            assert 'text_uid' in publication
+            assert 'publication_number' in publication
+            assert 'root_lang_iso' in publication
+            assert 'root_lang_name' in publication
+            assert 'translation_lang_iso' in publication
+            assert 'translation_lang_name' in publication
+            assert 'source_url' in publication
+            assert 'author_uid' in publication
+            assert 'translation_title' in publication
+            assert 'translation_subtitle' in publication
+            assert 'root_title' in publication
+            assert 'translation_process' in publication
+            assert 'translation_description' in publication
+            assert 'is_published' in publication
+            assert 'publication_status' in publication
+            assert 'license' in publication
+            assert 'edition' in publication
+
+
+class TestPublicationEditions:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_basic_publication_edition(self, client):
+        url = "/publication/editions"
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert 'edition_id' in item
+            assert 'publication_number' in item
+
+
+class TestPublicationEdition:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_all_publication_edition(self, client):
+        url = "/publication/editions"
+        response = client.get(url)
+        data = json.loads(response.data)
+
+        for item in data:
+            edition_id = item['edition_id']
+            url = f"/publication/edition/{edition_id}"
+            response = client.get(url)
+            data = json.loads(response.data)
+            assert 'edition' in data
+            assert 'publication' in data
+
+
+class TestPublicationEditionFiles:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_publication_edition_files(self, client):
+        url = "/publication/edition/an-en-sujato_scpub5-ed3-hardcover_2022-02-10/files"
+        response = client.get(url)
+        data = json.loads(response.data)
+        assert isinstance(data, dict)
+        assert data['./matter/epigraph.html'] != ''
+
+
+class TestPublicationEditionMainMatter:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_publication_edition_main_matter(self, client):
+        url = "/publication/edition/an-en-sujato_scpub5-ed3-hardcover_2022-02-10/an1.1-10"
+        response = client.get(url)
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert 'uid' in item
+            assert 'type' in item
+            assert 'name' in item
+            assert 'root_name' in item
+            assert 'blurb' in item
+            assert 'acronym' in item
+            assert 'editionDetails' in item
+            assert 'mainmatter' in item
+            assert 'main_text' in item['mainmatter']
+            assert 'markup' in item['mainmatter']
+            assert 'reference' in item['mainmatter']
+
+
+class TestPublicationEditionBlurbs:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_publication_edition_blurbs(self, client):
+        url = "/publication/edition/blurbs/en"
+        response = client.get(url)
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert 'uid' in item
+            assert 'blurb' in item
+
+
+class TestPublicationInfo:
+    @pytest.fixture
+    def client(self):
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            with app.app_context():
+                yield client
+
+    def test_publication_info(self, client):
+        url = "/publication_info/sn1.1/en/sujato"
+        response = client.get(url)
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) > 0

--- a/server/server/api/views/views.py
+++ b/server/server/api/views/views.py
@@ -614,6 +614,7 @@ class RangeSuttaplexList(Resource):
         return data, 200
 
     def get_suttaplex_list_by_uid(self, db, language, uid):
+        results = {}
         if uid[:3].lower() == 'dhp' and uid.count('-') == 0:
             vagga_children_uids = list(
                 db.aql.execute(
@@ -1071,9 +1072,11 @@ class ExtractSuttaFromRangeSutta(Resource):
 
         if not range_uid:
             return {'msg': 'Not Found'}, 200
+
+        lang = request.args.get('lang', 'en')
         range_sutta_result = db.aql.execute(
             SEGMENTED_SUTTA_VIEW,
-            bind_vars={'uid': range_uid, 'author_uid': author_uid}
+            bind_vars={'uid': range_uid, 'author_uid': author_uid, 'lang': lang}
         )
         range_sutta = next(range_sutta_result)
         data = {k: json_load(v) for k, v in range_sutta.items()}

--- a/server/server/common/tests/test_utils.py
+++ b/server/server/common/tests/test_utils.py
@@ -21,7 +21,8 @@ def test_get_possible_parent_uid():
       'divy13',
       'ea-2.7',
       'sa-3.13',
-      'thi-ap5'
+      'thi-ap5',
+      'dhp123'
     ]
 
     expected_results = [
@@ -44,7 +45,8 @@ def test_get_possible_parent_uid():
       'divy',
       'ea',
       'sa',
-      'thi-ap'
+      'thi-ap',
+      'dhp'
     ]
 
     for i, uid in enumerate(test_uids):


### PR DESCRIPTION
## Summary by Sourcery

Adds comprehensive tests for various API endpoints, including publication-related endpoints, and fixes a minor issue in the get_possible_parent_uid utility function.

Tests:
- Adds tests for the following endpoints: home page data, sutta full path, menu, tipitaka menu, dictionary full, parallels, parallels lite, range suttaplex list, suttaplex list, segmented sutta, navigation data, language, translation count, currencies, paragraphs, epigraphs, whyweread, glossary, dictionary full adjacent, dictionary full similar, expansion, collection URL list, PWA sizes, extract sutta from range sutta, transliterate, transliterated sutta, pali reference edition, available voices, root edition, guides, shortcuts, creator bio, abbreviation texts, abbreviation editions, abbreviation schools, fallen leaves, map data, fetch possible names, publication, publication editions, publication edition, publication edition files, publication edition main matter, publication edition blurbs, and publication info.
- Adds publication-related endpoint tests.
- Adds a test case to the get_possible_parent_uid utility function to improve code coverage.
- Adds tests for the /publication, /publication/editions, /publication/edition/{edition_id}/files, /publication/edition/{edition_id}/{range}, /publication/edition/blurbs/{lang}, and /publication_info/{text_uid}/{lang}/{author_uid} endpoints, ensuring they return the expected data structures and status codes.
- Adds tests for the /possible_names/{language} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /map_data endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /fallen_leaves endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /abbreviation_schools endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /abbreviation_editions endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /abbreviation_texts endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /creator_bio endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /shortcuts endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /guides endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /root_edition endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /available_voices/{sutta_uid} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /pali_reference_edition endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /transliterated_sutta/{sutta_uid}/{language} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /transliterate/{language}/{text} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /extractsutta/{sutta_uid} and /extractsutta/{sutta_uid}/{author_uid} endpoints, ensuring they return the expected data structures and status codes.
- Adds tests for the /pwa/sizes endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /pwa/collection/{collection_id} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /expansion endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /dictionary_full/similar/{word} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /dictionary_full/adjacent/{word} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /glossary endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /whyweread endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /epigraphs endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /paragraphs endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /currencies endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /translation_count and /translation_count/{language} endpoints, ensuring they return the expected data structures and status codes.
- Adds tests for the /languages endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /navigation_data/{uid} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /bilarasuttas/{uid} and /bilarasuttas/{uid}/{author_uid} endpoints, ensuring they return the expected data structures and status codes.
- Adds tests for the /suttaplex/{uid} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /range_suttaplex/{uid} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /parallels_lite/{uid} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /parallels/{uid} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /dictionary_full/{word} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /tipitaka_menu endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /menu and /menu/{uid} endpoints, ensuring they return the expected data structures and status codes.
- Adds tests for the /suttafullpath/{uid} endpoint, ensuring it returns the expected data structures and status codes.
- Adds tests for the /homepage_data endpoint, ensuring it returns the expected data structures and status codes.