### PR TITLE
A start on running the data load process in pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ test:
 test-server:
 	@docker exec -t sc-flask pytest -s server/
 
+test-data-load:
+	@docker exec -t sc-flask pytest -v server/data_loader/
+
 test-api:
 	docker compose run --entrypoint "python /opt/sc/api-tester/run-tests.py" sc-api-tester
 

--- a/server/server/config.py
+++ b/server/server/config.py
@@ -47,7 +47,6 @@ class TestingConfig(Config):
     TESTING = True
     DEBUG = True
     ARANGO_DB = os.getenv('ARANGO_BASE_DB_NAME') + '_tests'
-    ARANGO_DB_DATA_LOAD_TEST = os.getenv('ARANGO_BASE_DB_NAME') + '_data_load_tests'
 
 
 class ProductionConfig(Config):

--- a/server/server/config.py
+++ b/server/server/config.py
@@ -47,6 +47,7 @@ class TestingConfig(Config):
     TESTING = True
     DEBUG = True
     ARANGO_DB = os.getenv('ARANGO_BASE_DB_NAME') + '_tests'
+    ARANGO_DB_DATA_LOAD_TEST = os.getenv('ARANGO_BASE_DB_NAME') + '_data_load_tests'
 
 
 class ProductionConfig(Config):

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -3,3 +3,7 @@ from config import TestingConfig
 def test_normal_testing_database_name():
     config = TestingConfig()
     assert config.ARANGO_DB == "suttacentral_tests"
+
+def test_data_load_testing_database_name():
+    config = TestingConfig()
+    assert config.ARANGO_DB_DATA_LOAD_TEST == "suttacentral_data_load_tests"

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -11,7 +11,7 @@ from data_loader import arangoload
 def data_load_app(app):
     app = current_app()
     app.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
-    app.config['BASE_DIR'] = '/opt/sc/sc-flask/'
+    app.config['BASE_DIR'] = Path('/opt/sc/sc-flask/')
     return app
 
 def test_set_db_name(data_load_app):
@@ -21,7 +21,7 @@ def test_set_db_name(data_load_app):
 def test_base_dir_is_correct(data_load_app):
     with data_load_app.app_context():
         base_dir = data_load_app.config.get('BASE_DIR')
-        assert base_dir == '/opt/sc/sc-flask/'
+        assert base_dir == Path('/opt/sc/sc-flask/')
 
 def test_do_collect_data_stage(data_load_app):
     with data_load_app.app_context():
@@ -29,7 +29,7 @@ def test_do_collect_data_stage(data_load_app):
         git_repository = data_load_app.config.get('DATA_REPO')
         arangoload.collect_data(data_dir, git_repository)
 
-@pytest.mark.skip('Figure out why collect_data() fails first')
+@pytest.mark.skip("Get copy_localization working")
 def test_do_entire_run(data_load_app):
     with data_load_app.app_context():
         arangoload.run()

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -11,11 +11,17 @@ from data_loader import arangoload
 def data_load_app(app):
     app = current_app()
     app.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
+    app.config['BASE_DIR'] = '/opt/sc/sc-flask/'
     return app
 
 def test_set_db_name(data_load_app):
     with data_load_app.app_context():
         assert get_db().name == 'suttacentral_data_load_tests'
+
+def test_base_dir_is_correct(data_load_app):
+    with data_load_app.app_context():
+        base_dir = data_load_app.config.get('BASE_DIR')
+        assert base_dir == '/opt/sc/sc-flask/'
 
 def test_do_collect_data_stage(data_load_app):
     with data_load_app.app_context():
@@ -23,7 +29,7 @@ def test_do_collect_data_stage(data_load_app):
         git_repository = data_load_app.config.get('DATA_REPO')
         arangoload.collect_data(data_dir, git_repository)
 
-@pytest.mark.skip("Figure out why collect_data() fails first")
+@pytest.mark.skip('Figure out why collect_data() fails first')
 def test_do_entire_run(data_load_app):
     with data_load_app.app_context():
         arangoload.run()

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -1,25 +1,9 @@
-import pytest
-
-from config import TestingConfig
-from data_loader.arangoload import run
 from common.arangodb import get_db
-from common.utils import app_context, current_app
+from common.utils import current_app
 
-
-def test_normal_testing_db_name():
-    config = TestingConfig()
-    assert config.ARANGO_DB == 'suttacentral_tests'
-
-def test_data_load_tests_db_name():
-    config = TestingConfig()
-    assert config.ARANGO_DB_DATA_LOAD_TEST == 'suttacentral_data_load_tests'
-
-def test_get_application_context():
-    context = current_app().app_context()
-    assert context
 
 def test_set_db_name():
     app = current_app()
     app.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
-    with app.app_context() as context:
+    with app.app_context():
         assert get_db().name == 'suttacentral_data_load_tests'

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -1,9 +1,25 @@
+import pytest
+
 from config import TestingConfig
+from data_loader.arangoload import run
+from common.arangodb import get_db
+from common.utils import app_context, current_app
 
-def test_normal_testing_database_name():
-    config = TestingConfig()
-    assert config.ARANGO_DB == "suttacentral_tests"
 
-def test_data_load_testing_database_name():
+def test_normal_testing_db_name():
     config = TestingConfig()
-    assert config.ARANGO_DB_DATA_LOAD_TEST == "suttacentral_data_load_tests"
+    assert config.ARANGO_DB == 'suttacentral_tests'
+
+def test_data_load_tests_db_name():
+    config = TestingConfig()
+    assert config.ARANGO_DB_DATA_LOAD_TEST == 'suttacentral_data_load_tests'
+
+def test_get_application_context():
+    context = current_app().app_context()
+    assert context
+
+def test_set_db_name():
+    app = current_app()
+    app.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
+    with app.app_context() as context:
+        assert get_db().name == 'suttacentral_data_load_tests'

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 import pytest
 
 from common.arangodb import get_db
 from common.utils import current_app
+from data_loader import arangoload
+
 
 @pytest.fixture
 def data_load_app(app):
@@ -12,3 +16,14 @@ def data_load_app(app):
 def test_set_db_name(data_load_app):
     with data_load_app.app_context():
         assert get_db().name == 'suttacentral_data_load_tests'
+
+def test_do_collect_data_stage(data_load_app):
+    with data_load_app.app_context():
+        data_dir = Path('/opt/sc/sc-flask/sc-data')
+        git_repository = data_load_app.config.get('DATA_REPO')
+        arangoload.collect_data(data_dir, git_repository)
+
+@pytest.mark.skip("Figure out why collect_data() fails first")
+def test_do_entire_run(data_load_app):
+    with data_load_app.app_context():
+        arangoload.run()

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -1,9 +1,14 @@
+import pytest
+
 from common.arangodb import get_db
 from common.utils import current_app
 
-
-def test_set_db_name():
+@pytest.fixture
+def data_load_app(app):
     app = current_app()
     app.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
-    with app.app_context():
+    return app
+
+def test_set_db_name(data_load_app):
+    with data_load_app.app_context():
         assert get_db().name == 'suttacentral_data_load_tests'

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -1,0 +1,5 @@
+from config import TestingConfig
+
+def test_normal_testing_database_name():
+    config = TestingConfig()
+    assert config.ARANGO_DB == "suttacentral_tests"


### PR DESCRIPTION
I've managed to get the first stage of `make data-load` running in pytest. Running `make test-data-load` runs the test.

There's a test for the whole `arangoload.run()` function that is skipped. It doesn't pass due to a failure in `copy_localization()`. We may need the `sc-frontend` container available for this stage.

Given that when the test passes it will slow down the tests unacceptably, we may want to skip the test module in the `make test-server` target.

## Summary by Sourcery

Introduces a pytest-based test suite for the data load process. Adds a new make target to run the data load tests in a docker container. Implements tests for setting the database name, checking the base directory, and collecting data.

Tests:
- Adds initial tests for the data load process, covering database name setting, base directory verification, and data collection.
- Marks the end-to-end data load test as skipped due to a failure in the copy_localization function.