### PR TITLE
Entire data load process runs in pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test:
 test-server:
 	@docker exec -t sc-flask pytest -s --ignore server/data_loader/ server/
 
-test-data-load:
+test-load-data:
 	@docker exec -t sc-flask pytest -v server/data_loader/
 
 test-api:

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test:
 	@make test-server
 
 test-server:
-	@docker exec -t sc-flask pytest -s server/
+	@docker exec -t sc-flask pytest -s --ignore server/data_loader/ server/
 
 test-data-load:
 	@docker exec -t sc-flask pytest -v server/data_loader/

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test:
 test-server:
 	@docker exec -t sc-flask pytest -s --ignore server/data_loader/ server/
 
-test-load-data:
+test-data-load:
 	@docker exec -t sc-flask pytest -v server/data_loader/
 
 test-api:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,7 @@ services:
   sc-flask:
     volumes:
       - ./server/:/opt/sc/sc-flask
+      - ./client/:/opt/sc/frontend
     env_file:
       - server/env/.test.env
     command: bash docker/entrypoint.test.sh

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -3,7 +3,7 @@ import logging
 import os
 import pathlib
 from collections import defaultdict
-from itertools import product
+from itertools import product, count
 from pathlib import Path
 from typing import Dict
 import subprocess
@@ -628,13 +628,27 @@ def insert_uids(db, range_uid, uids):
     db['expanded_sutta_uids'].insert({'range_uid': range_uid, 'expanded_uids': uids})
 
 
-def run(no_pull=False):
+class StagePrinter:
+    def __init__(self):
+        self._numbers = count(start=1)
+        self.messages: list[str] = []
+
+    def print_stage(self, description: str) -> None:
+        number = next(self._numbers)
+        message = f'{number}: {description}'
+        print(f'\n   {message}')
+        self.messages.append(message)
+
+
+
+def run(no_pull: bool = False, printer: StagePrinter | None = None) -> None:
     """Runs data load.
 
     It will take data from sc-data repository and populate the database with it.
 
     Args:
         no_pull: Whether force clean db setup.
+        printer: Prints information for each stage.
     """
 
     data_dir = current_app.config.get('BASE_DIR') / 'sc-data'
@@ -654,173 +668,169 @@ def run(no_pull=False):
         storage_dir.mkdir()
     db = arangodb.get_db()
 
-    _stage = 1
-
-    def print_stage(msg):
-        nonlocal _stage
-        print(f'\n   {_stage}: {msg}')
-        _stage += 1
+    if not printer:
+        printer = StagePrinter()
 
     if not no_pull:
-        print_stage("Retrieving Data Repository")
+        printer.print_stage("Retrieving Data Repository")
         collect_data(data_dir, current_app.config.get('DATA_REPO'))
 
-    print_stage("Copying localization files")
+    printer.print_stage("Copying localization files")
     copy_localization.copy_localization(sc_bilara_data_dir, localized_elements_dir)
 
-    print_stage("Loading languages")
+    printer.print_stage("Loading languages")
     languages.load_languages(db, languages_file, localized_elements_dir)
 
     # print_stage("Loading images")
     # images_files.load_images_links(db)
 
-    print_stage("Loading ChangeTracker")
+    printer.print_stage("Loading ChangeTracker")
     change_tracker = ChangeTracker(data_dir, db)
 
-    print_stage("Loading uid_expansion.json")
+    printer.print_stage("Loading uid_expansion.json")
     load_json_file(db, change_tracker, misc_dir / 'uid_expansion.json')
 
-    print_stage("Loading uid_expansion_edition.json")
+    printer.print_stage("Loading uid_expansion_edition.json")
     load_json_file(db, change_tracker, misc_dir / 'uid_expansion_edition.json')
 
-    print_stage("Loading uid_expansion_language.json")
+    printer.print_stage("Loading uid_expansion_language.json")
     load_json_file(db, change_tracker, misc_dir / 'uid_expansion_language.json')
 
-    print_stage("Loading uid_expansion_school.json")
+    printer.print_stage("Loading uid_expansion_school.json")
     load_json_file(db, change_tracker, misc_dir / 'uid_expansion_school.json')
 
-    print_stage("Loading author_edition.json")
+    printer.print_stage("Loading author_edition.json")
     load_author_edition(change_tracker, additional_info_dir, db)
 
-    print_stage("Loading available_voices.json")
+    printer.print_stage("Loading available_voices.json")
     load_available_voices(change_tracker, additional_info_dir, db)
 
-    print_stage("Loading map_data.json")
+    printer.print_stage("Loading map_data.json")
     load_map_data(additional_info_dir, db)
 
-    print_stage('Loading guides.json')
+    printer.print_stage('Loading guides.json')
     load_guides_file(db, structure_dir / 'guides.json')
 
-    print_stage('Loading pali_reference_edition.json')
+    printer.print_stage('Loading pali_reference_edition.json')
     load_pali_reference_edition_file(db, misc_dir / 'pali_reference_edition.json')
 
-    print_stage('Loading root_edition.json')
+    printer.print_stage('Loading root_edition.json')
     load_root_edition_file(db, misc_dir / 'root_edition.json')
 
-    print_stage('Loading text_extra_info.json')
+    printer.print_stage('Loading text_extra_info.json')
     load_text_extra_info_file(db, structure_dir / 'text_extra_info.json')
 
-    print_stage('Loading shortcuts.json')
+    printer.print_stage('Loading shortcuts.json')
     load_shortcuts_file(db, structure_dir / 'shortcuts.json')
 
-    print_stage('Loading fallen-leaves files')
+    printer.print_stage('Loading fallen-leaves files')
     load_fallen_leaves_files(db, structure_dir / 'fallen-leaves')
 
-    print_stage("Building and loading navigation from structure_dir")
+    printer.print_stage("Building and loading navigation from structure_dir")
     navigation.add_navigation_docs_and_edges(change_tracker, db, structure_dir, sc_bilara_data_dir)
 
-    print_stage("Loading child ranges from structure_dir")
+    printer.print_stage("Loading child ranges from structure_dir")
     load_child_range(db, structure_dir)
 
-    print_stage('Load names from sc_bilara_data')
+    printer.print_stage('Load names from sc_bilara_data')
     sc_bilara_data.load_names(db, sc_bilara_data_dir, languages_file)
 
-    print_stage('Load super names from sc_bilara_data')
+    printer.print_stage('Load super names from sc_bilara_data')
     sc_bilara_data.load_super_names_root_misc_site(db, sc_bilara_data_dir)
 
-    print_stage('Load blurbs from sc_bilara_data')
+    printer.print_stage('Load blurbs from sc_bilara_data')
     sc_bilara_data.load_blurbs(db, sc_bilara_data_dir)
 
-    print_stage('Load publications from sc_bilara_data')
+    printer.print_stage('Load publications from sc_bilara_data')
     sc_bilara_data.load_publications(db, sc_bilara_data_dir)
 
-    print_stage('Load publication editions from sc_bilara_data')
+    printer.print_stage('Load publication editions from sc_bilara_data')
     sc_bilara_data.load_publication_editions(db, sc_bilara_data_dir)
 
-    print_stage('Load texts from sc_bilara_data')
+    printer.print_stage('Load texts from sc_bilara_data')
     sc_bilara_data.load_texts(db, sc_bilara_data_dir)
 
-    print_stage("Updating names")
+    printer.print_stage("Updating names")
     update_translated_title()
 
-    print_stage("Updating root names")
+    printer.print_stage("Updating root names")
     update_root_title()
 
-    print_stage('Load bilara_author_edition from sc_bilara_data')
+    printer.print_stage('Load bilara_author_edition from sc_bilara_data')
     sc_bilara_data.load_bilara_author_edition(db, sc_bilara_data_dir)
 
-    print_stage("Generating and loading relationships")
+    printer.print_stage("Generating and loading relationships")
     generate_relationship_edges(
         change_tracker, relationship_dir, additional_info_dir, db
     )
 
-    print_stage("Loading html_text")
+    printer.print_stage("Loading html_text")
     load_html_texts(change_tracker, data_dir, db, html_dir)
 
-    print_stage('Make yellow brick road')
+    printer.print_stage('Make yellow brick road')
     make_yellow_brick_road(db)
 
-    print_stage("Loading difficulty from additional_info")
+    printer.print_stage("Loading difficulty from additional_info")
     process_difficulty(db, additional_info_dir)
 
-    print_stage("Loading prioritize from additional_info")
+    printer.print_stage("Loading prioritize from additional_info")
     process_prioritize(db, additional_info_dir)
 
-    print_stage("Loading creator bio from additional_info")
+    printer.print_stage("Loading creator bio from additional_info")
     process_creator_bio(db, additional_info_dir)
 
-    print_stage('Loading simple dictionaries')
+    printer.print_stage('Loading simple dictionaries')
     dictionaries.load_simple_dictionaries(db, dictionaries_dir)
 
-    print_stage('Loading complex dictionaries')
+    printer.print_stage('Loading complex dictionaries')
     dictionaries.load_complex_dictionaries(db, dictionaries_dir)
 
-    print_stage('Loading glossary dictionaries')
+    printer.print_stage('Loading glossary dictionaries')
     dictionaries.load_glossaries(db, dictionaries_dir)
 
-    print_stage("Loading currencies from additional_info")
+    printer.print_stage("Loading currencies from additional_info")
     currencies.load_currencies(db, additional_info_dir)
 
-    print_stage("Loading paragraphs from additional_info")
+    printer.print_stage("Loading paragraphs from additional_info")
     paragraphs.load_paragraphs(db, additional_info_dir)
 
-    print_stage("Loading biblio from additional_info")
+    printer.print_stage("Loading biblio from additional_info")
     biblio.load_biblios(db, additional_info_dir)
 
-    print_stage("Loading epigraphs from additional_info")
+    printer.print_stage("Loading epigraphs from additional_info")
     homepage.load_epigraphs(db, additional_info_dir)
 
-    print_stage("Loading why_we_read from additional_info")
+    printer.print_stage("Loading why_we_read from additional_info")
     homepage.load_why_we_read(db, additional_info_dir)
 
-    print_stage("Updating text_extra_info")
+    printer.print_stage("Updating text_extra_info")
     update_text_extra_info()
 
-    print_stage("Update Acronym")
+    printer.print_stage("Update Acronym")
     upsert_text_acronym(structure_dir)
 
-    print_stage("Loading ebs_names")
+    printer.print_stage("Loading ebs_names")
     load_ebs_names()
 
-    print_stage("Generate uid list from range uid")
+    printer.print_stage("Generate uid list from range uid")
     generate_sutta_uid_list_from_range_sutta_uid()
 
-    print_stage("Generating sitemap")
+    printer.print_stage("Generating sitemap")
     sitemap = generate_sitemap(db)
     for folder in pathlib.Path('/opt/sc/frontend/builds').glob('*'):
         if folder.is_dir():
             (folder / 'sitemap.xml').open('w').write(sitemap)
 
-    print_stage("Generating and loading ordering information")
+    printer.print_stage("Generating and loading ordering information")
     order.add_next_prev_using_menu_data(db)
 
-    print_stage("Calculating and loading size data")
+    printer.print_stage("Calculating and loading size data")
     sizes.load_sizes(sizes_dir, db)
 
-    print_stage("Updating mtimes")
+    printer.print_stage("Updating mtimes")
     change_tracker.update_mtimes()
 
-    print_stage('All done')
+    printer.print_stage('All done')
 
 
 def hyphenate_pali_and_san():

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pytest
 
-from common import arangodb
 from common.arangodb import get_db, delete_db
 from common.utils import current_app
 from data_loader import arangoload

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -2,9 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from common.arangodb import get_db
+from common import arangodb
+from common.arangodb import get_db, delete_db
 from common.utils import current_app
 from data_loader import arangoload
+from migrations.runner import run_migrations
 
 
 @pytest.fixture
@@ -29,7 +31,9 @@ def test_do_collect_data_stage(data_load_app):
         git_repository = data_load_app.config.get('DATA_REPO')
         arangoload.collect_data(data_dir, git_repository)
 
-@pytest.mark.skip("Get copy_localization working")
 def test_do_entire_run(data_load_app):
     with data_load_app.app_context():
+        db = get_db()
+        delete_db(db)
+        run_migrations()
         arangoload.run()

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -5,6 +5,7 @@ import pytest
 from common.arangodb import get_db, delete_db
 from common.utils import current_app
 from data_loader import arangoload
+from data_loader.arangoload import StagePrinter
 from migrations.runner import run_migrations
 
 
@@ -30,9 +31,38 @@ def test_do_collect_data_stage(data_load_app):
         git_repository = data_load_app.config.get('DATA_REPO')
         arangoload.collect_data(data_dir, git_repository)
 
+@pytest.mark.skip('Long running test.')
 def test_do_entire_run(data_load_app):
     with data_load_app.app_context():
         db = get_db()
         delete_db(db)
         run_migrations()
-        arangoload.run()
+        printer = StagePrinter()
+        arangoload.run(no_pull=False, printer=printer)
+        assert len(printer.messages) == 51
+
+
+class TestStagePrinter:
+    def test_prints_one_stage(self, capsys):
+        printer = StagePrinter()
+        printer.print_stage('Retrieving Data Repository')
+        captured = capsys.readouterr()
+        assert captured.out == '\n   1: Retrieving Data Repository\n'
+
+    def test_prints_two_stages(self, capsys):
+        printer = StagePrinter()
+        printer.print_stage('Retrieving Data Repository')
+        printer.print_stage('Copying localization files')
+        captured = capsys.readouterr()
+        expected =  '\n   1: Retrieving Data Repository\n'
+        expected += '\n   2: Copying localization files\n'
+        assert captured.out == expected
+
+    def test_saves_messages(self):
+        printer = StagePrinter()
+        printer.print_stage('Retrieving Data Repository')
+        printer.print_stage('Copying localization files')
+        assert printer.messages == [
+            '1: Retrieving Data Repository',
+            '2: Copying localization files',
+        ]

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -2,11 +2,9 @@ from pathlib import Path
 
 import pytest
 
-from common import arangodb
-from common.arangodb import get_db, delete_db
+from common.arangodb import get_db
 from common.utils import current_app
 from data_loader import arangoload
-from migrations.runner import run_migrations
 
 
 @pytest.fixture
@@ -31,9 +29,7 @@ def test_do_collect_data_stage(data_load_app):
         git_repository = data_load_app.config.get('DATA_REPO')
         arangoload.collect_data(data_dir, git_repository)
 
+@pytest.mark.skip("Get copy_localization working")
 def test_do_entire_run(data_load_app):
     with data_load_app.app_context():
-        db = get_db()
-        delete_db(db)
-        run_migrations()
         arangoload.run()


### PR DESCRIPTION
- Changed `test-data-load` make target to `test-load-data` for consistency.
- Added client volume to sc-flask container as the "Loading Languages" stage requires access to run successfully.
- Finally got the whole loading process running in pytest.

Running `make test-data-load` now will delete and recreate the database and populate it with the latest suttacentral data.

## Summary by Sourcery

Improve the data loading process for testing by enabling full data load in pytest and updating related configuration

New Features:
- Enabled complete data loading process to run within pytest test environment

Enhancements:
- Renamed 'test-data-load' make target to 'test-load-data' for improved consistency
- Updated test server configuration to ignore data loader during standard server tests

Tests:
- Modified test configuration to allow full data loading process in pytest
- Removed skip marker from entire data load test

Chores:
- Updated docker-compose test configuration to mount client volume