### PR TITLE
Remove the language badge in the suttaplex cards.

### DIFF
--- a/client/elements/suttaplex/card/sc-suttaplex-tx.js
+++ b/client/elements/suttaplex/card/sc-suttaplex-tx.js
@@ -33,9 +33,6 @@ export class SCSuttaplexTx extends LitElement {
           >
             ${icon.open_book}
             <div class="tx-details">
-              <span class="badges">
-                <sc-badge text="${this.translation?.lang?.toUpperCase()}" color="language"></sc-badge>
-              </span>
               <span class="tx-creator">${this.translation?.author}</span>
               <span class="tx-publication"> ${this.publicationInfoTemplate()} </span>
               <span class="badges"> ${this.badgeTemplate()} </span>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Simplified the suttaplex translation card UI by removing the language badge