### PR TITLE
StagePrinter writes clock and cpu time to CSV

### DIFF
--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -625,7 +625,7 @@ def insert_uids(db, range_uid, uids):
     db['expanded_sutta_uids'].insert({'range_uid': range_uid, 'expanded_uids': uids})
 
 
-def run(no_pull: bool = False, printer: StagePrinter | None = None) -> None:
+def run(no_pull: bool = False) -> StagePrinter:
     """Runs data load.
 
     It will take data from sc-data repository and populate the database with it.
@@ -652,8 +652,7 @@ def run(no_pull: bool = False, printer: StagePrinter | None = None) -> None:
         storage_dir.mkdir()
     db = arangodb.get_db()
 
-    if not printer:
-        printer = StagePrinter()
+    printer = StagePrinter()
 
     if not no_pull:
         printer.print_stage("Retrieving Data Repository")
@@ -816,6 +815,7 @@ def run(no_pull: bool = False, printer: StagePrinter | None = None) -> None:
 
     printer.print_stage('All done')
 
+    return printer
 
 def hyphenate_pali_and_san():
     db = arangodb.get_db()

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -1,8 +1,12 @@
+import csv
 import json
 import logging
 import os
 import pathlib
+import time
 from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
 from itertools import product, count
 from pathlib import Path
 from typing import Dict
@@ -628,16 +632,57 @@ def insert_uids(db, range_uid, uids):
     db['expanded_sutta_uids'].insert({'range_uid': range_uid, 'expanded_uids': uids})
 
 
+@dataclass
+class Stage:
+    number: int
+    description: str
+    elapsed_time: float
+
+    def __str__(self) -> str:
+        return f'\n   {self.number}: {self.description}'
+
 class StagePrinter:
-    def __init__(self):
+    def __init__(self, perf_counter: Callable[[], float] = time.perf_counter):
+        self.stages: list[Stage] = []
+
         self._numbers = count(start=1)
-        self.messages: list[str] = []
+
+        self._perf_counter = perf_counter
+        self._elapsed: float = self._perf_counter()
+
+    def _get_elapsed_time(self) -> float:
+        old_time = self._elapsed
+        new_time = self._perf_counter()
+        self._elapsed = new_time
+        return new_time - old_time
+
+    def _create_stage(self, description) -> Stage:
+        number = next(self._numbers)
+
+        return Stage(
+            number=number,
+            description=description,
+            elapsed_time=0,
+        )
+
+    def _set_elapsed_time_of_previous_stage(self):
+        if len(self.stages) > 0:
+            self.stages[-1].elapsed_time = self._get_elapsed_time()
 
     def print_stage(self, description: str) -> None:
-        number = next(self._numbers)
-        message = f'{number}: {description}'
-        print(f'\n   {message}')
-        self.messages.append(message)
+        self._set_elapsed_time_of_previous_stage()
+
+        stage = self._create_stage(description)
+        self.stages.append(stage)
+
+        print(stage)
+
+    def save_as_csv(self, file: str) -> None:
+        with open(file, mode='w') as output_file:
+            writer = csv.writer(output_file)
+            writer.writerow(['Number', 'Message', 'Elapsed Time'])
+            for stage in self.stages:
+                writer.writerow([stage.number, stage.description, stage.elapsed_time])
 
 
 

--- a/server/server/data_loader/observability.py
+++ b/server/server/data_loader/observability.py
@@ -54,14 +54,22 @@ class Stage:
 
 
 class StagePrinter:
-    def __init__(self, perf_counter: Callable[[], float] = time.perf_counter):
+    def __init__(self,
+                 perf_counter: Callable[[], float] = time.perf_counter,
+                 process_time: Callable[[], float] = time.process_time,
+                 ):
+
         self.stages: list[Stage] = []
         self._numbers = count(start=1)
         self._perf_counter = perf_counter
+        self._process_time = process_time
 
     def _create_stage(self, description) -> Stage:
         number = next(self._numbers)
-        run_time = RunTime(perf_counter=self._perf_counter)
+        run_time = RunTime(
+            perf_counter=self._perf_counter,
+            process_time=self._process_time,
+        )
         run_time.start()
 
         return Stage(

--- a/server/server/data_loader/observability.py
+++ b/server/server/data_loader/observability.py
@@ -6,6 +6,10 @@ from itertools import count
 from typing import Callable
 
 
+def clock_seconds(perf_counter: Callable[[], float]) -> Iterator[float]:
+    yield from [1.2, 9.3, 0.3]
+
+
 @dataclass
 class Stage:
     number: int

--- a/server/server/data_loader/observability.py
+++ b/server/server/data_loader/observability.py
@@ -27,7 +27,7 @@ class RunTime:
 class Stage:
     number: int
     description: str
-    elapsed_time: float
+    run_time: RunTime
 
     def __str__(self) -> str:
         return f'\n   {self.number}: {self.description}'
@@ -50,19 +50,18 @@ class StagePrinter:
 
     def _create_stage(self, description) -> Stage:
         number = next(self._numbers)
+        run_time = RunTime(perf_counter=self._perf_counter)
+        run_time.start()
 
         return Stage(
             number=number,
             description=description,
-            elapsed_time=0,
+            run_time=run_time,
         )
 
-    def _set_elapsed_time_of_previous_stage(self):
-        if len(self.stages) > 0:
-            self.stages[-1].elapsed_time = next(self._clock_time_elapsed())
-
     def print_stage(self, description: str) -> None:
-        self._set_elapsed_time_of_previous_stage()
+        if len(self.stages) > 0:
+            self.stages[-1].run_time.end()
 
         stage = self._create_stage(description)
         self.stages.append(stage)
@@ -74,4 +73,4 @@ class StagePrinter:
             writer = csv.writer(output_file)
             writer.writerow(['Number', 'Message', 'Elapsed Time'])
             for stage in self.stages:
-                writer.writerow([stage.number, stage.description, stage.elapsed_time])
+                writer.writerow([stage.number, stage.description, stage.run_time.clock_seconds])

--- a/server/server/data_loader/observability.py
+++ b/server/server/data_loader/observability.py
@@ -6,10 +6,6 @@ from itertools import count
 from typing import Callable
 
 
-def clock_seconds(perf_counter: Callable[[], float]) -> Iterator[float]:
-    yield from [1.2, 9.3, 0.3]
-
-
 @dataclass
 class Stage:
     number: int

--- a/server/server/data_loader/observability.py
+++ b/server/server/data_loader/observability.py
@@ -1,0 +1,59 @@
+import csv
+import time
+from dataclasses import dataclass
+from itertools import count
+from typing import Callable
+
+
+@dataclass
+class Stage:
+    number: int
+    description: str
+    elapsed_time: float
+
+    def __str__(self) -> str:
+        return f'\n   {self.number}: {self.description}'
+
+
+class StagePrinter:
+    def __init__(self, perf_counter: Callable[[], float] = time.perf_counter):
+        self.stages: list[Stage] = []
+
+        self._numbers = count(start=1)
+
+        self._perf_counter = perf_counter
+        self._elapsed: float = self._perf_counter()
+
+    def _get_elapsed_time(self) -> float:
+        old_time = self._elapsed
+        new_time = self._perf_counter()
+        self._elapsed = new_time
+        return new_time - old_time
+
+    def _create_stage(self, description) -> Stage:
+        number = next(self._numbers)
+
+        return Stage(
+            number=number,
+            description=description,
+            elapsed_time=0,
+        )
+
+    def _set_elapsed_time_of_previous_stage(self):
+        if len(self.stages) > 0:
+            self.stages[-1].elapsed_time = self._get_elapsed_time()
+
+    def print_stage(self, description: str) -> None:
+        self._set_elapsed_time_of_previous_stage()
+
+        stage = self._create_stage(description)
+        self.stages.append(stage)
+
+        print(stage)
+
+    def save_as_csv(self, file: str) -> None:
+        with open(file, mode='w') as output_file:
+            writer = csv.writer(output_file)
+            writer.writerow(['Number', 'Message', 'Elapsed Time'])
+            for stage in self.stages:
+                writer.writerow([stage.number, stage.description, stage.elapsed_time])

--- a/server/server/data_loader/observability.py
+++ b/server/server/data_loader/observability.py
@@ -9,8 +9,8 @@ from typing import Callable
 class RunTime:
     def __init__(self, perf_counter: Callable[[], float] = time.perf_counter):
         self._perf_counter = perf_counter
-        self._start_clock_time = 0
-        self._end_clock_time = 0
+        self._start_clock_time = None
+        self._end_clock_time = None
 
     def start(self) -> None:
         self._start_clock_time = self._perf_counter()
@@ -20,7 +20,10 @@ class RunTime:
 
     @property
     def clock_seconds(self) -> float | None:
-        return self._end_clock_time - self._start_clock_time
+        if self._start_clock_time and self._end_clock_time:
+            return self._end_clock_time - self._start_clock_time
+        else:
+            return None
 
 
 @dataclass

--- a/server/server/data_loader/observability.py
+++ b/server/server/data_loader/observability.py
@@ -87,9 +87,13 @@ class StagePrinter:
 
         print(stage)
 
-    def save_as_csv(self, file: str) -> None:
-        with open(file, mode='w') as output_file:
-            writer = csv.writer(output_file)
-            writer.writerow(['Number', 'Message', 'Elapsed Time'])
-            for stage in self.stages:
-                writer.writerow([stage.number, stage.description, stage.run_time.clock_seconds])
+def save_as_csv(stages: list[Stage], file: str) -> None:
+    with open(file, mode='w') as output_file:
+        writer = csv.writer(output_file)
+        writer.writerow(['Number', 'Message', 'Clock Time (s)', 'CPU Time (s)'])
+        for stage in stages:
+            writer.writerow(
+                [stage.number,
+                 stage.description,
+                 stage.run_time.clock_seconds,
+                 stage.run_time.cpu_seconds])

--- a/server/server/data_loader/observability.py
+++ b/server/server/data_loader/observability.py
@@ -7,21 +7,38 @@ from typing import Callable
 
 
 class RunTime:
-    def __init__(self, perf_counter: Callable[[], float] = time.perf_counter):
+    def __init__(self,
+                 perf_counter: Callable[[], float] = time.perf_counter,
+                 process_time: Callable[[], float] = time.process_time,
+                 ):
+
         self._perf_counter = perf_counter
+        self._process_time = process_time
+
         self._start_clock_time = None
         self._end_clock_time = None
+        self._start_cpu_time = None
+        self._end_cpu_time = None
 
     def start(self) -> None:
         self._start_clock_time = self._perf_counter()
+        self._start_cpu_time = self._process_time()
 
     def end(self) -> None:
         self._end_clock_time = self._perf_counter()
+        self._end_cpu_time = self._process_time()
 
     @property
     def clock_seconds(self) -> float | None:
         if self._start_clock_time and self._end_clock_time:
             return self._end_clock_time - self._start_clock_time
+        else:
+            return None
+
+    @property
+    def cpu_seconds(self) -> float | None:
+        if self._start_cpu_time and self._end_cpu_time:
+            return self._end_cpu_time - self._start_cpu_time
         else:
             return None
 

--- a/server/server/data_loader/observability.py
+++ b/server/server/data_loader/observability.py
@@ -1,5 +1,6 @@
 import csv
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from itertools import count
 from typing import Callable
@@ -24,11 +25,11 @@ class StagePrinter:
         self._perf_counter = perf_counter
         self._elapsed: float = self._perf_counter()
 
-    def _get_elapsed_time(self) -> float:
+    def _clock_time_elapsed(self) -> Iterator[float]:
         old_time = self._elapsed
         new_time = self._perf_counter()
         self._elapsed = new_time
-        return new_time - old_time
+        yield new_time - old_time
 
     def _create_stage(self, description) -> Stage:
         number = next(self._numbers)
@@ -41,7 +42,7 @@ class StagePrinter:
 
     def _set_elapsed_time_of_previous_stage(self):
         if len(self.stages) > 0:
-            self.stages[-1].elapsed_time = self._get_elapsed_time()
+            self.stages[-1].elapsed_time = next(self._clock_time_elapsed())
 
     def print_stage(self, description: str) -> None:
         self._set_elapsed_time_of_previous_stage()

--- a/server/server/data_loader/observability.py
+++ b/server/server/data_loader/observability.py
@@ -6,6 +6,23 @@ from itertools import count
 from typing import Callable
 
 
+class RunTime:
+    def __init__(self, perf_counter: Callable[[], float] = time.perf_counter):
+        self._perf_counter = perf_counter
+        self._start_clock_time = 0
+        self._end_clock_time = 0
+
+    def start(self) -> None:
+        self._start_clock_time = self._perf_counter()
+
+    def end(self) -> None:
+        self._end_clock_time = self._perf_counter()
+
+    @property
+    def clock_seconds(self) -> float | None:
+        return self._end_clock_time - self._start_clock_time
+
+
 @dataclass
 class Stage:
     number: int

--- a/server/server/data_loader/observability.py
+++ b/server/server/data_loader/observability.py
@@ -36,17 +36,8 @@ class Stage:
 class StagePrinter:
     def __init__(self, perf_counter: Callable[[], float] = time.perf_counter):
         self.stages: list[Stage] = []
-
         self._numbers = count(start=1)
-
         self._perf_counter = perf_counter
-        self._elapsed: float = self._perf_counter()
-
-    def _clock_time_elapsed(self) -> Iterator[float]:
-        old_time = self._elapsed
-        new_time = self._perf_counter()
-        self._elapsed = new_time
-        yield new_time - old_time
 
     def _create_stage(self, description) -> Stage:
         number = next(self._numbers)

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -1,4 +1,3 @@
-from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -38,8 +37,7 @@ def test_do_entire_run(data_load_app):
         db = get_db()
         delete_db(db)
         run_migrations()
-        printer = StagePrinter()
-        arangoload.run(no_pull=False, printer=printer)
+        printer = arangoload.run(no_pull=False)
         assert len(printer.stages) == 51
         printer.save_as_csv("load-data-run.csv")
 

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -5,6 +5,7 @@ import pytest
 from common.arangodb import get_db, delete_db
 from common.utils import current_app
 from data_loader import arangoload
+from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
 
@@ -30,7 +31,7 @@ def test_do_collect_data_stage(data_load_app):
         git_repository = data_load_app.config.get('DATA_REPO')
         arangoload.collect_data(data_dir, git_repository)
 
-@pytest.mark.skip('Long running test.')
+# @pytest.mark.skip('Long running test.')
 def test_do_entire_run(data_load_app):
     with data_load_app.app_context():
         db = get_db()
@@ -38,6 +39,4 @@ def test_do_entire_run(data_load_app):
         run_migrations()
         printer = arangoload.run(no_pull=False)
         assert len(printer.stages) == 51
-        printer.save_as_csv("load-data-run.csv")
-
-
+        save_as_csv(printer.stages, "load-data-run.csv")

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -30,7 +30,7 @@ def test_do_collect_data_stage(data_load_app):
         git_repository = data_load_app.config.get('DATA_REPO')
         arangoload.collect_data(data_dir, git_repository)
 
-# @pytest.mark.skip('Long running test.')
+@pytest.mark.skip('Long running test.')
 def test_do_entire_run(data_load_app):
     with data_load_app.app_context():
         db = get_db()

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -31,7 +31,7 @@ def test_do_collect_data_stage(data_load_app):
         git_repository = data_load_app.config.get('DATA_REPO')
         arangoload.collect_data(data_dir, git_repository)
 
-# @pytest.mark.skip('Long running test.')
+@pytest.mark.skip('Long running test.')
 def test_do_entire_run(data_load_app):
     with data_load_app.app_context():
         db = get_db()

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -6,7 +6,7 @@ import pytest
 from common.arangodb import get_db, delete_db
 from common.utils import current_app
 from data_loader import arangoload
-from data_loader.arangoload import StagePrinter
+from data_loader.observability import StagePrinter
 from migrations.runner import run_migrations
 
 
@@ -32,7 +32,7 @@ def test_do_collect_data_stage(data_load_app):
         git_repository = data_load_app.config.get('DATA_REPO')
         arangoload.collect_data(data_dir, git_repository)
 
-@pytest.mark.skip('Long running test.')
+# @pytest.mark.skip('Long running test.')
 def test_do_entire_run(data_load_app):
     with data_load_app.app_context():
         db = get_db()

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -5,7 +5,6 @@ import pytest
 from common.arangodb import get_db, delete_db
 from common.utils import current_app
 from data_loader import arangoload
-from data_loader.observability import StagePrinter
 from migrations.runner import run_migrations
 
 
@@ -42,44 +41,3 @@ def test_do_entire_run(data_load_app):
         printer.save_as_csv("load-data-run.csv")
 
 
-class FakePerfCounter:
-    def __init__(self, times: list[float]):
-        self._times = iter(times)
-
-    def __call__(self) -> float:
-        return next(self._times)
-
-
-class TestStagePrinter:
-    def test_prints_one_stage(self, capsys):
-        printer = StagePrinter()
-        printer.print_stage('Retrieving Data Repository')
-        captured = capsys.readouterr()
-        assert captured.out == '\n   1: Retrieving Data Repository\n'
-
-    def test_prints_two_stages(self, capsys):
-        printer = StagePrinter()
-        printer.print_stage('Retrieving Data Repository')
-        printer.print_stage('Copying localization files')
-        captured = capsys.readouterr()
-        expected =  '\n   1: Retrieving Data Repository\n'
-        expected += '\n   2: Copying localization files\n'
-        assert captured.out == expected
-
-    def test_tracks_message(self):
-        printer = StagePrinter()
-        printer.print_stage('Retrieving Data Repository')
-        printer.print_stage('Copying localization files')
-        assert printer.stages[0].description == 'Retrieving Data Repository'
-        assert printer.stages[1].description == 'Copying localization files'
-
-    def test_tracks_elapsed_time(self):
-        perf_counter = FakePerfCounter([1.1, 2.3, 11.6, 11.9])
-        printer = StagePrinter(perf_counter=perf_counter)
-        printer.print_stage('Retrieving Data Repository')
-        printer.print_stage('Copying localization files')
-        printer.print_stage('All done')
-
-        assert printer.stages[0].elapsed_time == pytest.approx(1.2)
-        assert printer.stages[1].elapsed_time == pytest.approx(9.3)
-        assert printer.stages[2].elapsed_time == 0.0

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -89,6 +89,15 @@ class TestRunTime:
         run_time.end()
         assert run_time.clock_seconds == 2.0
 
+    def test_run_time_records_cpu_seconds(self):
+        process_time = FakeTimeCounter(
+            start_time=1.0, stage_time=2.0)
+
+        run_time = RunTime(process_time=process_time)
+        run_time.start()
+        run_time.end()
+        assert run_time.cpu_seconds == 2.0
+
 
 class TestStagePrinter:
     def test_prints_one_stage(self, capsys):

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -1,6 +1,6 @@
 import pytest
 
-from data_loader.observability import StagePrinter
+from data_loader.observability import StagePrinter, clock_seconds
 
 
 class FakePerfCounter:
@@ -10,6 +10,12 @@ class FakePerfCounter:
     def __call__(self) -> float:
         return next(self._times)
 
+
+class TestClockSeconds:
+    def test_clock_seconds(self):
+        counter = FakePerfCounter([1.1, 2.3, 11.6, 11.9])
+        seconds = clock_seconds(counter)
+        assert next(seconds) == 1.2
 
 class TestStagePrinter:
     def test_prints_one_stage(self, capsys):

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -5,7 +5,7 @@ import pytest
 from data_loader.observability import StagePrinter, RunTime
 
 
-class FakePerfCounter:
+class FakeTimeCounter:
     def __init__(self,
                  start_time: float,
                  stage_time: float,
@@ -32,9 +32,9 @@ class FakePerfCounter:
         return next(self._results)
 
 
-class TestFakePerfCounter:
+class TestTimeCounter:
     def test_starting_time(self):
-        counter = FakePerfCounter(
+        counter = FakeTimeCounter(
             start_time=1.1,
             stage_time=1.0,
         )
@@ -42,7 +42,7 @@ class TestFakePerfCounter:
         assert counter() == 1.1
 
     def test_constant_stage_time_with_no_inbetween(self):
-        counter = FakePerfCounter(
+        counter = FakeTimeCounter(
             start_time=1.0,
             stage_time=2.0,
             time_between_stages=0.0,
@@ -54,7 +54,7 @@ class TestFakePerfCounter:
         assert counter() == 5.0
 
     def test_time_between_stages(self):
-        counter = FakePerfCounter(
+        counter = FakeTimeCounter(
             start_time=2.0,
             stage_time=1.0,
             time_between_stages=0.2,
@@ -67,7 +67,7 @@ class TestFakePerfCounter:
         assert counter() == 4.2
 
     def test_increment_stage_time(self):
-        counter = FakePerfCounter(
+        counter = FakeTimeCounter(
             start_time=2.0,
             stage_time=1.0,
             time_between_stages=0.1,
@@ -81,7 +81,7 @@ class TestFakePerfCounter:
 
 class TestRunTime:
     def test_create_run_time(self):
-        perf_counter = FakePerfCounter(
+        perf_counter = FakeTimeCounter(
             start_time=1.0, stage_time=2.0)
 
         run_time = RunTime(perf_counter=perf_counter)
@@ -114,7 +114,7 @@ class TestStagePrinter:
         assert printer.stages[1].description == 'Copying localization files'
 
     def test_tracks_elapsed_time(self):
-        perf_counter = FakePerfCounter(
+        perf_counter = FakeTimeCounter(
             start_time=1.0, stage_time=2.0,
             time_between_stages=0.5, increase_each_stage_by=0.5)
 

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -1,6 +1,6 @@
 import pytest
 
-from data_loader.observability import StagePrinter
+from data_loader.observability import StagePrinter, RunTime
 
 
 class FakePerfCounter:
@@ -9,6 +9,15 @@ class FakePerfCounter:
 
     def __call__(self) -> float:
         return next(self._times)
+
+
+class TestRunTime:
+    def test_create_run_time(self):
+        perf_counter = FakePerfCounter([1.1, 2.3])
+        run_time = RunTime(perf_counter=perf_counter)
+        run_time.start()
+        run_time.end()
+        assert run_time.clock_seconds == pytest.approx(1.2)
 
 
 class TestStagePrinter:

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -1,6 +1,6 @@
 import pytest
 
-from data_loader.observability import StagePrinter, clock_seconds
+from data_loader.observability import StagePrinter
 
 
 class FakePerfCounter:
@@ -10,14 +10,6 @@ class FakePerfCounter:
     def __call__(self) -> float:
         return next(self._times)
 
-
-class TestClockSeconds:
-    def test_clock_seconds(self):
-        counter = FakePerfCounter([1.1, 2.3, 11.6, 11.9])
-        seconds = clock_seconds(counter)
-        assert next(seconds) == 1.2
-        assert next(seconds) == 9.3
-        assert next(seconds) == 0.3
 
 class TestStagePrinter:
     def test_prints_one_stage(self, capsys):

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -15,12 +15,17 @@ class FakePerfCounter:
         self._interval = interval
         self._time_between_stages = time_between_stages
         self._increment_interval_by = increment_interval_by
+        self._results = iter(self._result_generator())
 
-    def _results(self) -> Iterator[float]:
-        yield self._first_results
+    def _result_generator(self) -> Iterator[float]:
+        result = self._first_results
+
+        while True:
+            yield result
+            result += self._interval
 
     def __call__(self) -> float:
-        return next(self._results())
+        return next(self._results)
 
 
 class TestFakePerfCounter:
@@ -33,6 +38,17 @@ class TestFakePerfCounter:
         )
 
         assert counter() == 1.1
+
+    def test_constant_intervals(self):
+        counter = FakePerfCounter(
+            first_result=1.1,
+            interval=1.2,
+            time_between_stages=0.0,
+            increment_interval_by=0.0
+        )
+
+        assert counter() == 1.1
+        assert counter() == 2.3
 
 
 class TestRunTime:

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -127,13 +127,23 @@ class TestStagePrinter:
             start_time=1.0, stage_time=2.0,
             time_between_stages=0.5, increase_each_stage_by=0.5)
 
-        printer = StagePrinter(perf_counter=perf_counter)
+        process_time = FakeTimeCounter(
+            start_time=1.0, stage_time=1.5,
+            time_between_stages=0.5, increase_each_stage_by=0.5)
+
+        printer = StagePrinter(
+            perf_counter=perf_counter,
+            process_time=process_time,
+        )
         printer.print_stage('Retrieving Data Repository')
         printer.print_stage('Copying localization files')
         printer.print_stage('All done')
 
         assert printer.stages[0].run_time.clock_seconds == 2.0
         assert printer.stages[1].run_time.clock_seconds == 2.5
+
+        assert printer.stages[0].run_time.cpu_seconds == 1.5
+        assert printer.stages[1].run_time.cpu_seconds == 2.0
 
     def test_clock_seconds_is_none_when_there_is_no_subsequent_stage(self):
         printer = StagePrinter()

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -81,11 +81,13 @@ class TestFakePerfCounter:
 
 class TestRunTime:
     def test_create_run_time(self):
-        perf_counter = FakePerfCounter(start_time=1.2, stage_time=1.3)
+        perf_counter = FakePerfCounter(
+            start_time=1.0, stage_time=2.0)
+
         run_time = RunTime(perf_counter=perf_counter)
         run_time.start()
         run_time.end()
-        assert run_time.clock_seconds == 1.3
+        assert run_time.clock_seconds == 2.0
 
 
 class TestStagePrinter:
@@ -111,14 +113,16 @@ class TestStagePrinter:
         assert printer.stages[0].description == 'Retrieving Data Repository'
         assert printer.stages[1].description == 'Copying localization files'
 
-    @pytest.mark.skip("Still needs work")
     def test_tracks_elapsed_time(self):
-        perf_counter = FakePerfCounter(start_time=1.2, stage_time=1.3)
+        perf_counter = FakePerfCounter(
+            start_time=1.0, stage_time=2.0,
+            time_between_stages=0.5, increase_each_stage_by=0.5)
+
         printer = StagePrinter(perf_counter=perf_counter)
         printer.print_stage('Retrieving Data Repository')
         printer.print_stage('Copying localization files')
         printer.print_stage('All done')
 
-        assert printer.stages[0].run_time.clock_seconds == 1.3
-        assert printer.stages[1].run_time.clock_seconds == 1.3
-        assert printer.stages[2].run_time.clock_seconds is None
+        assert printer.stages[0].run_time.clock_seconds == 2.0
+        assert printer.stages[1].run_time.clock_seconds == 2.5
+        # assert printer.stages[2].run_time.clock_seconds is None

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -125,4 +125,8 @@ class TestStagePrinter:
 
         assert printer.stages[0].run_time.clock_seconds == 2.0
         assert printer.stages[1].run_time.clock_seconds == 2.5
-        # assert printer.stages[2].run_time.clock_seconds is None
+
+    def test_clock_seconds_is_none_when_there_is_no_subsequent_stage(self):
+        printer = StagePrinter()
+        printer.print_stage('First Stage')
+        assert printer.stages[0].run_time.clock_seconds is None

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -9,8 +9,8 @@ class FakePerfCounter:
     def __init__(self,
                  start_time: float,
                  stage_time: float,
-                 time_between_stages: float,
-                 increase_each_stage_by: float):
+                 time_between_stages: float = 0.0,
+                 increase_each_stage_by: float = 0.0):
         self._start_time = start_time
         self._stage_time = stage_time
         self._time_between_stages = time_between_stages
@@ -37,8 +37,6 @@ class TestFakePerfCounter:
         counter = FakePerfCounter(
             start_time=1.1,
             stage_time=1.0,
-            time_between_stages=0.0,
-            increase_each_stage_by=0.0,
         )
 
         assert counter() == 1.1
@@ -48,7 +46,6 @@ class TestFakePerfCounter:
             start_time=1.0,
             stage_time=2.0,
             time_between_stages=0.0,
-            increase_each_stage_by=0.0
         )
 
         assert counter() == 1.0
@@ -83,13 +80,12 @@ class TestFakePerfCounter:
         assert counter() == 4.6
 
 class TestRunTime:
-    @pytest.mark.skip("Sort out FakePerfCounter first")
     def test_create_run_time(self):
-        perf_counter = FakePerfCounter(start=1.2, intervals=[1.1])
+        perf_counter = FakePerfCounter(start_time=1.2, stage_time=1.3)
         run_time = RunTime(perf_counter=perf_counter)
         run_time.start()
         run_time.end()
-        assert run_time.clock_seconds == pytest.approx(1.2)
+        assert run_time.clock_seconds == 1.3
 
 
 class TestStagePrinter:
@@ -115,14 +111,14 @@ class TestStagePrinter:
         assert printer.stages[0].description == 'Retrieving Data Repository'
         assert printer.stages[1].description == 'Copying localization files'
 
-    @pytest.mark.skip("Sort out FakePerfCounter first")
+    @pytest.mark.skip("Still needs work")
     def test_tracks_elapsed_time(self):
-        perf_counter = FakePerfCounter([1.1, 2.3, 11.6, 11.9])
+        perf_counter = FakePerfCounter(start_time=1.2, stage_time=1.3)
         printer = StagePrinter(perf_counter=perf_counter)
         printer.print_stage('Retrieving Data Repository')
         printer.print_stage('Copying localization files')
         printer.print_stage('All done')
 
-        assert printer.stages[0].run_time.clock_seconds == pytest.approx(1.2)
-        assert printer.stages[1].run_time.clock_seconds == pytest.approx(9.3)
+        assert printer.stages[0].run_time.clock_seconds == 1.3
+        assert printer.stages[1].run_time.clock_seconds == 1.3
         assert printer.stages[2].run_time.clock_seconds is None

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -16,6 +16,8 @@ class TestClockSeconds:
         counter = FakePerfCounter([1.1, 2.3, 11.6, 11.9])
         seconds = clock_seconds(counter)
         assert next(seconds) == 1.2
+        assert next(seconds) == 9.3
+        assert next(seconds) == 0.3
 
 class TestStagePrinter:
     def test_prints_one_stage(self, capsys):

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -80,7 +80,7 @@ class TestTimeCounter:
         assert counter() == 4.6
 
 class TestRunTime:
-    def test_create_run_time(self):
+    def test_run_time_records_clock_seconds(self):
         perf_counter = FakeTimeCounter(
             start_time=1.0, stage_time=2.0)
 

--- a/server/server/data_loader/tests/test_observability.py
+++ b/server/server/data_loader/tests/test_observability.py
@@ -1,0 +1,46 @@
+import pytest
+
+from data_loader.observability import StagePrinter
+
+
+class FakePerfCounter:
+    def __init__(self, times: list[float]):
+        self._times = iter(times)
+
+    def __call__(self) -> float:
+        return next(self._times)
+
+
+class TestStagePrinter:
+    def test_prints_one_stage(self, capsys):
+        printer = StagePrinter()
+        printer.print_stage('Retrieving Data Repository')
+        captured = capsys.readouterr()
+        assert captured.out == '\n   1: Retrieving Data Repository\n'
+
+    def test_prints_two_stages(self, capsys):
+        printer = StagePrinter()
+        printer.print_stage('Retrieving Data Repository')
+        printer.print_stage('Copying localization files')
+        captured = capsys.readouterr()
+        expected =  '\n   1: Retrieving Data Repository\n'
+        expected += '\n   2: Copying localization files\n'
+        assert captured.out == expected
+
+    def test_tracks_message(self):
+        printer = StagePrinter()
+        printer.print_stage('Retrieving Data Repository')
+        printer.print_stage('Copying localization files')
+        assert printer.stages[0].description == 'Retrieving Data Repository'
+        assert printer.stages[1].description == 'Copying localization files'
+
+    def test_tracks_elapsed_time(self):
+        perf_counter = FakePerfCounter([1.1, 2.3, 11.6, 11.9])
+        printer = StagePrinter(perf_counter=perf_counter)
+        printer.print_stage('Retrieving Data Repository')
+        printer.print_stage('Copying localization files')
+        printer.print_stage('All done')
+
+        assert printer.stages[0].elapsed_time == pytest.approx(1.2)
+        assert printer.stages[1].elapsed_time == pytest.approx(9.3)
+        assert printer.stages[2].elapsed_time == 0.0


### PR DESCRIPTION
I've expanded the `StagePrinter` class to track the time taken by each stage and added a method allowing details to be written in CSV format for later analysis.

See issue #3369

## Summary by Sourcery

Enhance StagePrinter to track and report stage execution times

New Features:
- Add ability to save stage timing information to a CSV file for performance analysis

Enhancements:
- Modify StagePrinter to track elapsed time for each stage
- Introduce a Stage dataclass to store stage details including timing information

Tests:
- Add tests to verify stage timing tracking
- Implement a FakePerfCounter for precise time tracking in tests