### PR TITLE
Delete dead code from sc_html.py

### DIFF
--- a/server/server/data_loader/sc_html.py
+++ b/server/server/data_loader/sc_html.py
@@ -43,47 +43,12 @@ class HtHtmlElementMixin:
     def __str__(self):
         return _html.tostring(self, encoding='utf8').decode()
 
-    def detach(self):
-        """ Detach the element from the tree for re-insertion
+    def __bool__(self):
+        """ Objects are always truth, as in future lxml
 
-        Like drop_tree but there are two differences, first, the
-        tail is automatically removed (drop_tree always leaves the tail
-        in the document, but it also leaves it attached to the dropped
-        tag), secondly, the dropped element is returned as a convenience
-        for re-insertion.
-
+        Use 'len' to discover if contains children.
         """
-
-        self.drop_tree()
-        self.tail = None
-        return self
-
-    def prepend(self, other):
-        """Inserts other at the start of self.
-
-        Unlike .insert(0, other), handles text properly.
-
-        """
-        self.insert(0, other)
-        if self.text:
-            other.tail = self.text + (other.tail or '')
-            self.text = None
-
-    def wrap_outer(self, other):
-        """Wrap self in other"""
-
-        self.addprevious(other)
-        other.tail = self.tail
-        self.tail = None
-        other.append(self)
-
-    def wrap_inner(self, other):
-        """Wrap the contents of self inside other """
-
-        other.extend(self)
-        other.text = self.text
-        self.text = None
-        self.append(other)
+        return True
 
     def select(self, selector):
         """ Shorthand for csssselect, less sss's
@@ -106,56 +71,6 @@ class HtHtmlElementMixin:
         if result:
             return result[0]
         return None
-
-    def select_or_fail(self, selector):
-        """ Raises ``CssSelectorFailed`` instead of returning an empty list """
-
-        result = self.select(selector)
-        if not result:
-            raise CssSelectorFailed(selector)
-        return result
-
-    def each_text(self, callback):
-        """ Apply callback to each text and tail, in proper order
-
-        If the return value of the callback is not False, the text
-        will be set to the return value.
-
-        """
-        if self.text:
-            result = callback(self.text)
-            if result is not False:
-                self.text = result
-        for child in self:
-            child.each_text(callback)
-        if self.tail:
-            result = callback(self.tail)
-            if result is not False:
-                self.tail = result
-
-    def convert_bad_tags(self):
-        """ Convert invalid html tags into div/span class="tag"
-
-        Uses a simple heuristic to decide whether it should be a span
-        or div, an element which contains block level elements will
-        be a div, otherwise it will be span.
-
-        """
-
-        validtags = _html.defs.tags
-        blocktags = _html.defs.block_tags
-
-        for e in self.iter():
-            if e.tag not in validtags:
-                e.attrib['class'] = (
-                    e.attrib['class'] + ' ' + e.tag if 'class' in e.attrib else e.tag
-                )
-                e.tag = 'span'
-                for desc in e.iterdescendants():
-                    print(e.tag)
-                    if desc.tag in blocktags:
-                        e.tag = 'div'
-                        break
 
     def next_in_order(self):
         """ Returns the next element in document order
@@ -183,61 +98,42 @@ class HtHtmlElementMixin:
 
         return None
 
+    def detach(self):
+        raise NotImplementedError('Unused mixin method deleted.')
+
+    def prepend(self, other):
+        raise NotImplementedError('Unused mixin method deleted.')
+
+    def wrap_outer(self, other):
+        raise NotImplementedError('Unused mixin method deleted.')
+
+    def wrap_inner(self, other):
+        raise NotImplementedError('Unused mixin method deleted.')
+
+    def select_or_fail(self, selector):
+        raise NotImplementedError('Unused mixin method deleted.')
+
+    def each_text(self, callback):
+        raise NotImplementedError('Unused mixin method deleted.')
+
+    def convert_bad_tags(self):
+        raise NotImplementedError('Unused mixin method deleted.')
+
     def pretty(self, **kwargs):
-        """ Return a string with prettified whitespace """
-        string = _html.tostring(self, pretty_print=True, **kwargs).decode()
-        extra_tags = ('article', 'section', 'hgroup')
-        string = regex.sub(
-            r'(<(?:{})[^>]*>)'.format('|'.join(extra_tags)), r'\n\1\n', string
-        )
-        string = regex.sub(
-            r'(</(?:{})>)'.format('|'.join(extra_tags)), r'\n\1\n', string
-        )
-        string = string.replace('<br>', '<br>\n')
-        string = string.replace('\n\n', '\n')
-        string = regex.sub(r'\n +', '\n', string)
-        return string
+        raise NotImplementedError('Unused mixin method deleted.')
+
+    def add_class(self, value):
+        raise NotImplementedError('Unused mixin method deleted.')
+
+    def remove_class(self, value):
+        raise NotImplementedError('Unused mixin method deleted.')
+
+    def id_map(self):
+        raise NotImplementedError('Unused mixin method deleted.')
 
     @property
     def headsure(self):
-        """ Returns head, creating it if it doesn't exist """
-        try:
-            return self.head
-        except IndexError:
-            head = self.makeelement('head')
-            root = self.getroottree().getroot()
-            assert root.tag == 'html', "Incomplete HTML tree"
-            root.insert(0, head)
-            return head
-
-    def add_class(self, value):
-        if 'class' in self.attrib:
-            if value not in self.attrib['class']:
-                self.attrib['class'] += ' ' + value
-        else:
-            self.attrib['class'] = value
-
-    def remove_class(self, value):
-        if 'class' in self.attrib:
-            if 'value' in self.attrib['class']:
-                new_class = ' '.join(
-                    e for e in self.attr['class'].split() if e != value
-                )
-                if new_class:
-                    self.attrib['class'] = new_class
-                else:
-                    del self.attrib['class']
-
-    def id_map(self):
-        """ Get a mapping of ids to elements """
-        return {id: e for id, e in ((e.get('id'), e) for e in self.iter()) if e}
-
-    def __bool__(self):
-        """ Objects are always truth, as in future lxml
-
-        Use 'len' to discover if contains children.
-        """
-        return True
+        raise NotImplementedError('Unused mixin method deleted.')
 
 
 # We need to jump through some hoops to ensure the mixins are included

--- a/server/server/data_loader/sc_html.py
+++ b/server/server/data_loader/sc_html.py
@@ -98,43 +98,6 @@ class HtHtmlElementMixin:
 
         return None
 
-    def detach(self):
-        raise NotImplementedError('Unused mixin method deleted.')
-
-    def prepend(self, other):
-        raise NotImplementedError('Unused mixin method deleted.')
-
-    def wrap_outer(self, other):
-        raise NotImplementedError('Unused mixin method deleted.')
-
-    def wrap_inner(self, other):
-        raise NotImplementedError('Unused mixin method deleted.')
-
-    def select_or_fail(self, selector):
-        raise NotImplementedError('Unused mixin method deleted.')
-
-    def each_text(self, callback):
-        raise NotImplementedError('Unused mixin method deleted.')
-
-    def convert_bad_tags(self):
-        raise NotImplementedError('Unused mixin method deleted.')
-
-    def pretty(self, **kwargs):
-        raise NotImplementedError('Unused mixin method deleted.')
-
-    def add_class(self, value):
-        raise NotImplementedError('Unused mixin method deleted.')
-
-    def remove_class(self, value):
-        raise NotImplementedError('Unused mixin method deleted.')
-
-    def id_map(self):
-        raise NotImplementedError('Unused mixin method deleted.')
-
-    @property
-    def headsure(self):
-        raise NotImplementedError('Unused mixin method deleted.')
-
 
 # We need to jump through some hoops to ensure the mixins are included
 # in all Element class for every tag type. (in lxml.html, some, like input

--- a/server/server/data_loader/sc_html.py
+++ b/server/server/data_loader/sc_html.py
@@ -50,12 +50,6 @@ class HtHtmlElementMixin:
         tag), secondly, the dropped element is returned as a convenience
         for re-insertion.
 
-        >>> p = fromstring('<p><em>p1</em>Once upon a time...</p>')
-        >>> p.append(p.find('em').detach())
-        >>> str(p)
-        '<p>Once upon a time...<em>p1</em></p>'
-
-
         """
 
         self.drop_tree()
@@ -67,31 +61,14 @@ class HtHtmlElementMixin:
 
         Unlike .insert(0, other), handles text properly.
 
-        >>> p = fromstring('<p>There can be only one.</p>')
-        >>> p.insert(0, p.makeelement('a', {'id': 'wrong'}))
-        >>> str(p)
-        '<p>There can be only one.<a id="wrong"></a></p>'
-        >>> p.prepend(p.makeelement('a', {'id': 'right'}))
-        >>> str(p)
-        '<p><a id="right"></a>There can be only one.<a id="wrong"></a></p>'
-
-
         """
-
         self.insert(0, other)
         if self.text:
             other.tail = self.text + (other.tail or '')
             self.text = None
 
     def wrap_outer(self, other):
-        """Wrap self in other
-
-        >>> dom = fromstring('<div><a>foo</a>bar</div>')
-        >>> dom.find('a').wrap_outer(dom.makeelement('b'))
-        >>> str(dom)
-        '<div><b><a>foo</a></b>bar</div>'
-
-        """
+        """Wrap self in other"""
 
         self.addprevious(other)
         other.tail = self.tail
@@ -99,14 +76,7 @@ class HtHtmlElementMixin:
         other.append(self)
 
     def wrap_inner(self, other):
-        """Wrap the contents of self inside other
-
-        >>> dom = fromstring('<div><a>foo</a>bar</div>')
-        >>> dom.find('a').wrap_inner(dom.makeelement('i'))
-        >>> str(dom)
-        '<div><a><i>foo</i></a>bar</div>'
-
-        """
+        """Wrap the contents of self inside other """
 
         other.extend(self)
         other.text = self.text
@@ -136,9 +106,7 @@ class HtHtmlElementMixin:
         return None
 
     def select_or_fail(self, selector):
-        """ Raises ``CssSelectorFailed`` instead of returning an empty list
-
-        """
+        """ Raises ``CssSelectorFailed`` instead of returning an empty list """
 
         result = self.select(selector)
         if not result:
@@ -169,12 +137,6 @@ class HtHtmlElementMixin:
         Uses a simple heuristic to decide whether it should be a span
         or div, an element which contains block level elements will
         be a div, otherwise it will be span.
-
-        >>> dom = fromstring('<baa><p><moo>Goes the cow</namo> ...')
-        >>> dom.convert_bad_tags()
-        >>> str(dom)
-        '<div class="baa"><p><span class="moo">Goes the cow ...</span></p></div>'
-
 
         """
 

--- a/server/server/data_loader/sc_html.py
+++ b/server/server/data_loader/sc_html.py
@@ -8,6 +8,8 @@ manipulations.
 The only HtmlElement method which is overridden by this module is __str__,
 which now returns the html code of the element.
 
+Ajahn J.R.: This is not true, we override __bool__ as well. And the code
+may change again so don't write comments like this.
 """
 
 import itertools

--- a/server/server/data_loader/tests/test_sc_html.py
+++ b/server/server/data_loader/tests/test_sc_html.py
@@ -23,3 +23,8 @@ class TestHtHtmlElementMixin:
         dom = fromstring('<div><a>foo</a>bar</div>')
         dom.find('a').wrap_inner(dom.makeelement('i'))
         assert str(dom) == '<div><a><i>foo</i></a>bar</div>'
+
+    def test_convert_bad_tags(self):
+        dom = fromstring('<baa><p><moo>Goes the cow</namo> ...')
+        dom.convert_bad_tags()
+        assert str(dom) == '<div class="baa"><p><span class="moo">Goes the cow ...</span></p></div>'

--- a/server/server/data_loader/tests/test_sc_html.py
+++ b/server/server/data_loader/tests/test_sc_html.py
@@ -1,30 +1,125 @@
-from data_loader.sc_html import fromstring
+import pytest
+
+import lxml.html
+
+from data_loader import sc_html
 
 
 class TestHtHtmlElementMixin:
     def test_detach(self):
-        p = fromstring('<p><em>p1</em>Once upon a time...</p>')
+        p = sc_html.fromstring('<p><em>p1</em>Once upon a time...</p>')
         p.append(p.find('em').detach())
         assert str(p) == '<p>Once upon a time...<em>p1</em></p>'
 
     def test_prepend(self):
-        p = fromstring('<p>There can be only one.</p>')
+        p = sc_html.fromstring('<p>There can be only one.</p>')
         p.insert(0, p.makeelement('a', {'id': 'wrong'}))
         assert str(p) == '<p>There can be only one.<a id="wrong"></a></p>'
         p.prepend(p.makeelement('a', {'id': 'right'}))
         assert str(p) == '<p><a id="right"></a>There can be only one.<a id="wrong"></a></p>'
 
     def test_wrap_outer(self):
-        dom = fromstring('<div><a>foo</a>bar</div>')
+        dom = sc_html.fromstring('<div><a>foo</a>bar</div>')
         dom.find('a').wrap_outer(dom.makeelement('b'))
         assert str(dom) == '<div><b><a>foo</a></b>bar</div>'
 
     def test_wrap_inner(self):
-        dom = fromstring('<div><a>foo</a>bar</div>')
+        dom = sc_html.fromstring('<div><a>foo</a>bar</div>')
         dom.find('a').wrap_inner(dom.makeelement('i'))
         assert str(dom) == '<div><a><i>foo</i></a>bar</div>'
 
     def test_convert_bad_tags(self):
-        dom = fromstring('<baa><p><moo>Goes the cow</namo> ...')
+        dom = sc_html.fromstring('<baa><p><moo>Goes the cow</namo> ...')
         dom.convert_bad_tags()
         assert str(dom) == '<div class="baa"><p><span class="moo">Goes the cow ...</span></p></div>'
+
+    def test_str_returns_html_code(self):
+        p = sc_html.fromstring('<p>There can be only one.</p>')
+        assert str(p) == '<p>There can be only one.</p>'
+
+    def test_bool_returns_true_for_object(self):
+        p = sc_html.fromstring('<p>There can be only one.</p>')
+        assert bool(p) is True
+
+class TestLxmlHtmlElement:
+    parser = lxml.html.HTMLParser(encoding='utf-8')
+
+    def fromstring(self, string: str):
+        return lxml.html.fromstring(string, parser=self.parser)
+
+    def test_lxml_html5_tags_are_monkey_patched(self):
+        patched_definitions = frozenset({'section', 'article', 'header'})
+        assert lxml.html.defs.html5_tags == patched_definitions
+
+    def test_str_returns_object_representation(self):
+        p = self.fromstring('<p>There can be only one.</p>')
+        assert str(p).startswith("<Element p at")
+
+    def test_falsy_if_has_no_children(self):
+        p = self.fromstring('<p>I have no children.</p>')
+        assert bool(p) is False
+
+    def test_truthy_if_has_no_children(self):
+        p = self.fromstring('<p>I have a child.<br/></p>')
+        assert bool(p) is True
+
+    def test_no_detach(self):
+        p = self.fromstring('<p><em>p1</em>Once upon a time...</p>')
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'detach'"):
+            p.append(p.find('em').detach())
+
+    def test_no_prepend(self):
+        p = self.fromstring('<p>There can be only one.</p>')
+        p.insert(0, p.makeelement('a', {'id': 'wrong'}))
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'prepend'"):
+            p.prepend(p.makeelement('a', {'id': 'right'}))
+
+    def test_no_wrap_outer(self):
+        dom = self.fromstring('<div><a>foo</a>bar</div>')
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'wrap_outer'"):
+            dom.find('a').wrap_outer(dom.makeelement('b'))
+
+    def test_no_wrap_inner(self):
+        dom = self.fromstring('<div><a>foo</a>bar</div>')
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'wrap_inner'"):
+            dom.find('a').wrap_inner(dom.makeelement('i'))
+
+    def test_no_select_or_fail(self):
+        p = self.fromstring('<p>There can be only one.</p>')
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'select_or_fail'"):
+            p.select_or_fail('p')
+
+    def test_no_each_text(self):
+        p = self.fromstring('<p>There can be only one.</p>')
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'each_text'"):
+            p.each_text(None)
+
+    def test_no_convert_bad_tags(self):
+        dom = self.fromstring('<baa><p><moo>Goes the cow</namo> ...')
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'convert_bad_tags'"):
+            dom.convert_bad_tags()
+
+    def test_no_pretty(self):
+        p = self.fromstring('<p>There can be only one.</p>')
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'pretty'"):
+            p.pretty()
+
+    def test_no_head(self):
+        p = self.fromstring('<p>There can be only one.</p>')
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'headsure'"):
+            p.headsure
+
+    def test_no_add_class(self):
+        p = self.fromstring('<p>There can be only one.</p>')
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'add_class'"):
+            p.add_class(None)
+
+    def test_no_remove_class(self):
+        p = self.fromstring('<p>There can be only one.</p>')
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'remove_class'"):
+            p.remove_class(None)
+
+    def test_no_id_map(self):
+        p = self.fromstring('<p>There can be only one.</p>')
+        with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'id_map'"):
+            p.id_map()

--- a/server/server/data_loader/tests/test_sc_html.py
+++ b/server/server/data_loader/tests/test_sc_html.py
@@ -8,30 +8,30 @@ from data_loader import sc_html
 class TestHtHtmlElementMixin:
     def test_detach(self):
         p = sc_html.fromstring('<p><em>p1</em>Once upon a time...</p>')
-        p.append(p.find('em').detach())
-        assert str(p) == '<p>Once upon a time...<em>p1</em></p>'
+        with pytest.raises(NotImplementedError):
+            p.append(p.find('em').detach())
 
     def test_prepend(self):
         p = sc_html.fromstring('<p>There can be only one.</p>')
         p.insert(0, p.makeelement('a', {'id': 'wrong'}))
         assert str(p) == '<p>There can be only one.<a id="wrong"></a></p>'
-        p.prepend(p.makeelement('a', {'id': 'right'}))
-        assert str(p) == '<p><a id="right"></a>There can be only one.<a id="wrong"></a></p>'
+        with pytest.raises(NotImplementedError):
+            p.prepend(p.makeelement('a', {'id': 'right'}))
 
     def test_wrap_outer(self):
         dom = sc_html.fromstring('<div><a>foo</a>bar</div>')
-        dom.find('a').wrap_outer(dom.makeelement('b'))
-        assert str(dom) == '<div><b><a>foo</a></b>bar</div>'
+        with pytest.raises(NotImplementedError):
+            dom.find('a').wrap_outer(dom.makeelement('b'))
 
     def test_wrap_inner(self):
         dom = sc_html.fromstring('<div><a>foo</a>bar</div>')
-        dom.find('a').wrap_inner(dom.makeelement('i'))
-        assert str(dom) == '<div><a><i>foo</i></a>bar</div>'
+        with pytest.raises(NotImplementedError):
+            dom.find('a').wrap_inner(dom.makeelement('i'))
 
     def test_convert_bad_tags(self):
         dom = sc_html.fromstring('<baa><p><moo>Goes the cow</namo> ...')
-        dom.convert_bad_tags()
-        assert str(dom) == '<div class="baa"><p><span class="moo">Goes the cow ...</span></p></div>'
+        with pytest.raises(NotImplementedError):
+            dom.convert_bad_tags()
 
     def test_str_returns_html_code(self):
         p = sc_html.fromstring('<p>There can be only one.</p>')
@@ -104,7 +104,7 @@ class TestLxmlHtmlElement:
         with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'pretty'"):
             p.pretty()
 
-    def test_no_head(self):
+    def test_no_headsure(self):
         p = self.fromstring('<p>There can be only one.</p>')
         with pytest.raises(AttributeError, match="'HtmlElement' object has no attribute 'headsure'"):
             p.headsure

--- a/server/server/data_loader/tests/test_sc_html.py
+++ b/server/server/data_loader/tests/test_sc_html.py
@@ -1,0 +1,25 @@
+from data_loader.sc_html import fromstring
+
+
+class TestHtHtmlElementMixin:
+    def test_detach(self):
+        p = fromstring('<p><em>p1</em>Once upon a time...</p>')
+        p.append(p.find('em').detach())
+        assert str(p) == '<p>Once upon a time...<em>p1</em></p>'
+
+    def test_prepend(self):
+        p = fromstring('<p>There can be only one.</p>')
+        p.insert(0, p.makeelement('a', {'id': 'wrong'}))
+        assert str(p) == '<p>There can be only one.<a id="wrong"></a></p>'
+        p.prepend(p.makeelement('a', {'id': 'right'}))
+        assert str(p) == '<p><a id="right"></a>There can be only one.<a id="wrong"></a></p>'
+
+    def test_wrap_outer(self):
+        dom = fromstring('<div><a>foo</a>bar</div>')
+        dom.find('a').wrap_outer(dom.makeelement('b'))
+        assert str(dom) == '<div><b><a>foo</a></b>bar</div>'
+
+    def test_wrap_inner(self):
+        dom = fromstring('<div><a>foo</a>bar</div>')
+        dom.find('a').wrap_inner(dom.makeelement('i'))
+        assert str(dom) == '<div><a><i>foo</i></a>bar</div>'


### PR DESCRIPTION
First of all, I see those first three commits remain in the pull request, even though they were merged before. Just check to be sure.

Here I've deleted the unused methods on `HtHtmlElementMixin`. I've added tests to make sure the `HtmlElement` class doesn't use these methods as I don't want the behavior reverting should they exist.

As you can see from the commits, I first replaced the method bodies with a raised `NotImplementedError` then ran the data load test in my test harness and then as the normal `make load-data` command to see if anything else was calling the methods unexpectedly.

This is part of the overall refactoring of `load_html_texts()` - issue #3369

## Summary by Sourcery

Remove unused methods from HtHtmlElementMixin in sc_html.py and add tests to verify method removal

Enhancements:
- Cleaned up unused methods in the HtHtmlElementMixin class to reduce code complexity

Tests:
- Added comprehensive tests to ensure removed methods are no longer available in the HtmlElement class
- Verified that attempts to use removed methods now raise appropriate exceptions

Chores:
- Removed multiple unused methods including detach, prepend, wrap_outer, wrap_inner, convert_bad_tags, pretty, and others from the HtHtmlElementMixin