### PR TITLE
Tests written and type hints added for `TextInfoModel` class.

### DIFF
--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -93,10 +93,18 @@ class TestTextInfoModel:
         )
         assert not text_info.added_documents
 
-    def test_missing_data_dir_causes_type_error(self, text_info, sc_data_dir, html_text_dir):
+    def test_type_error_raised_when_files_to_process_is_none(self, text_info, sc_data_dir, html_text_dir):
         with pytest.raises(TypeError):
-            text_info.process_lang_dir(lang_dir=html_text_dir)
+            text_info.process_lang_dir(
+                lang_dir=html_text_dir,
+                data_dir=sc_data_dir,
+                files_to_process=None
+            )
 
-    def test_missing_files_to_process_causes_type_error(self, text_info, sc_data_dir, html_text_dir):
+    def test_type_error_when_data_dir_is_none(self, text_info, html_text_dir, files_to_process):
         with pytest.raises(TypeError):
-            text_info.process_lang_dir(lang_dir=html_text_dir, data_dir=sc_data_dir)
+            text_info.process_lang_dir(
+                lang_dir=html_text_dir,
+                data_dir=None,
+                files_to_process=files_to_process
+            )

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -35,20 +35,23 @@ class TextInfoModelSpy(TextInfoModel):
         pass
 
 
-class TestTextInfoModel:
-    def test_lang_dir_empty(self, tmp_path):
-        model = TextInfoModelSpy()
-        model.process_lang_dir(lang_dir=tmp_path)
-        assert not model.added_documents
+@pytest.fixture
+def text_info():
+    return TextInfoModelSpy()
 
-    def test_one_lang_dir(self, tmp_path):
+
+class TestTextInfoModel:
+    def test_lang_dir_empty(self, text_info, tmp_path):
+        text_info.process_lang_dir(lang_dir=tmp_path)
+        assert not text_info.added_documents
+
+    def test_one_lang_dir(self, text_info, tmp_path):
         en = tmp_path / "en"
         en.mkdir()
-        model = TextInfoModelSpy()
-        model.process_lang_dir(tmp_path)
-        assert not model.added_documents
+        text_info.process_lang_dir(tmp_path)
+        assert not text_info.added_documents
 
-    def test_one_html_file_and_no_data_dir(self, tmp_path):
+    def test_one_html_file_and_no_data_dir(self, text_info, tmp_path):
         file_location = tmp_path / "en" / "pli" / "sutta" / "mn"
         file_location.mkdir(parents=True)
         html_file = file_location / "mn1.html"
@@ -57,8 +60,6 @@ class TestTextInfoModel:
                 "<html/>"
             )
 
-        model = TextInfoModelSpy()
-
         # Blows up when we call relative_to(data_dir)
         with pytest.raises(TypeError):
-            model.process_lang_dir(tmp_path)
+            text_info.process_lang_dir(tmp_path)

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -76,3 +76,11 @@ class TestTextInfoModel:
     def test_fails_when_no_files_to_process(self, text_info, sc_data_dir, html_text_dir):
         with pytest.raises(TypeError):
             text_info.process_lang_dir(lang_dir=html_text_dir, data_dir=sc_data_dir)
+
+    def test_html_file_not_in_files_to_process(self, text_info, sc_data_dir, html_text_dir):
+        text_info.process_lang_dir(
+            lang_dir=html_text_dir,
+            data_dir=sc_data_dir,
+            files_to_process={}
+        )
+        assert not text_info.added_documents

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -40,6 +40,19 @@ def text_info():
     return TextInfoModelSpy()
 
 
+@pytest.fixture
+def sc_data_dir(tmp_path) -> Path:
+    file_location = tmp_path / "html_text" / "en" / "pli" / "sutta" / "mn"
+    file_location.mkdir(parents=True)
+    html_file = file_location / "mn1.html"
+    with html_file.open("w") as f:
+        html_file.write_text(
+            "<html/>"
+        )
+
+    return tmp_path
+
+
 class TestTextInfoModel:
     def test_lang_dir_empty(self, text_info, tmp_path):
         text_info.process_lang_dir(lang_dir=tmp_path)
@@ -51,15 +64,8 @@ class TestTextInfoModel:
         text_info.process_lang_dir(tmp_path)
         assert not text_info.added_documents
 
-    def test_one_html_file_and_no_data_dir(self, text_info, tmp_path):
-        file_location = tmp_path / "en" / "pli" / "sutta" / "mn"
-        file_location.mkdir(parents=True)
-        html_file = file_location / "mn1.html"
-        with html_file.open("w") as f:
-            html_file.write_text(
-                "<html/>"
-            )
-
+    def test_one_html_file_and_no_data_dir(self, text_info, sc_data_dir):
+        lang_dir = sc_data_dir / "html_text"
         # Blows up when we call relative_to(data_dir)
         with pytest.raises(TypeError):
-            text_info.process_lang_dir(tmp_path)
+            text_info.process_lang_dir(lang_dir)

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -32,16 +32,18 @@ class TextInfoModelSpy(TextInfoModel):
     def update_code_points(self, lang_uid, unicode_points, force):
         pass
 
+
+@pytest.fixture
+def text_info():
+    return TextInfoModelSpy()
+
+
 @pytest.fixture
 def valid_html() -> str:
     return """\
 <html>
 <meta name='author' content='Bhikkhu Bodhi'>
 </html>"""
-
-@pytest.fixture
-def text_info():
-    return TextInfoModelSpy()
 
 
 @pytest.fixture
@@ -72,7 +74,6 @@ class TestTextInfoModel:
             data_dir=sc_data_dir,
             files_to_process=files_to_process
         )
-
         assert text_info.added_documents[0]['author'] == 'Bhikkhu Bodhi'
 
     def test_empty_lang_dir_does_not_add_text_info(self, text_info, tmp_path):

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -77,10 +77,20 @@ class TestTextInfoModel:
         with pytest.raises(TypeError):
             text_info.process_lang_dir(lang_dir=html_text_dir, data_dir=sc_data_dir)
 
-    def test_html_file_not_in_files_to_process(self, text_info, sc_data_dir, html_text_dir):
+    def test_html_file_ignored_if_not_in_files_to_process(self, text_info, sc_data_dir, html_text_dir):
         text_info.process_lang_dir(
             lang_dir=html_text_dir,
             data_dir=sc_data_dir,
             files_to_process={}
         )
         assert not text_info.added_documents
+
+    def test_html_file_in_files_to_process(self, text_info, sc_data_dir, html_text_dir):
+        html_file = 'html_text/en/pli/sutta/mn/mn1.html'
+        # Die at line 102
+        with pytest.raises(KeyError):
+            text_info.process_lang_dir(
+                lang_dir=html_text_dir,
+                data_dir=sc_data_dir,
+                files_to_process={ html_file: 0 }
+            )

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -61,6 +61,17 @@ def html_text_dir(sc_data_dir) -> Path:
 
 
 class TestTextInfoModel:
+    def test_happy_path_adds_document(self, text_info, sc_data_dir, html_text_dir):
+        html_file = 'html_text/en/pli/sutta/mn/mn1.html'
+
+        text_info.process_lang_dir(
+            lang_dir=html_text_dir,
+            data_dir=sc_data_dir,
+            files_to_process={ html_file: 0 }
+        )
+
+        assert len(text_info.added_documents) == 1
+
     def test_lang_dir_empty(self, text_info, tmp_path):
         text_info.process_lang_dir(lang_dir=tmp_path)
         assert not text_info.added_documents
@@ -86,14 +97,3 @@ class TestTextInfoModel:
             files_to_process={}
         )
         assert not text_info.added_documents
-
-    def test_happy_path_adds_document(self, text_info, sc_data_dir, html_text_dir):
-        html_file = 'html_text/en/pli/sutta/mn/mn1.html'
-
-        text_info.process_lang_dir(
-            lang_dir=html_text_dir,
-            data_dir=sc_data_dir,
-            files_to_process={ html_file: 0 }
-        )
-
-        assert len(text_info.added_documents) == 1

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -17,13 +17,13 @@ class TextInfoModelSpy(TextInfoModel):
 
     def get_author_by_name(self, name, file) -> dict:
         return {
-            '_key': '123456',
-            '_id': 'author_edition/123456',
-            '_rev': 'randomjunk',
-            'type': 'edition',
-            'uid': 'salt',
-            'short_name': 'Salt',
-            'long_name': 'Veruca Salt'
+            "_key" : "10318325",
+            "_id" : "author_edition/10318325",
+            "_rev" : "_jbu75VK--G",
+            "type" : "author",
+            "uid" : "bodhi",
+            "short_name" : "Bodhi",
+            "long_name" : "Bhikkhu Bodhi"
         }
 
     def add_document(self, doc):
@@ -36,7 +36,7 @@ class TextInfoModelSpy(TextInfoModel):
 def valid_html() -> str:
     return """\
 <html>
-<meta name='author' content='Veruca Salt'>
+<meta name='author' content='Bhikkhu Bodhi'>
 </html>"""
 
 @pytest.fixture

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -69,7 +69,7 @@ class TestTextInfoModel:
         text_info.process_lang_dir(tmp_path)
         assert not text_info.added_documents
 
-    def test_one_html_file_and_no_data_dir(self, text_info, sc_data_dir, html_text_dir):
+    def test_one_html_file_and_data_dir_not_specified(self, text_info, sc_data_dir, html_text_dir):
         # Blows up when we call relative_to(data_dir)
         with pytest.raises(TypeError):
             text_info.process_lang_dir(lang_dir=html_text_dir)

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -73,7 +73,7 @@ class TestTextInfoModel:
             files_to_process=files_to_process
         )
 
-        assert len(text_info.added_documents) == 1
+        assert text_info.added_documents[0]['author'] == 'Bhikkhu Bodhi'
 
     def test_empty_lang_dir_does_not_add_text_info(self, text_info, tmp_path):
         text_info.process_lang_dir(lang_dir=tmp_path)

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -61,7 +61,7 @@ def html_text_dir(sc_data_dir) -> Path:
 
 
 class TestTextInfoModel:
-    def test_happy_path_adds_document(self, text_info, sc_data_dir, html_text_dir):
+    def test_process_lang_dir_adds_text_info(self, text_info, sc_data_dir, html_text_dir):
         html_file = 'html_text/en/pli/sutta/mn/mn1.html'
 
         text_info.process_lang_dir(
@@ -72,28 +72,28 @@ class TestTextInfoModel:
 
         assert len(text_info.added_documents) == 1
 
-    def test_lang_dir_empty(self, text_info, tmp_path):
+    def test_empty_lang_dir_does_not_add_text_info(self, text_info, tmp_path):
         text_info.process_lang_dir(lang_dir=tmp_path)
         assert not text_info.added_documents
 
-    def test_one_lang_dir(self, text_info, tmp_path):
+    def test_lang_dir_with_empty_language_does_not_add_text_info(self, text_info, tmp_path):
         en = tmp_path / 'en'
         en.mkdir()
         text_info.process_lang_dir(tmp_path)
         assert not text_info.added_documents
 
-    def test_fails_when_no_data_dir(self, text_info, sc_data_dir, html_text_dir):
-        with pytest.raises(TypeError):
-            text_info.process_lang_dir(lang_dir=html_text_dir)
-
-    def test_fails_when_no_files_to_process(self, text_info, sc_data_dir, html_text_dir):
-        with pytest.raises(TypeError):
-            text_info.process_lang_dir(lang_dir=html_text_dir, data_dir=sc_data_dir)
-
-    def test_html_file_ignored_if_not_in_files_to_process(self, text_info, sc_data_dir, html_text_dir):
+    def test_file_not_in_files_to_process_does_not_add_text_info(self, text_info, sc_data_dir, html_text_dir):
         text_info.process_lang_dir(
             lang_dir=html_text_dir,
             data_dir=sc_data_dir,
             files_to_process={}
         )
         assert not text_info.added_documents
+
+    def test_missing_data_dir_causes_type_error(self, text_info, sc_data_dir, html_text_dir):
+        with pytest.raises(TypeError):
+            text_info.process_lang_dir(lang_dir=html_text_dir)
+
+    def test_missing_files_to_process_causes_type_error(self, text_info, sc_data_dir, html_text_dir):
+        with pytest.raises(TypeError):
+            text_info.process_lang_dir(lang_dir=html_text_dir, data_dir=sc_data_dir)

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -17,15 +17,13 @@ class TextInfoModelSpy(TextInfoModel):
 
     def get_author_by_name(self, name, file) -> dict:
         return {
-            'Veruca Salt': {
-                '_key': '123456',
-                '_id': 'author_edition/123456',
-                '_rev': 'randomjunk',
-                'type': 'edition',
-                'uid': 'salt',
-                'short_name': 'Salt',
-                'long_name': 'Veruca Salt'
-            }
+            '_key': '123456',
+            '_id': 'author_edition/123456',
+            '_rev': 'randomjunk',
+            'type': 'edition',
+            'uid': 'salt',
+            'short_name': 'Salt',
+            'long_name': 'Veruca Salt'
         }
 
     def add_document(self, doc):
@@ -34,6 +32,12 @@ class TextInfoModelSpy(TextInfoModel):
     def update_code_points(self, lang_uid, unicode_points, force):
         pass
 
+@pytest.fixture
+def valid_html() -> str:
+    return """\
+<html>
+<meta name='author' content='Veruca Salt'>
+</html>"""
 
 @pytest.fixture
 def text_info():
@@ -41,14 +45,12 @@ def text_info():
 
 
 @pytest.fixture
-def sc_data_dir(tmp_path) -> Path:
+def sc_data_dir(tmp_path, valid_html) -> Path:
     file_location = tmp_path / 'html_text' / 'en' / 'pli' / 'sutta' / 'mn'
     file_location.mkdir(parents=True)
     html_file = file_location / 'mn1.html'
     with html_file.open('w') as f:
-        html_file.write_text(
-            '<html/>'
-        )
+        html_file.write_text(valid_html)
 
     return tmp_path
 
@@ -85,12 +87,13 @@ class TestTextInfoModel:
         )
         assert not text_info.added_documents
 
-    def test_html_file_in_files_to_process(self, text_info, sc_data_dir, html_text_dir):
+    def test_happy_path_adds_document(self, text_info, sc_data_dir, html_text_dir):
         html_file = 'html_text/en/pli/sutta/mn/mn1.html'
-        # Die at line 102
-        with pytest.raises(KeyError):
-            text_info.process_lang_dir(
-                lang_dir=html_text_dir,
-                data_dir=sc_data_dir,
-                files_to_process={ html_file: 0 }
-            )
+
+        text_info.process_lang_dir(
+            lang_dir=html_text_dir,
+            data_dir=sc_data_dir,
+            files_to_process={ html_file: 0 }
+        )
+
+        assert len(text_info.added_documents) == 1

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -42,15 +42,20 @@ def text_info():
 
 @pytest.fixture
 def sc_data_dir(tmp_path) -> Path:
-    file_location = tmp_path / "html_text" / "en" / "pli" / "sutta" / "mn"
+    file_location = tmp_path / 'html_text' / 'en' / 'pli' / 'sutta' / 'mn'
     file_location.mkdir(parents=True)
-    html_file = file_location / "mn1.html"
-    with html_file.open("w") as f:
+    html_file = file_location / 'mn1.html'
+    with html_file.open('w') as f:
         html_file.write_text(
-            "<html/>"
+            '<html/>'
         )
 
     return tmp_path
+
+
+@pytest.fixture
+def html_text_dir(sc_data_dir) -> Path:
+    return sc_data_dir / 'html_text'
 
 
 class TestTextInfoModel:
@@ -59,13 +64,12 @@ class TestTextInfoModel:
         assert not text_info.added_documents
 
     def test_one_lang_dir(self, text_info, tmp_path):
-        en = tmp_path / "en"
+        en = tmp_path / 'en'
         en.mkdir()
         text_info.process_lang_dir(tmp_path)
         assert not text_info.added_documents
 
-    def test_one_html_file_and_no_data_dir(self, text_info, sc_data_dir):
-        lang_dir = sc_data_dir / "html_text"
+    def test_one_html_file_and_no_data_dir(self, text_info, sc_data_dir, html_text_dir):
         # Blows up when we call relative_to(data_dir)
         with pytest.raises(TypeError):
-            text_info.process_lang_dir(lang_dir)
+            text_info.process_lang_dir(lang_dir=html_text_dir)

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -60,14 +60,17 @@ def html_text_dir(sc_data_dir) -> Path:
     return sc_data_dir / 'html_text'
 
 
-class TestTextInfoModel:
-    def test_process_lang_dir_adds_text_info(self, text_info, sc_data_dir, html_text_dir):
-        html_file = 'html_text/en/pli/sutta/mn/mn1.html'
+@pytest.fixture
+def files_to_process() -> dict[str, int]:
+    return {'html_text/en/pli/sutta/mn/mn1.html': 0}
 
+
+class TestTextInfoModel:
+    def test_process_lang_dir_adds_text_info(self, text_info, sc_data_dir, html_text_dir, files_to_process):
         text_info.process_lang_dir(
             lang_dir=html_text_dir,
             data_dir=sc_data_dir,
-            files_to_process={ html_file: 0 }
+            files_to_process=files_to_process
         )
 
         assert len(text_info.added_documents) == 1

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from data_loader.textdata import TextInfoModel
+
+
+class TextInfoModelSpy(TextInfoModel):
+    """
+    TextInfoModel uses the template method design pattern giving us a
+    handy way to interact with the TextInfoModel class without accessing
+    the database.
+    """
+    def __init__(self):
+        super().__init__()
+        self.added_documents = []
+
+    def get_author_by_name(self, name, file) -> dict:
+        return {
+            'Veruca Salt': {
+                '_key': '123456',
+                '_id': 'author_edition/123456',
+                '_rev': 'randomjunk',
+                'type': 'edition',
+                'uid': 'salt',
+                'short_name': 'Salt',
+                'long_name': 'Veruca Salt'
+            }
+        }
+
+    def add_document(self, doc):
+        self.added_documents.append(doc)
+
+    def update_code_points(self, lang_uid, unicode_points, force):
+        pass
+
+
+class TestTextInfoModel:
+    def test_lang_dir_empty(self, tmp_path):
+        model = TextInfoModelSpy()
+        model.process_lang_dir(lang_dir=tmp_path)
+        assert not model.added_documents
+
+    def test_one_lang_dir(self, tmp_path):
+        en = tmp_path / "en"
+        en.mkdir()
+        model = TextInfoModelSpy()
+        model.process_lang_dir(tmp_path)
+        assert not model.added_documents
+
+    def test_one_html_file_and_no_data_dir(self, tmp_path):
+        file_location = tmp_path / "en" / "pli" / "sutta" / "mn"
+        file_location.mkdir(parents=True)
+        html_file = file_location / "mn1.html"
+        with html_file.open("w") as f:
+            html_file.write_text(
+                "<html/>"
+            )
+
+        model = TextInfoModelSpy()
+
+        # Blows up when we call relative_to(data_dir)
+        with pytest.raises(TypeError):
+            model.process_lang_dir(tmp_path)

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -46,7 +46,7 @@ def text_info():
 
 @pytest.fixture
 def sc_data_dir(tmp_path, valid_html) -> Path:
-    file_location = tmp_path / 'html_text' / 'en' / 'pli' / 'sutta' / 'mn'
+    file_location = tmp_path / 'html_text/en/pli/sutta/mn'
     file_location.mkdir(parents=True)
     html_file = file_location / 'mn1.html'
     with html_file.open('w') as f:

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -69,7 +69,10 @@ class TestTextInfoModel:
         text_info.process_lang_dir(tmp_path)
         assert not text_info.added_documents
 
-    def test_one_html_file_and_data_dir_not_specified(self, text_info, sc_data_dir, html_text_dir):
-        # Blows up when we call relative_to(data_dir)
+    def test_fails_when_no_data_dir(self, text_info, sc_data_dir, html_text_dir):
         with pytest.raises(TypeError):
             text_info.process_lang_dir(lang_dir=html_text_dir)
+
+    def test_fails_when_no_files_to_process(self, text_info, sc_data_dir, html_text_dir):
+        with pytest.raises(TypeError):
+            text_info.process_lang_dir(lang_dir=html_text_dir, data_dir=sc_data_dir)

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -34,7 +34,7 @@ class TextInfoModel:
     def process_lang_dir(self,
             lang_dir: Path,
             data_dir: Path = None,
-            files_to_process: dict[Path, int] | None = None,
+            files_to_process: dict[str, int] | None = None,
             force: bool = False
     ):
         # files_to_process is actually "files that may be processed" its

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from pathlib import Path
 
 import regex
 from arango.exceptions import DocumentReplaceError
@@ -30,8 +31,11 @@ class TextInfoModel:
     def is_italic(self, element):
         return element.tag in {'i', 'em'}
 
-    def process_lang_dir(
-            self, lang_dir, data_dir=None, files_to_process=None, force=False
+    def process_lang_dir(self,
+            lang_dir: Path,
+            data_dir: Path = None,
+            files_to_process: dict[Path, int] | None = None,
+            force: bool = False
     ):
         # files_to_process is actually "files that may be processed" its
         # not the list of files to actually process


### PR DESCRIPTION
A nice clean pull request this time. The only changes to the production code are a few type hints that I figured out. I might be wrong there, don't take them as gospel. I've added unit tests that reveal a couple of bugs where missing parameters default to `None`, some tests of different path structures and a very simple test of the happy path where an object is ready to be written to ArangoDB.

I've taken advantage of the template method pattern already used in the production code so I can test without reading to and writing from ArangoDB.

Again this is continuing work on issue #3369