### PR TITLE
Increase test coverage for TextInfoModel 

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -18,6 +18,8 @@ services:
   sc-arangodb:
     env_file:
       - server/env/.test.env
+    ports:
+      - '8529:8529'
 
   sc-frontend:
     command: npm run build

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -1,8 +1,16 @@
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
 from data_loader.textdata import TextInfoModel
+
+
+@dataclass
+class CodePoints:
+    lang_uid: str
+    unicode_points: dict
+    force: bool
 
 
 class TextInfoModelSpy(TextInfoModel):
@@ -14,6 +22,7 @@ class TextInfoModelSpy(TextInfoModel):
     def __init__(self):
         super().__init__()
         self.added_documents = []
+        self.added_code_points: list[CodePoints] = []
 
     def get_author_by_name(self, name, file) -> dict:
         return {
@@ -30,7 +39,12 @@ class TextInfoModelSpy(TextInfoModel):
         self.added_documents.append(doc)
 
     def update_code_points(self, lang_uid, unicode_points, force):
-        pass
+        self.added_code_points.append(CodePoints(lang_uid, unicode_points, force))
+
+
+def add_html_file(path: Path, html: str) -> None:
+    with path.open('w') as f:
+        path.write_text(html)
 
 
 @pytest.fixture
@@ -39,27 +53,15 @@ def text_info():
 
 
 @pytest.fixture
-def valid_html() -> str:
-    return """\
-<html>
-<meta name='author' content='Bhikkhu Bodhi'>
-</html>"""
-
-
-@pytest.fixture
-def sc_data_dir(tmp_path, valid_html) -> Path:
+def sc_data_dir(tmp_path) -> Path:
     file_location = tmp_path / 'html_text/en/pli/sutta/mn'
     file_location.mkdir(parents=True)
-    html_file = file_location / 'mn1.html'
-    with html_file.open('w') as f:
-        html_file.write_text(valid_html)
-
     return tmp_path
 
 
 @pytest.fixture
-def html_text_dir(sc_data_dir) -> Path:
-    return sc_data_dir / 'html_text'
+def en_dir(sc_data_dir) -> Path:
+    return sc_data_dir / 'html_text/en/'
 
 
 @pytest.fixture
@@ -67,15 +69,16 @@ def files_to_process() -> dict[str, int]:
     return {'html_text/en/pli/sutta/mn/mn1.html': 0}
 
 
-class TestTextInfoModel:
-    def test_process_lang_dir_adds_text_info(self, text_info, sc_data_dir, html_text_dir, files_to_process):
-        text_info.process_lang_dir(
-            lang_dir=html_text_dir,
-            data_dir=sc_data_dir,
-            files_to_process=files_to_process
-        )
-        assert text_info.added_documents[0]['author'] == 'Bhikkhu Bodhi'
+@pytest.fixture
+def with_mn1(sc_data_dir) -> Path:
+    add_html_file(
+        sc_data_dir / 'html_text/en/pli/sutta/mn/mn1.html',
+        "<html><meta name='author' content='Bhikkhu Bodhi'></html>"
+    )
+    return sc_data_dir
 
+
+class TestTextInfoModel:
     def test_empty_lang_dir_does_not_add_text_info(self, text_info, tmp_path):
         text_info.process_lang_dir(lang_dir=tmp_path)
         assert not text_info.added_documents
@@ -86,26 +89,57 @@ class TestTextInfoModel:
         text_info.process_lang_dir(tmp_path)
         assert not text_info.added_documents
 
-    def test_file_not_in_files_to_process_does_not_add_text_info(self, text_info, sc_data_dir, html_text_dir):
+    def test_file_not_in_files_to_process_does_not_add_text_info(self, text_info, with_mn1, en_dir):
         text_info.process_lang_dir(
-            lang_dir=html_text_dir,
-            data_dir=sc_data_dir,
+            lang_dir=en_dir,
+            data_dir=with_mn1,
             files_to_process={}
         )
         assert not text_info.added_documents
 
-    def test_type_error_raised_when_files_to_process_is_none(self, text_info, sc_data_dir, html_text_dir):
+    def test_type_error_raised_when_files_to_process_is_none(self, text_info, with_mn1, en_dir):
         with pytest.raises(TypeError):
             text_info.process_lang_dir(
-                lang_dir=html_text_dir,
-                data_dir=sc_data_dir,
+                lang_dir=en_dir,
+                data_dir=with_mn1,
                 files_to_process=None
             )
 
-    def test_type_error_when_data_dir_is_none(self, text_info, html_text_dir, files_to_process):
+    def test_type_error_when_data_dir_is_none(self, text_info, with_mn1, en_dir, files_to_process):
         with pytest.raises(TypeError):
             text_info.process_lang_dir(
-                lang_dir=html_text_dir,
+                lang_dir=with_mn1,
                 data_dir=None,
                 files_to_process=files_to_process
             )
+
+    @pytest.mark.parametrize(
+        "html,author",
+        [
+            ("<html><meta name='author' content='Bhikkhu Bodhi'></html>", 'Bhikkhu Bodhi'),
+            ("<html><meta author='Bhikkhu Bodhi'></html>", 'Bhikkhu Bodhi'),
+            ("<html></html>", None),
+        ]
+    )
+    def test_extracts_author_from_html(
+            self, text_info, sc_data_dir, en_dir, files_to_process, html, author):
+        add_html_file(sc_data_dir / 'html_text/en/pli/sutta/mn/mn1.html', html)
+        text_info.process_lang_dir(en_dir, sc_data_dir, files_to_process)
+        assert text_info.added_documents[0]['author'] == author
+
+    def test_update_code_points(self, text_info, sc_data_dir, en_dir, files_to_process):
+        html = """
+        <html>
+        <head><meta author='Bhikkhu Bodhi'></head>
+        <body><b>abcd</b><em>wxyz</em></body>
+        </html>
+        """
+        add_html_file(sc_data_dir / 'html_text/en/pli/sutta/mn/mn1.html', html)
+        text_info.process_lang_dir(en_dir, sc_data_dir, files_to_process)
+        assert text_info.added_code_points[0].lang_uid == "en"
+        assert text_info.added_code_points[0].force is False
+        assert text_info.added_code_points[0].unicode_points == {
+            'normal' : {' ', '\n', 'a', 'b', 'c', 'd', 'w', 'x', 'y', 'z'},
+            'bold' : {'a', 'b', 'c', 'd'},
+            'italic' : {'w', 'x', 'y', 'z'},
+        }

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -38,7 +38,7 @@ class TextInfoModelSpy(TextInfoModel):
     def add_document(self, doc):
         self.added_documents.append(doc)
 
-    def update_code_points(self, lang_uid, unicode_points, force):
+    def update_code_points(self, lang_uid: str, unicode_points: dict[str, set[str]], force: bool) -> None:
         self.added_code_points.append(CodePoints(lang_uid, unicode_points, force))
 
 

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -274,6 +274,15 @@ class TestTextInfoModel:
 
         assert text_info.added_documents[0]['volpage'] is None
 
+    def test_sets_file_path(
+            self, text_info, base_path, language_path, sutta_path, files_to_process
+    ):
+        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
+        add_html_file(sutta_path, html)
+        text_info.process_lang_dir(language_path, base_path, files_to_process)
+
+        assert text_info.added_documents[0]['file_path'] == str(sutta_path)
+
     def test_update_code_points(self, text_info, base_path, language_path, sutta_path, files_to_process):
         html = """
         <html>

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -250,6 +250,30 @@ class TestTextInfoModel:
 
         assert text_info.added_documents[0]['name'] == '（四三）不思經 (43. No Need for Thought)'
 
+    def test_extracts_chinese_volpage(self, text_info, base_path):
+        sutta_relative = 'html_text/lzh/sutta/ma/ma43.html'
+        sutta_path = base_path / sutta_relative
+        language_path = base_path / 'html_text/lzh/'
+        files_to_process = {str(sutta_relative): 0}
+
+        html = ("<html><head><meta name='author' content='Taishō Tripiṭaka'></head><body><header>"
+                "<a class='ref t' id='t0485b21' href='#t0485b21'>T 0485b21</a>"
+                "</h1></header></body></html>")
+
+        add_html_file(sutta_path, html)
+        text_info.process_lang_dir(language_path, base_path, files_to_process)
+
+        assert text_info.added_documents[0]['volpage'] == 'T 0485b21'
+
+    def test_volpage_none_when_legacy_translation(
+            self, text_info, base_path, language_path, sutta_path, files_to_process
+    ):
+        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
+        add_html_file(sutta_path, html)
+        text_info.process_lang_dir(language_path, base_path, files_to_process)
+
+        assert text_info.added_documents[0]['volpage'] is None
+
     def test_update_code_points(self, text_info, base_path, language_path, sutta_path, files_to_process):
         html = """
         <html>

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -283,6 +283,15 @@ class TestTextInfoModel:
 
         assert text_info.added_documents[0]['file_path'] == str(sutta_path)
 
+    def test_sets_last_modified(
+            self, text_info, base_path, language_path, sutta_path, files_to_process
+    ):
+        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
+        add_html_file(sutta_path, html)
+        text_info.process_lang_dir(language_path, base_path, files_to_process)
+
+        assert text_info.added_documents[0]['mtime'] == sutta_path.stat().st_mtime
+
     def test_update_code_points(self, text_info, base_path, language_path, sutta_path, files_to_process):
         html = """
         <html>

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -20,7 +20,7 @@ class TextInfoModel:
     def add_document(self, doc):
         raise NotImplementedError
 
-    def update_code_points(self, lang_uid, unicode_points, force):
+    def update_code_points(self, lang_uid: str, unicode_points: dict[str, set[str]], force: bool) -> None:
         raise NotImplementedError
 
     def is_bold(self, lang, element):
@@ -244,7 +244,7 @@ class ArangoTextInfoModel(TextInfoModel):
             self.db['html_text'].import_bulk_logged(self.queue)
             self.queue.clear()
 
-    def update_code_points(self, lang_uid, unicode_points, force=False):
+    def update_code_points(self, lang_uid: str, unicode_points: dict[str, set[str]], force: bool = False) -> None:
         keys = ('normal', 'bold', 'italic')
         try:
             existing = self.db['unicode_points'].get(lang_uid)


### PR DESCRIPTION
More work relating to Issue #3369 

Test coverage for the `TextInfoModel` class is at a point where I'm happy to start refactoring. I've also added some type hints, though there is more to go. There's a small change to the docker configuration to allow access to ArangoDB's web interface when running `make prepare-tests`