### PR TITLE
Testing and refactoring of textdata.py

### DIFF
--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -25,6 +25,7 @@ def test_base_dir_is_correct(data_load_app):
         base_dir = data_load_app.config.get('BASE_DIR')
         assert base_dir == Path('/opt/sc/sc-flask/')
 
+@pytest.mark.skip('Disabled as it may interfere with other tests.')
 def test_do_collect_data_stage(data_load_app):
     with data_load_app.app_context():
         data_dir = Path('/opt/sc/sc-flask/sc-data')

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -308,3 +308,70 @@ class TestTextInfoModel:
             'bold' : {'a', 'b', 'c', 'd'},
             'italic' : {'w', 'x', 'y', 'z'},
         }
+
+    def test_multiple_files_added(self, text_info, base_path):
+        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
+
+        paths = [
+            Path('html_text/en/pli/sutta/mn/mn1.html'),
+            Path('html_text/en/pli/sutta/mn/mn2.html'),
+            Path('html_text/en/pli/sutta/mn/mn3.html'),
+        ]
+
+        files_to_process = dict()
+        for path in paths:
+            files_to_process[str(path)] = 0
+            add_html_file(base_path / path, html)
+
+        language_path = base_path / 'html_text/en'
+        text_info.process_lang_dir(language_path, base_path, files_to_process)
+
+        assert len(text_info.added_documents) == 3
+
+    def test_files_not_in_files_to_process_are_skipped(self, text_info, base_path):
+        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
+
+        paths = [
+            Path('html_text/en/pli/sutta/mn/mn1.html'),
+            Path('html_text/en/pli/sutta/mn/mn2.html'),
+            Path('html_text/en/pli/sutta/mn/mn3.html'),
+        ]
+
+        for path in paths:
+            add_html_file(base_path / path, html)
+
+        files_to_process = {
+            'html_text/en/pli/sutta/mn/mn1.html' : 0,
+            'html_text/en/pli/sutta/mn/mn3.html' : 0,
+        }
+
+        language_path = base_path / 'html_text/en'
+        text_info.process_lang_dir(language_path, base_path, files_to_process)
+
+        file_names = [Path(document['file_path']).name
+                 for document in text_info.added_documents]
+
+        assert file_names == ['mn1.html', 'mn3.html']
+
+    def test_force_flag_causes_all_files_to_be_added(self, text_info, base_path):
+        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
+
+        paths = [
+            Path('html_text/en/pli/sutta/mn/mn1.html'),
+            Path('html_text/en/pli/sutta/mn/mn2.html'),
+        ]
+
+        for path in paths:
+            add_html_file(base_path / path, html)
+
+        files_to_process = {
+            'html_text/en/pli/sutta/mn/mn1.html': 0,
+        }
+
+        language_path = base_path / 'html_text/en'
+        text_info.process_lang_dir(language_path, base_path, files_to_process, force=True)
+
+        file_names = [Path(document['file_path']).name
+                      for document in text_info.added_documents]
+
+        assert file_names == ['mn1.html', 'mn2.html']

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -9,22 +9,15 @@ from data_loader.unsegmented_texts import UnsegmentedText
 class TestUnsegmentedText:
     def test_extracts_authors_long_name_from_content_attribute(self):
         html = "<html><meta name='author' content='Bhikkhu Bodhi'></html>"
-        text = UnsegmentedText(file=Path('mn1.html'), html=html, lang_uid='en')
+        text = UnsegmentedText(html=html, lang_uid='en')
         assert text.authors_long_name() == 'Bhikkhu Bodhi'
 
     def test_extracts_authors_long_name_from_author_attribute(self):
         html = "<html><meta author='Bhikkhu Bodhi'></html>"
-        text = UnsegmentedText(file=Path('mn1.html'), html=html, lang_uid='en')
+        text = UnsegmentedText(html=html, lang_uid='en')
         assert text.authors_long_name() == 'Bhikkhu Bodhi'
 
     def test_authors_long_name_is_none_when_missing(self):
         html = "<html></html>"
-        text = UnsegmentedText(file=Path('mn1.html'), html=html, lang_uid='en')
+        text = UnsegmentedText(html=html, lang_uid='en')
         assert text.authors_long_name() is None
-
-    def test_logs_missing_authors_long_name(self, caplog):
-        html = "<html></html>"
-        text = UnsegmentedText(file=Path('missing.html'), html=html, lang_uid="en")
-        _ = text.authors_long_name()
-        assert caplog.records[0].levelno == logging.CRITICAL
-        assert caplog.records[0].message == "Author not found: missing.html"

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -1,8 +1,3 @@
-import logging
-from pathlib import Path
-
-import pytest
-
 from data_loader.unsegmented_texts import UnsegmentedText
 
 

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import pytest
+
+from data_loader.unsegmented_texts import UnsegmentedText
+
+
+class TestUnsegmentedText:
+    @pytest.mark.parametrize(
+    "html,author_long_name",
+        [
+            ("<html><meta name='author' content='Bhikkhu Bodhi'></html>", 'Bhikkhu Bodhi'),
+            ("<html><meta author='Bhikkhu Bodhi'></html>", 'Bhikkhu Bodhi'),
+            ("<html></html>", None),
+        ]
+    )
+    def test_extracts_author_long_name_from_html(self, html, author_long_name):
+        text = UnsegmentedText(file=Path('/'), html=html, lang_uid="en")
+        assert text.authors_long_name() == author_long_name

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -7,19 +7,22 @@ from data_loader.unsegmented_texts import UnsegmentedText
 
 
 class TestUnsegmentedText:
-    @pytest.mark.parametrize(
-    "html,author_long_name",
-        [
-            ("<html><meta name='author' content='Bhikkhu Bodhi'></html>", 'Bhikkhu Bodhi'),
-            ("<html><meta author='Bhikkhu Bodhi'></html>", 'Bhikkhu Bodhi'),
-            ("<html></html>", None),
-        ]
-    )
-    def test_extracts_author_long_name_from_html(self, html, author_long_name):
-        text = UnsegmentedText(file=Path('/'), html=html, lang_uid="en")
-        assert text.authors_long_name() == author_long_name
+    def test_extracts_authors_long_name_from_content_attribute(self):
+        html = "<html><meta name='author' content='Bhikkhu Bodhi'></html>"
+        text = UnsegmentedText(file=Path('mn1.html'), html=html, lang_uid='en')
+        assert text.authors_long_name() == 'Bhikkhu Bodhi'
 
-    def test_logs_author_not_found(self, caplog):
+    def test_extracts_authors_long_name_from_author_attribute(self):
+        html = "<html><meta author='Bhikkhu Bodhi'></html>"
+        text = UnsegmentedText(file=Path('mn1.html'), html=html, lang_uid='en')
+        assert text.authors_long_name() == 'Bhikkhu Bodhi'
+
+    def test_authors_long_name_is_none_when_missing(self):
+        html = "<html></html>"
+        text = UnsegmentedText(file=Path('mn1.html'), html=html, lang_uid='en')
+        assert text.authors_long_name() is None
+
+    def test_logs_missing_authors_long_name(self, caplog):
         html = "<html></html>"
         text = UnsegmentedText(file=Path('missing.html'), html=html, lang_uid="en")
         _ = text.authors_long_name()

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import pytest
@@ -17,3 +18,10 @@ class TestUnsegmentedText:
     def test_extracts_author_long_name_from_html(self, html, author_long_name):
         text = UnsegmentedText(file=Path('/'), html=html, lang_uid="en")
         assert text.authors_long_name() == author_long_name
+
+    def test_logs_author_not_found(self, caplog):
+        html = "<html></html>"
+        text = UnsegmentedText(file=Path('missing.html'), html=html, lang_uid="en")
+        _ = text.authors_long_name()
+        assert caplog.records[0].levelno == logging.CRITICAL
+        assert caplog.records[0].message == "Author not found: missing.html"

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -1,96 +1,12 @@
-import json
 import logging
 from pathlib import Path
 
-import regex
 from arango.exceptions import DocumentReplaceError
 
-from . import sc_html, util
+from . import util
+from .unsegmented_texts import UnsegmentedText
 
 logger = logging.getLogger(__name__)
-
-
-class UnsegmentedText:
-    def __init__(self, file: Path, html: str, lang_uid: str):
-        self._file = file
-        self._html = html
-        self._lang_uid = lang_uid
-        self._root = sc_html.fromstring(html)
-
-    def authors_long_name(self):
-        author = None
-        e = self._root.select_one('meta[author]')
-        if e:
-            author = e.attrib['author']
-
-        if not author:
-            e = self._root.select_one('meta[name=author]')
-            if e:
-                author = e.attrib['content']
-
-        if not author:
-            logging.critical(f'Author not found: {str(self._file)}')
-        return author
-
-    def publication_date(self):
-        e = self._root.select_one('.publication-date')
-        if e:
-            return e.text_content()
-
-        return None
-
-    def title(self):
-        root = self._root
-        header = root.select_one('header')
-        if not header:
-            logger.error(f'No header found in {str(self._file)}')
-            return ''
-
-        h1 = header.select_one('h1')
-        if not h1:
-            logger.error(f'No h1 found in {str(self._file)}')
-            return ''
-
-        if self._lang_uid == 'lzh':
-            left_side = h1.select_one('.mirror-left')
-            right_side = h1.select_one('.mirror-right')
-            if left_side and right_side:
-                return right_side.text_content() + ' (' + left_side.text_content() + ')'
-
-        return regex.sub(r'[\d\.\{\} –-]*', '', h1.text_content(), 1)
-
-    def volpage(self):
-        if self._lang_uid == 'lzh':
-            e = self._root.next_in_order()
-            while e is not None:
-                if e.tag == 'a' and e.select_one('.t'):
-                    break
-                e = e.next_in_order()
-            else:
-                return
-            return '{}'.format(e.attrib['id']).replace('t', 'T ')
-        return None
-
-    def extract_unicode_points(self, unicode_points):
-        root = self._root
-        _stack = [root]
-        while _stack:
-            e = _stack.pop()
-            if self.is_bold(self._lang_uid, e):
-                unicode_points['bold'].update(e.text_content())
-            elif self.is_italic(e):
-                unicode_points['italic'].update(e.text_content())
-            else:
-                _stack.extend(e)
-        unicode_points['normal'].update(root.text_content())
-
-    def is_bold(self, lang, element):
-        if element.tag in {'b', 'strong'}:
-            return True
-        return lang in {'lzh', 'ko', 'jp', 'tw'} and element.tag in {'h1', 'h2', 'h3', 'h4', 'h5', 'h6'}
-
-    def is_italic(self, element):
-        return element.tag in {'i', 'em'}
 
 
 class TextInfoModel:

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -128,7 +128,7 @@ class TextInfoModel:
 
                 name = unsegmented_text.title(lang_uid)
 
-                volpage = self._get_volpage(root, lang_uid, uid)
+                volpage = self._get_volpage(root, lang_uid)
 
                 mtime = html_file.stat().st_mtime
 
@@ -180,9 +180,9 @@ class TextInfoModel:
         ]
         return files
 
-    def _get_volpage(self, element, lang_uid, uid):
+    def _get_volpage(self, root, lang_uid):
         if lang_uid == 'lzh':
-            e = element.next_in_order()
+            e = root.next_in_order()
             while e is not None:
                 if e.tag == 'a' and e.select_one('.t'):
                     break

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -59,8 +59,8 @@ class UnsegmentedText:
 
         return regex.sub(r'[\d\.\{\} –-]*', '', h1.text_content(), 1)
 
-    def volpage(self, lang_uid):
-        if lang_uid == 'lzh':
+    def volpage(self):
+        if self._lang_uid == 'lzh':
             e = self._root.next_in_order()
             while e is not None:
                 if e.tag == 'a' and e.select_one('.t'):
@@ -133,7 +133,7 @@ class TextInfoModel:
                 unsegmented_text.extract_unicode_points(lang_uid, unicode_points)
                 publication_date = unsegmented_text.publication_date()
                 name = unsegmented_text.title()
-                volpage = unsegmented_text.volpage(lang_uid)
+                volpage = unsegmented_text.volpage()
                 author = unsegmented_text.authors_long_name()
 
                 author_data = self.get_author_by_name(author, html_file)

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -58,6 +58,19 @@ class UnsegmentedText:
 
         return regex.sub(r'[\d\.\{\} –-]*', '', h1.text_content(), 1)
 
+    def volpage(self, lang_uid):
+        root = self._root
+        if lang_uid == 'lzh':
+            e = root.next_in_order()
+            while e is not None:
+                if e.tag == 'a' and e.select_one('.t'):
+                    break
+                e = e.next_in_order()
+            else:
+                return
+            return '{}'.format(e.attrib['id']).replace('t', 'T ')
+        return None
+
 
 class TextInfoModel:
     def __init__(self):
@@ -128,7 +141,7 @@ class TextInfoModel:
 
                 name = unsegmented_text.title(lang_uid)
 
-                volpage = self._get_volpage(root, lang_uid)
+                volpage = unsegmented_text.volpage(lang_uid)
 
                 mtime = html_file.stat().st_mtime
 
@@ -179,18 +192,6 @@ class TextInfoModel:
             f for f in all_files if f.stem != 'metadata'
         ]
         return files
-
-    def _get_volpage(self, root, lang_uid):
-        if lang_uid == 'lzh':
-            e = root.next_in_order()
-            while e is not None:
-                if e.tag == 'a' and e.select_one('.t'):
-                    break
-                e = e.next_in_order()
-            else:
-                return
-            return '{}'.format(e.attrib['id']).replace('t', 'T ')
-        return None
 
 
 class ArangoTextInfoModel(TextInfoModel):

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -41,12 +41,9 @@ class TextInfoModel:
         unicode_points = {'normal': set(), 'bold': set(), 'italic': set()}
 
         lang_uid = lang_dir.stem
-        all_files = sorted(
-            lang_dir.glob('**/*.html'), key=lambda f: util.numericsortkey(f.stem)
-        )
-        files = [f for f in all_files if f.stem == 'metadata'] + [
-            f for f in all_files if f.stem != 'metadata'
-        ]
+
+        files = self._files_for_language(lang_dir)
+
         for html_file in files:
             try:
                 # Should we process this file?
@@ -125,6 +122,15 @@ class TextInfoModel:
         self.update_code_points(
             unicode_points=unicode_points, lang_uid=lang_dir.stem, force=force
         )
+
+    def _files_for_language(self, lang_dir):
+        all_files = sorted(
+            lang_dir.glob('**/*.html'), key=lambda f: util.numericsortkey(f.stem)
+        )
+        files = [f for f in all_files if f.stem == 'metadata'] + [
+            f for f in all_files if f.stem != 'metadata'
+        ]
+        return files
 
     def _get_author(self, root, file):
         author = None

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -11,8 +11,9 @@ logger = logging.getLogger(__name__)
 
 
 class UnsegmentedText:
-    def __init__(self, html: str):
-        pass
+    def __init__(self, file: Path, html: str):
+        self._file = file
+        self._html = html
 
     def get_authors_long_name(self, root, file):
         author = None
@@ -26,7 +27,7 @@ class UnsegmentedText:
                 author = e.attrib['content']
 
         if not author:
-            logging.critical(f'Author not found: {str(file)}')
+            logging.critical(f'Author not found: {str(self._file)}')
         return author
 
 
@@ -74,7 +75,7 @@ class TextInfoModel:
                 with html_file.open('r', encoding='utf8') as f:
                     text = f.read()
 
-                unsegmented_text = UnsegmentedText(text)
+                unsegmented_text = UnsegmentedText(html_file, text)
                 root = sc_html.fromstring(text)
 
                 self._extract_unicode_points(lang_uid, root, unicode_points)

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -58,7 +58,7 @@ class TextInfoModel:
 
                 self._extract_unicode_points(lang_uid, root, unicode_points)
 
-                author = self._get_author(root, html_file)
+                author = self._get_authors_long_name(root, html_file)
                 author_data = self.get_author_by_name(author, html_file)
 
                 if author_data:
@@ -131,7 +131,7 @@ class TextInfoModel:
         ]
         return files
 
-    def _get_author(self, root, file):
+    def _get_authors_long_name(self, root, file):
         author = None
         e = root.select_one('meta[author]')
         if e:

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class TextInfoModel:
     def __init__(self):
-        pass
+        self._ppn: PaliPageNumbinator | None = None
 
     def get_author_by_name(self, name, file):
         raise NotImplementedError
@@ -45,7 +45,7 @@ class TextInfoModel:
         # But it shouldn't be created at all if we don't need it.
         # So we use a getter, and delete it when we are done.
 
-        self._ppn = None
+
         if lang_dir.stem == 'pli':
             try:
                 self._ppn = PaliPageNumbinator(data_dir=data_dir)

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -10,6 +10,26 @@ from . import sc_html, util
 logger = logging.getLogger(__name__)
 
 
+class UnsegmentedText:
+    def __init__(self, html: str):
+        pass
+
+    def get_authors_long_name(self, root, file):
+        author = None
+        e = root.select_one('meta[author]')
+        if e:
+            author = e.attrib['author']
+
+        if not author:
+            e = root.select_one('meta[name=author]')
+            if e:
+                author = e.attrib['content']
+
+        if not author:
+            logging.critical(f'Author not found: {str(file)}')
+        return author
+
+
 class TextInfoModel:
     def __init__(self):
         pass
@@ -54,11 +74,13 @@ class TextInfoModel:
                 with html_file.open('r', encoding='utf8') as f:
                     text = f.read()
 
+                unsegmented_text = UnsegmentedText(text)
                 root = sc_html.fromstring(text)
 
                 self._extract_unicode_points(lang_uid, root, unicode_points)
 
-                author = self._get_authors_long_name(root, html_file)
+                author = unsegmented_text.get_authors_long_name(root, html_file)
+
                 author_data = self.get_author_by_name(author, html_file)
 
                 if author_data:

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -11,9 +11,10 @@ logger = logging.getLogger(__name__)
 
 
 class UnsegmentedText:
-    def __init__(self, file: Path, html: str):
+    def __init__(self, file: Path, html: str, lang_uid: str):
         self._file = file
         self._html = html
+        self._lang_uid = lang_uid
         self._root = sc_html.fromstring(html)
 
     def authors_long_name(self):
@@ -38,7 +39,7 @@ class UnsegmentedText:
 
         return None
 
-    def title(self, lang_uid):
+    def title(self):
         root = self._root
         header = root.select_one('header')
         if not header:
@@ -50,7 +51,7 @@ class UnsegmentedText:
             logger.error(f'No h1 found in {str(self._file)}')
             return ''
 
-        if lang_uid == 'lzh':
+        if self._lang_uid == 'lzh':
             left_side = h1.select_one('.mirror-left')
             right_side = h1.select_one('.mirror-right')
             if left_side and right_side:
@@ -128,10 +129,10 @@ class TextInfoModel:
                 with html_file.open('r', encoding='utf8') as f:
                     text = f.read()
 
-                unsegmented_text = UnsegmentedText(html_file, text)
+                unsegmented_text = UnsegmentedText(html_file, text, lang_uid)
                 unsegmented_text.extract_unicode_points(lang_uid, unicode_points)
                 publication_date = unsegmented_text.publication_date()
-                name = unsegmented_text.title(lang_uid)
+                name = unsegmented_text.title()
                 volpage = unsegmented_text.volpage(lang_uid)
                 author = unsegmented_text.authors_long_name()
 

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -14,15 +14,16 @@ class UnsegmentedText:
     def __init__(self, file: Path, html: str):
         self._file = file
         self._html = html
+        self._root = sc_html.fromstring(html)
 
-    def get_authors_long_name(self, root, file):
+    def get_authors_long_name(self):
         author = None
-        e = root.select_one('meta[author]')
+        e = self._root.select_one('meta[author]')
         if e:
             author = e.attrib['author']
 
         if not author:
-            e = root.select_one('meta[name=author]')
+            e = self._root.select_one('meta[name=author]')
             if e:
                 author = e.attrib['content']
 
@@ -80,7 +81,7 @@ class TextInfoModel:
 
                 self._extract_unicode_points(lang_uid, root, unicode_points)
 
-                author = unsegmented_text.get_authors_long_name(root, html_file)
+                author = unsegmented_text.get_authors_long_name()
 
                 author_data = self.get_author_by_name(author, html_file)
 

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -46,13 +46,8 @@ class TextInfoModel:
 
         for html_file in files:
             try:
-                # Should we process this file?
-
                 if self._should_process_file(data_dir, files_to_process, force, html_file):
                     continue
-
-                # By the way we can't just iterate over the files_to_process
-                # because we also care about the previous and next file
 
                 logger.info('Adding file: {!s}'.format(html_file))
                 uid = html_file.stem

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -37,9 +37,6 @@ class TextInfoModel:
             files_to_process: dict[str, int] | None = None,
             force: bool = False
     ):
-        # files_to_process is actually "files that may be processed" its
-        # not the list of files to actually process
-
         # It should be noted SuttaCentral does not use bolditalic
         unicode_points = {'normal': set(), 'bold': set(), 'italic': set()}
 

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -147,8 +147,6 @@ class TextInfoModel:
                 else:
                     path = f'{lang_uid}/{uid}'
 
-                mtime = html_file.stat().st_mtime
-
                 text_info = {
                     "uid": uid,
                     "lang": lang_uid,
@@ -159,7 +157,7 @@ class TextInfoModel:
                     "author_uid": author_uid,
                     "publication_date": text.publication_date(),
                     "volpage": text.volpage(),
-                    "mtime": mtime,
+                    "mtime": self.last_modified(html_file),
                     "file_path": str(html_file.resolve()),
                 }
 
@@ -172,6 +170,9 @@ class TextInfoModel:
         self.update_code_points(
             unicode_points=unicode_points, lang_uid=lang_dir.stem, force=force
         )
+
+    def last_modified(self, html_file):
+        return html_file.stat().st_mtime
 
     def _should_process_file(self, data_dir, files_to_process, force, html_file):
         return not force and str(html_file.relative_to(data_dir)) not in files_to_process

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -71,12 +71,12 @@ class UnsegmentedText:
             return '{}'.format(e.attrib['id']).replace('t', 'T ')
         return None
 
-    def extract_unicode_points(self, lang_uid, unicode_points):
+    def extract_unicode_points(self, unicode_points):
         root = self._root
         _stack = [root]
         while _stack:
             e = _stack.pop()
-            if self.is_bold(lang_uid, e):
+            if self.is_bold(self._lang_uid, e):
                 unicode_points['bold'].update(e.text_content())
             elif self.is_italic(e):
                 unicode_points['italic'].update(e.text_content())
@@ -130,7 +130,7 @@ class TextInfoModel:
                     text = f.read()
 
                 unsegmented_text = UnsegmentedText(html_file, text, lang_uid)
-                unsegmented_text.extract_unicode_points(lang_uid, unicode_points)
+                unsegmented_text.extract_unicode_points(unicode_points)
                 publication_date = unsegmented_text.publication_date()
                 name = unsegmented_text.title()
                 volpage = unsegmented_text.volpage()

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class TextInfoModel:
     def __init__(self):
-        self._metadata = {}
+        pass
 
     def get_author_by_name(self, name, file):
         raise NotImplementedError

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -58,11 +58,16 @@ class TextInfoModel:
         with html_file.open('r', encoding='utf8') as f:
             text = f.read()
 
-        text = UnsegmentedText(html_file, text, lang_uid)
+        text = UnsegmentedText(text, lang_uid)
 
         text.extract_unicode_points(unicode_points)
 
-        author_data = self.get_author_by_name(text.authors_long_name(), html_file)
+        author_long_name = text.authors_long_name()
+
+        if not author_long_name:
+            logging.critical(f'Author not found: {str(html_file)}')
+
+        author_data = self.get_author_by_name(author_long_name, html_file)
 
         if author_data:
             author_uid = author_data['uid']
@@ -75,12 +80,17 @@ class TextInfoModel:
         else:
             path = f'{lang_uid}/{uid}'
 
+        title = text.title()
+
+        if title == '':
+            logger.error(f'Could not find title for text in file: {str(html_file)}')
+
         document = {
             "uid": uid,
             "lang": lang_uid,
             "path": path,
-            "name": text.title(),
-            "author": text.authors_long_name(),
+            "name": title,
+            "author": author_long_name,
             "author_short": author_short,
             "author_uid": author_uid,
             "publication_date": text.publication_date(),

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -47,7 +47,7 @@ class TextInfoModel:
         files = [f for f in all_files if f.stem == 'metadata'] + [
             f for f in all_files if f.stem != 'metadata'
         ]
-        for i, htmlfile in enumerate(files):
+        for htmlfile in files:
             try:
                 # Should we process this file?
 

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -47,22 +47,22 @@ class TextInfoModel:
         files = [f for f in all_files if f.stem == 'metadata'] + [
             f for f in all_files if f.stem != 'metadata'
         ]
-        for htmlfile in files:
+        for html_file in files:
             try:
                 # Should we process this file?
 
                 if (
                         not force
-                        and str(htmlfile.relative_to(data_dir)) not in files_to_process
+                        and str(html_file.relative_to(data_dir)) not in files_to_process
                 ):
                     continue
 
                 # By the way we can't just iterate over the files_to_process
                 # because we also care about the previous and next file
 
-                logger.info('Adding file: {!s}'.format(htmlfile))
-                uid = htmlfile.stem
-                with htmlfile.open('r', encoding='utf8') as f:
+                logger.info('Adding file: {!s}'.format(html_file))
+                uid = html_file.stem
+                with html_file.open('r', encoding='utf8') as f:
                     text = f.read()
 
                 root = sc_html.fromstring(text)
@@ -80,8 +80,8 @@ class TextInfoModel:
                         _stack.extend(e)
                 unicode_points['normal'].update(root.text_content())
 
-                author = self._get_author(root, htmlfile)
-                author_data = self.get_author_by_name(author, htmlfile)
+                author = self._get_author(root, html_file)
+                author_data = self.get_author_by_name(author, html_file)
 
                 if author_data:
                     author_uid = author_data['uid']
@@ -100,7 +100,7 @@ class TextInfoModel:
                 name = self._get_name(root, lang_uid, uid)
                 volpage = self._get_volpage(root, lang_uid, uid)
 
-                mtime = htmlfile.stat().st_mtime
+                mtime = html_file.stat().st_mtime
 
                 text_info = {
                     "uid": uid,
@@ -113,13 +113,13 @@ class TextInfoModel:
                     "publication_date": publication_date,
                     "volpage": volpage,
                     "mtime": mtime,
-                    "file_path": str(htmlfile.resolve()),
+                    "file_path": str(html_file.resolve()),
                 }
 
                 self.add_document(text_info)
 
             except Exception as e:
-                print('An exception occurred: {!s}'.format(htmlfile))
+                print('An exception occurred: {!s}'.format(html_file))
                 raise
 
         self.update_code_points(

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -129,9 +129,10 @@ class TextInfoModel:
                     text = f.read()
 
                 unsegmented_text = UnsegmentedText(html_file, text)
-
                 unsegmented_text.extract_unicode_points(lang_uid, unicode_points)
-
+                publication_date = unsegmented_text.publication_date()
+                name = unsegmented_text.title(lang_uid)
+                volpage = unsegmented_text.volpage(lang_uid)
                 author = unsegmented_text.authors_long_name()
 
                 author_data = self.get_author_by_name(author, html_file)
@@ -147,12 +148,6 @@ class TextInfoModel:
                     path = f'{lang_uid}/{uid}/{author_uid}'
                 else:
                     path = f'{lang_uid}/{uid}'
-
-                publication_date = unsegmented_text.publication_date()
-
-                name = unsegmented_text.title(lang_uid)
-
-                volpage = unsegmented_text.volpage(lang_uid)
 
                 mtime = html_file.stat().st_mtime
 

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -48,10 +48,7 @@ class TextInfoModel:
             try:
                 # Should we process this file?
 
-                if (
-                        not force
-                        and str(html_file.relative_to(data_dir)) not in files_to_process
-                ):
+                if self._should_process_file(data_dir, files_to_process, force, html_file):
                     continue
 
                 # By the way we can't just iterate over the files_to_process
@@ -121,6 +118,12 @@ class TextInfoModel:
 
         self.update_code_points(
             unicode_points=unicode_points, lang_uid=lang_dir.stem, force=force
+        )
+
+    def _should_process_file(self, data_dir, files_to_process, force, html_file):
+        return (
+                not force
+                and str(html_file.relative_to(data_dir)) not in files_to_process
         )
 
     def _files_for_language(self, lang_dir):

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -56,18 +56,7 @@ class TextInfoModel:
 
                 root = sc_html.fromstring(text)
 
-                # Set codepoint data
-
-                _stack = [root]
-                while _stack:
-                    e = _stack.pop()
-                    if self.is_bold(lang_uid, e):
-                        unicode_points['bold'].update(e.text_content())
-                    elif self.is_italic(e):
-                        unicode_points['italic'].update(e.text_content())
-                    else:
-                        _stack.extend(e)
-                unicode_points['normal'].update(root.text_content())
+                self._extract_unicode_points(lang_uid, root, unicode_points)
 
                 author = self._get_author(root, html_file)
                 author_data = self.get_author_by_name(author, html_file)
@@ -114,6 +103,18 @@ class TextInfoModel:
         self.update_code_points(
             unicode_points=unicode_points, lang_uid=lang_dir.stem, force=force
         )
+
+    def _extract_unicode_points(self, lang_uid, root, unicode_points):
+        _stack = [root]
+        while _stack:
+            e = _stack.pop()
+            if self.is_bold(lang_uid, e):
+                unicode_points['bold'].update(e.text_content())
+            elif self.is_italic(e):
+                unicode_points['italic'].update(e.text_content())
+            else:
+                _stack.extend(e)
+        unicode_points['normal'].update(root.text_content())
 
     def _should_process_file(self, data_dir, files_to_process, force, html_file):
         return (

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -151,21 +151,6 @@ class TextInfoModel:
         ]
         return files
 
-    def _get_authors_long_name(self, root, file):
-        author = None
-        e = root.select_one('meta[author]')
-        if e:
-            author = e.attrib['author']
-
-        if not author:
-            e = root.select_one('meta[name=author]')
-            if e:
-                author = e.attrib['content']
-
-        if not author:
-            logging.critical(f'Author not found: {str(file)}')
-        return author
-
     def _get_publication_date(self, root):
         e = root.select_one('.publication-date')
         if e:

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -16,7 +16,7 @@ class UnsegmentedText:
         self._html = html
         self._root = sc_html.fromstring(html)
 
-    def get_authors_long_name(self):
+    def authors_long_name(self):
         author = None
         e = self._root.select_one('meta[author]')
         if e:
@@ -81,7 +81,7 @@ class TextInfoModel:
 
                 self._extract_unicode_points(lang_uid, root, unicode_points)
 
-                author = unsegmented_text.get_authors_long_name()
+                author = unsegmented_text.authors_long_name()
 
                 author_data = self.get_author_by_name(author, html_file)
 

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -129,14 +129,11 @@ class TextInfoModel:
                 with html_file.open('r', encoding='utf8') as f:
                     text = f.read()
 
-                unsegmented_text = UnsegmentedText(html_file, text, lang_uid)
-                unsegmented_text.extract_unicode_points(unicode_points)
-                publication_date = unsegmented_text.publication_date()
-                name = unsegmented_text.title()
-                volpage = unsegmented_text.volpage()
-                author = unsegmented_text.authors_long_name()
+                text = UnsegmentedText(html_file, text, lang_uid)
 
-                author_data = self.get_author_by_name(author, html_file)
+                text.extract_unicode_points(unicode_points)
+
+                author_data = self.get_author_by_name(text.authors_long_name(), html_file)
 
                 if author_data:
                     author_uid = author_data['uid']
@@ -156,12 +153,12 @@ class TextInfoModel:
                     "uid": uid,
                     "lang": lang_uid,
                     "path": path,
-                    "name": name,
-                    "author": author,
+                    "name": text.title(),
+                    "author": text.authors_long_name(),
                     "author_short": author_short,
                     "author_uid": author_uid,
-                    "publication_date": publication_date,
-                    "volpage": volpage,
+                    "publication_date": text.publication_date(),
+                    "volpage": text.volpage(),
                     "mtime": mtime,
                     "file_path": str(html_file.resolve()),
                 }

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -124,41 +124,7 @@ class TextInfoModel:
                     continue
 
                 logger.info('Adding file: {!s}'.format(html_file))
-                uid = html_file.stem
-                with html_file.open('r', encoding='utf8') as f:
-                    text = f.read()
-
-                text = UnsegmentedText(html_file, text, lang_uid)
-
-                text.extract_unicode_points(unicode_points)
-
-                author_data = self.get_author_by_name(text.authors_long_name(), html_file)
-
-                if author_data:
-                    author_uid = author_data['uid']
-                    author_short = author_data['short_name']
-                else:
-                    author_uid = None
-                    author_short = None
-
-                if author_uid:
-                    path = f'{lang_uid}/{uid}/{author_uid}'
-                else:
-                    path = f'{lang_uid}/{uid}'
-
-                document = {
-                    "uid": uid,
-                    "lang": lang_uid,
-                    "path": path,
-                    "name": text.title(),
-                    "author": text.authors_long_name(),
-                    "author_short": author_short,
-                    "author_uid": author_uid,
-                    "publication_date": text.publication_date(),
-                    "volpage": text.volpage(),
-                    "mtime": self.last_modified(html_file),
-                    "file_path": str(html_file.resolve()),
-                }
+                document = self.create_document(html_file, lang_uid, unicode_points)
 
                 self.add_document(document)
 
@@ -169,6 +135,45 @@ class TextInfoModel:
         self.update_code_points(
             unicode_points=unicode_points, lang_uid=lang_dir.stem, force=force
         )
+
+    def create_document(self, html_file, lang_uid, unicode_points):
+        uid = html_file.stem
+
+        with html_file.open('r', encoding='utf8') as f:
+            text = f.read()
+
+        text = UnsegmentedText(html_file, text, lang_uid)
+
+        text.extract_unicode_points(unicode_points)
+
+        author_data = self.get_author_by_name(text.authors_long_name(), html_file)
+
+        if author_data:
+            author_uid = author_data['uid']
+            author_short = author_data['short_name']
+        else:
+            author_uid = None
+            author_short = None
+        if author_uid:
+            path = f'{lang_uid}/{uid}/{author_uid}'
+        else:
+            path = f'{lang_uid}/{uid}'
+
+        document = {
+            "uid": uid,
+            "lang": lang_uid,
+            "path": path,
+            "name": text.title(),
+            "author": text.authors_long_name(),
+            "author_short": author_short,
+            "author_uid": author_uid,
+            "publication_date": text.publication_date(),
+            "volpage": text.volpage(),
+            "mtime": self.last_modified(html_file),
+            "file_path": str(html_file.resolve()),
+        }
+
+        return document
 
     def last_modified(self, html_file):
         return html_file.stat().st_mtime

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -129,7 +129,6 @@ class TextInfoModel:
                     text = f.read()
 
                 unsegmented_text = UnsegmentedText(html_file, text)
-                root = sc_html.fromstring(text)
 
                 unsegmented_text.extract_unicode_points(lang_uid, unicode_points)
 

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -31,6 +31,13 @@ class UnsegmentedText:
             logging.critical(f'Author not found: {str(self._file)}')
         return author
 
+    def publication_date(self):
+        e = self._root.select_one('.publication-date')
+        if e:
+            return e.text_content()
+
+        return None
+
 
 class TextInfoModel:
     def __init__(self):
@@ -97,7 +104,7 @@ class TextInfoModel:
                 else:
                     path = f'{lang_uid}/{uid}'
 
-                publication_date = self._get_publication_date(root)
+                publication_date = unsegmented_text.publication_date()
 
                 name = self._get_name(root, lang_uid, uid)
                 volpage = self._get_volpage(root, lang_uid, uid)
@@ -151,13 +158,6 @@ class TextInfoModel:
             f for f in all_files if f.stem != 'metadata'
         ]
         return files
-
-    def _get_publication_date(self, root):
-        e = root.select_one('.publication-date')
-        if e:
-            return e.text_content()
-
-        return None
 
     def _get_name(self, root, lang_uid, uid):
         header = root.select_one('header')

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -112,7 +112,6 @@ class TextInfoModel:
             files_to_process: dict[str, int] | None = None,
             force: bool = False
     ):
-        # It should be noted SuttaCentral does not use bolditalic
         unicode_points = {'normal': set(), 'bold': set(), 'italic': set()}
 
         lang_uid = lang_dir.stem

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -106,7 +106,7 @@ class TextInfoModel:
 
                 publication_date = unsegmented_text.publication_date()
 
-                name = self._get_name(root, lang_uid, uid)
+                name = self._get_title(root, lang_uid, uid)
                 volpage = self._get_volpage(root, lang_uid, uid)
 
                 mtime = html_file.stat().st_mtime
@@ -159,7 +159,7 @@ class TextInfoModel:
         ]
         return files
 
-    def _get_name(self, root, lang_uid, uid):
+    def _get_title(self, root, lang_uid, uid):
         header = root.select_one('header')
         if not header:
             logger.error(f'No header found in {lang_uid}/{uid}')

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -59,9 +59,8 @@ class UnsegmentedText:
         return regex.sub(r'[\d\.\{\} –-]*', '', h1.text_content(), 1)
 
     def volpage(self, lang_uid):
-        root = self._root
         if lang_uid == 'lzh':
-            e = root.next_in_order()
+            e = self._root.next_in_order()
             while e is not None:
                 if e.tag == 'a' and e.select_one('.t'):
                     break

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -146,7 +146,7 @@ class TextInfoModel:
                 else:
                     path = f'{lang_uid}/{uid}'
 
-                text_info = {
+                document = {
                     "uid": uid,
                     "lang": lang_uid,
                     "path": path,
@@ -160,7 +160,7 @@ class TextInfoModel:
                     "file_path": str(html_file.resolve()),
                 }
 
-                self.add_document(text_info)
+                self.add_document(document)
 
             except Exception as e:
                 print('An exception occurred: {!s}'.format(html_file))

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -117,10 +117,7 @@ class TextInfoModel:
         unicode_points['normal'].update(root.text_content())
 
     def _should_process_file(self, data_dir, files_to_process, force, html_file):
-        return (
-                not force
-                and str(html_file.relative_to(data_dir)) not in files_to_process
-        )
+        return not force and str(html_file.relative_to(data_dir)) not in files_to_process
 
     def _files_for_language(self, lang_dir):
         all_files = sorted(

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -38,16 +38,16 @@ class UnsegmentedText:
 
         return None
 
-    def title(self, lang_uid, uid):
+    def title(self, lang_uid):
         root = self._root
         header = root.select_one('header')
         if not header:
-            logger.error(f'No header found in {lang_uid}/{uid}')
+            logger.error(f'No header found in {str(self._file)}')
             return ''
 
         h1 = header.select_one('h1')
         if not h1:
-            logger.error(f'No h1 found in {lang_uid}/{uid}')
+            logger.error(f'No h1 found in {str(self._file)}')
             return ''
 
         if lang_uid == 'lzh':
@@ -126,7 +126,7 @@ class TextInfoModel:
 
                 publication_date = unsegmented_text.publication_date()
 
-                name = unsegmented_text.title(lang_uid, uid)
+                name = unsegmented_text.title(lang_uid)
 
                 volpage = self._get_volpage(root, lang_uid, uid)
 

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 
 import regex
 

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -1,0 +1,90 @@
+import logging
+from pathlib import Path
+
+import regex
+
+from data_loader import sc_html
+
+logger = logging.getLogger(__name__)
+
+class UnsegmentedText:
+    def __init__(self, file: Path, html: str, lang_uid: str):
+        self._file = file
+        self._html = html
+        self._lang_uid = lang_uid
+        self._root = sc_html.fromstring(html)
+
+    def authors_long_name(self):
+        author = None
+        e = self._root.select_one('meta[author]')
+        if e:
+            author = e.attrib['author']
+
+        if not author:
+            e = self._root.select_one('meta[name=author]')
+            if e:
+                author = e.attrib['content']
+
+        if not author:
+            logging.critical(f'Author not found: {str(self._file)}')
+        return author
+
+    def publication_date(self):
+        e = self._root.select_one('.publication-date')
+        if e:
+            return e.text_content()
+
+        return None
+
+    def title(self):
+        root = self._root
+        header = root.select_one('header')
+        if not header:
+            logger.error(f'No header found in {str(self._file)}')
+            return ''
+
+        h1 = header.select_one('h1')
+        if not h1:
+            logger.error(f'No h1 found in {str(self._file)}')
+            return ''
+
+        if self._lang_uid == 'lzh':
+            left_side = h1.select_one('.mirror-left')
+            right_side = h1.select_one('.mirror-right')
+            if left_side and right_side:
+                return right_side.text_content() + ' (' + left_side.text_content() + ')'
+
+        return regex.sub(r'[\d\.\{\} –-]*', '', h1.text_content(), 1)
+
+    def volpage(self):
+        if self._lang_uid == 'lzh':
+            e = self._root.next_in_order()
+            while e is not None:
+                if e.tag == 'a' and e.select_one('.t'):
+                    break
+                e = e.next_in_order()
+            else:
+                return
+            return '{}'.format(e.attrib['id']).replace('t', 'T ')
+        return None
+
+    def extract_unicode_points(self, unicode_points):
+        root = self._root
+        _stack = [root]
+        while _stack:
+            e = _stack.pop()
+            if self.is_bold(self._lang_uid, e):
+                unicode_points['bold'].update(e.text_content())
+            elif self.is_italic(e):
+                unicode_points['italic'].update(e.text_content())
+            else:
+                _stack.extend(e)
+        unicode_points['normal'].update(root.text_content())
+
+    def is_bold(self, lang, element):
+        if element.tag in {'b', 'strong'}:
+            return True
+        return lang in {'lzh', 'ko', 'jp', 'tw'} and element.tag in {'h1', 'h2', 'h3', 'h4', 'h5', 'h6'}
+
+    def is_italic(self, element):
+        return element.tag in {'i', 'em'}

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -8,8 +8,7 @@ from data_loader import sc_html
 logger = logging.getLogger(__name__)
 
 class UnsegmentedText:
-    def __init__(self, file: Path, html: str, lang_uid: str):
-        self._file = file
+    def __init__(self, html: str, lang_uid: str):
         self._html = html
         self._lang_uid = lang_uid
         self._root = sc_html.fromstring(html)
@@ -25,8 +24,6 @@ class UnsegmentedText:
             if e:
                 author = e.attrib['content']
 
-        if not author:
-            logging.critical(f'Author not found: {str(self._file)}')
         return author
 
     def publication_date(self):
@@ -36,16 +33,14 @@ class UnsegmentedText:
 
         return None
 
-    def title(self):
+    def title(self) -> str:
         root = self._root
         header = root.select_one('header')
         if not header:
-            logger.error(f'No header found in {str(self._file)}')
             return ''
 
         h1 = header.select_one('h1')
         if not h1:
-            logger.error(f'No h1 found in {str(self._file)}')
             return ''
 
         if self._lang_uid == 'lzh':


### PR DESCRIPTION
I've continued to beef up my tests for the `textdata.py` module and I think they're pretty solid.

Refactoring has finally begun. There are very few changes to behavior, though there are some small changes to logging of missing data in the HTML files.

The old `PaliPageNumbinator` class is finally gone.

As expected, there does not seem to be much of a change in terms of performance as it still does what it did before.

This is continued work for issue #3369