### PR TITLE
Remove unicode points and refactor unsegmented text titles.

### DIFF
--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -255,7 +255,7 @@ class TestTextInfoModel:
         add_html_file(sutta_path, html)
         text_info.process_lang_dir(language_path, base_path, files_to_process)
         assert caplog.records[0].levelno == logging.ERROR
-        assert caplog.records[0].message == f"Could not find title for text in file: {str(sutta_path)}"
+        assert caplog.records[0].message == f"Could not find title in file: {str(sutta_path)}"
 
     def test_logs_missing_title_when_there_is_no_h1_tag(
                 self, text_info, sutta_path, language_path, base_path, files_to_process, caplog
@@ -270,7 +270,19 @@ class TestTextInfoModel:
             add_html_file(sutta_path, html)
             text_info.process_lang_dir(language_path, base_path, files_to_process)
             assert caplog.records[0].levelno == logging.ERROR
-            assert caplog.records[0].message == f"Could not find title for text in file: {str(sutta_path)}"
+            assert caplog.records[0].message == f"Could not find title in file: {str(sutta_path)}"
+
+    def test_does_not_log_missing_title_when_it_is_an_empty_string(
+            self, text_info, sutta_path, language_path, base_path, files_to_process, caplog
+    ):
+        html = ("<html>"
+                "<head><meta author='Bhikkhu Bodhi'><head>"
+                "<body><header><h1></h1></header></body>"
+                "</html>")
+
+        add_html_file(sutta_path, html)
+        text_info.process_lang_dir(language_path, base_path, files_to_process)
+        assert not caplog.records
 
     def test_extracts_chinese_volpage(self, text_info, base_path):
         sutta_relative = 'html_text/lzh/sutta/ma/ma43.html'

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -7,13 +7,6 @@ import pytest
 from data_loader.textdata import TextInfoModel
 
 
-@dataclass
-class CodePoints:
-    lang_uid: str
-    unicode_points: dict
-    force: bool
-
-
 class TextInfoModelSpy(TextInfoModel):
     """
     TextInfoModel uses the template method design pattern giving us a
@@ -23,7 +16,6 @@ class TextInfoModelSpy(TextInfoModel):
     def __init__(self):
         super().__init__()
         self.added_documents = []
-        self.added_code_points: list[CodePoints] = []
 
     def get_author_by_name(self, name, file) -> dict | None:
         if name == "Bhikkhu Bodhi":
@@ -52,10 +44,6 @@ class TextInfoModelSpy(TextInfoModel):
 
     def add_document(self, doc):
         self.added_documents.append(doc)
-
-    def update_code_points(self, lang_uid: str, unicode_points: dict[str, set[str]], force: bool) -> None:
-        self.added_code_points.append(CodePoints(lang_uid, unicode_points, force))
-
 
 def add_html_file(path: Path, html: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -326,22 +314,6 @@ class TestTextInfoModel:
 
         assert text_info.added_documents[0]['mtime'] == sutta_path.stat().st_mtime
 
-    def test_update_code_points(self, text_info, base_path, language_path, sutta_path, files_to_process):
-        html = """
-        <html>
-        <head><meta author='Bhikkhu Bodhi'></head>
-        <body><b>abcd</b><em>wxyz</em></body>
-        </html>
-        """
-        add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
-        assert text_info.added_code_points[0].lang_uid == "en"
-        assert text_info.added_code_points[0].force is False
-        assert text_info.added_code_points[0].unicode_points == {
-            'normal' : {' ', '\n', 'a', 'b', 'c', 'd', 'w', 'x', 'y', 'z'},
-            'bold' : {'a', 'b', 'c', 'd'},
-            'italic' : {'w', 'x', 'y', 'z'},
-        }
 
     def test_multiple_files_added(self, text_info, base_path):
         html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -1,18 +1,86 @@
-from data_loader.unsegmented_texts import UnsegmentedText
+from data_loader import sc_html
+from data_loader.unsegmented_texts import extract_details, find_title_tag
 
 
-class TestUnsegmentedText:
+class TestExtractDetails:
     def test_extracts_authors_long_name_from_content_attribute(self):
         html = "<html><meta name='author' content='Bhikkhu Bodhi'></html>"
-        text = UnsegmentedText(html=html, lang_uid='en')
-        assert text.authors_long_name() == 'Bhikkhu Bodhi'
+        details = extract_details(html, language='en')
+        assert details.authors_long_name == 'Bhikkhu Bodhi'
 
     def test_extracts_authors_long_name_from_author_attribute(self):
         html = "<html><meta author='Bhikkhu Bodhi'></html>"
-        text = UnsegmentedText(html=html, lang_uid='en')
-        assert text.authors_long_name() == 'Bhikkhu Bodhi'
+        details = extract_details(html, language='en')
+        assert details.authors_long_name == 'Bhikkhu Bodhi'
 
     def test_authors_long_name_is_none_when_missing(self):
         html = "<html></html>"
-        text = UnsegmentedText(html=html, lang_uid='en')
-        assert text.authors_long_name() is None
+        details = extract_details(html, language='en')
+        assert details.authors_long_name is None
+
+    def test_extracts_title(self):
+        html = "<html><body><header><h1>Don't Think</h1></header></body></html>"
+        details = extract_details(html, language='en')
+        assert details.title == "Don't Think"
+
+    def test_title_is_empty_due_to_regex(self):
+        html = "<html><body><header><h1>11.358–405</h1></header></body></html>"
+        details = extract_details(html, language='en')
+        assert details.title == ''
+
+    def test_has_title_tags_true_when_present(self):
+        html = '<html><header><h1>1. The Root of All Things</h1></header></html>'
+        details = extract_details(html, language='en')
+        assert details.has_title_tags is True
+
+    def test_has_title_tags_false_if_h1_tag_missing(self):
+        html = "<html><body><header></header><body></html>"
+        details = extract_details(html, language='en')
+        assert details.has_title_tags is False
+
+    def test_has_title_tags_false_if_header_tag_missing(self):
+        html = "<html><body><body></html>"
+        details = extract_details(html, language='en')
+        assert details.has_title_tags is False
+
+    def test_extracts_publication_date(self):
+        html = ("<html>"
+                "<head><meta author='Bhikkhu Bodhi'></head>"
+                "<body><span class='publication-date'>1962</span></body>"
+                "</html>")
+
+        details = extract_details(html, language='en')
+        assert details.publication_date == '1962'
+
+    def test_extracts_volpage_from_chinese_root(self):
+        html = ("<html><head><meta name='author' content='Taishō Tripiṭaka'></head><body><header>"
+                "<a class='ref t' id='t0485b21' href='#t0485b21'>T 0485b21</a>"
+                "</h1></header></body></html>")
+
+        details = extract_details(html, language='lzh')
+        assert details.volume_page == 'T 0485b21'
+
+    def test_volpage_is_none_when_not_chinese_root(self):
+        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
+        details = extract_details(html, language='en')
+        assert details.volume_page is None
+
+
+class TestFindTitleTag:
+    def test_find_title_tag(self):
+        html = '<html><header><h1>1. The Root of All Things</h1></header></html>'
+        root = sc_html.fromstring(html)
+        tag = find_title_tag(root)
+        assert tag.text == '1. The Root of All Things'
+
+    def test_return_none_when_there_is_no_header_tag(self):
+        html = '<html/>'
+        root = sc_html.fromstring(html)
+        tag = find_title_tag(root)
+        assert tag is None
+
+    def test_return_none_when_there_is_no_h1_tag(self):
+        html = '<html><body><header></header></body></html>'
+        root = sc_html.fromstring(html)
+        tag = find_title_tag(root)
+        assert tag is None

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 from arango.exceptions import DocumentReplaceError
 
-from . import util
-from .unsegmented_texts import UnsegmentedText
+from data_loader import util
+from data_loader.unsegmented_texts import extract_details
 
 logger = logging.getLogger(__name__)
 
@@ -47,11 +47,11 @@ class TextInfoModel:
         uid = html_file.stem
 
         with html_file.open('r', encoding='utf8') as f:
-            text = f.read()
+            html = f.read()
 
-        text = UnsegmentedText(text, lang_uid)
+        text_details = extract_details(html, lang_uid)
 
-        author_long_name = text.authors_long_name()
+        author_long_name = text_details.authors_long_name
 
         if not author_long_name:
             logging.critical(f'Author not found: {str(html_file)}')
@@ -69,21 +69,19 @@ class TextInfoModel:
         else:
             path = f'{lang_uid}/{uid}'
 
-        title = text.title()
-
-        if title == '':
-            logger.error(f'Could not find title for text in file: {str(html_file)}')
+        if not text_details.has_title_tags:
+            logger.error(f'Could not find title in file: {str(html_file)}')
 
         document = {
             "uid": uid,
             "lang": lang_uid,
             "path": path,
-            "name": title,
+            "name": text_details.title,
             "author": author_long_name,
             "author_short": author_short,
             "author_uid": author_uid,
-            "publication_date": text.publication_date(),
-            "volpage": text.volpage(),
+            "publication_date": text_details.publication_date,
+            "volpage": text_details.volume_page,
             "mtime": self.last_modified(html_file),
             "file_path": str(html_file.resolve()),
         }

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -19,17 +19,12 @@ class TextInfoModel:
     def add_document(self, doc):
         raise NotImplementedError
 
-    def update_code_points(self, lang_uid: str, unicode_points: dict[str, set[str]], force: bool) -> None:
-        raise NotImplementedError
-
     def process_lang_dir(self,
             lang_dir: Path,
             data_dir: Path = None,
             files_to_process: dict[str, int] | None = None,
             force: bool = False
     ):
-        unicode_points = {'normal': set(), 'bold': set(), 'italic': set()}
-
         lang_uid = lang_dir.stem
 
         files = self._files_for_language(lang_dir)
@@ -40,7 +35,7 @@ class TextInfoModel:
                     continue
 
                 logger.info('Adding file: {!s}'.format(html_file))
-                document = self.create_document(html_file, lang_uid, unicode_points)
+                document = self.create_document(html_file, lang_uid)
 
                 self.add_document(document)
 
@@ -48,19 +43,13 @@ class TextInfoModel:
                 print('An exception occurred: {!s}'.format(html_file))
                 raise
 
-        self.update_code_points(
-            unicode_points=unicode_points, lang_uid=lang_dir.stem, force=force
-        )
-
-    def create_document(self, html_file, lang_uid, unicode_points):
+    def create_document(self, html_file, lang_uid):
         uid = html_file.stem
 
         with html_file.open('r', encoding='utf8') as f:
             text = f.read()
 
         text = UnsegmentedText(text, lang_uid)
-
-        text.extract_unicode_points(unicode_points)
 
         author_long_name = text.authors_long_name()
 

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -1,63 +1,93 @@
 import logging
+from dataclasses import dataclass
 
 import regex
 
 from data_loader import sc_html
+from data_loader.sc_html import HtHtmlElement
 
 logger = logging.getLogger(__name__)
 
-class UnsegmentedText:
-    def __init__(self, html: str, lang_uid: str):
-        self._html = html
-        self._lang_uid = lang_uid
-        self._root = sc_html.fromstring(html)
 
-    def authors_long_name(self):
-        author = None
-        e = self._root.select_one('meta[author]')
+@dataclass(frozen=True)
+class TextDetails:
+    title: str
+    has_title_tags: bool
+    authors_long_name: str | None
+    publication_date: str | None
+    volume_page: str | None
+
+
+def extract_details(html: str, language: str) -> TextDetails:
+    root = sc_html.fromstring(html)
+    title_tag = find_title_tag(root)
+    title = extract_title(title_tag, language)
+
+    return TextDetails(
+        title=title,
+        has_title_tags=bool(title_tag),
+        authors_long_name=extract_authors_long_name(root),
+        publication_date=extract_publication_date(root),
+        volume_page=extract_volpage(root, language)
+    )
+
+
+def extract_authors_long_name(root) -> str | None:
+    author = None
+    e = root.select_one('meta[author]')
+    if e:
+        author = e.attrib['author']
+
+    if not author:
+        e = root.select_one('meta[name=author]')
         if e:
-            author = e.attrib['author']
+            author = e.attrib['content']
 
-        if not author:
-            e = self._root.select_one('meta[name=author]')
-            if e:
-                author = e.attrib['content']
+    return author
 
-        return author
 
-    def publication_date(self):
-        e = self._root.select_one('.publication-date')
-        if e:
-            return e.text_content()
+def extract_publication_date(root) -> str | None:
+    e = root.select_one('.publication-date')
+    if e:
+        return e.text_content()
 
+    return None
+
+
+def extract_title(title_tag: HtHtmlElement | None, language: str) -> str:
+    if title_tag is None:
+        return ''
+
+    if language == 'lzh':
+        left_side = title_tag.select_one('.mirror-left')
+        right_side = title_tag.select_one('.mirror-right')
+        if left_side and right_side:
+            return right_side.text_content() + ' (' + left_side.text_content() + ')'
+
+    return regex.sub(r'[\d\.\{\} –-]*', '', title_tag.text_content(), 1)
+
+
+def find_title_tag(root: HtHtmlElement) -> HtHtmlElement | None:
+    header = root.select_one('header')
+    if not header:
         return None
 
-    def title(self) -> str:
-        root = self._root
-        header = root.select_one('header')
-        if not header:
-            return ''
+    h1 = header.select_one('h1')
 
-        h1 = header.select_one('h1')
-        if not h1:
-            return ''
-
-        if self._lang_uid == 'lzh':
-            left_side = h1.select_one('.mirror-left')
-            right_side = h1.select_one('.mirror-right')
-            if left_side and right_side:
-                return right_side.text_content() + ' (' + left_side.text_content() + ')'
-
-        return regex.sub(r'[\d\.\{\} –-]*', '', h1.text_content(), 1)
-
-    def volpage(self):
-        if self._lang_uid == 'lzh':
-            e = self._root.next_in_order()
-            while e is not None:
-                if e.tag == 'a' and e.select_one('.t'):
-                    break
-                e = e.next_in_order()
-            else:
-                return
-            return '{}'.format(e.attrib['id']).replace('t', 'T ')
+    if not h1:
         return None
+
+    return h1
+
+
+def extract_volpage(root, language: str) -> str | None:
+    if language == 'lzh':
+        e = root.next_in_order()
+        while e is not None:
+            if e.tag == 'a' and e.select_one('.t'):
+                break
+            e = e.next_in_order()
+        else:
+            return
+        return '{}'.format(e.attrib['id']).replace('t', 'T ')
+    return None

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -61,24 +61,3 @@ class UnsegmentedText:
                 return
             return '{}'.format(e.attrib['id']).replace('t', 'T ')
         return None
-
-    def extract_unicode_points(self, unicode_points):
-        root = self._root
-        _stack = [root]
-        while _stack:
-            e = _stack.pop()
-            if self.is_bold(self._lang_uid, e):
-                unicode_points['bold'].update(e.text_content())
-            elif self.is_italic(e):
-                unicode_points['italic'].update(e.text_content())
-            else:
-                _stack.extend(e)
-        unicode_points['normal'].update(root.text_content())
-
-    def is_bold(self, lang, element):
-        if element.tag in {'b', 'strong'}:
-            return True
-        return lang in {'lzh', 'ko', 'jp', 'tw'} and element.tag in {'h1', 'h2', 'h3', 'h4', 'h5', 'h6'}
-
-    def is_italic(self, element):
-        return element.tag in {'i', 'em'}


### PR DESCRIPTION
I've addressed issue #3418 by removing the process that extracts characters and stores them in the `unicode_points` collection. I've left the `ArangoTextInfoModel.update_code_points()` method alone for now as I don't have test coverage for the class. It isn't called though.

On my machine this avoids 10 seconds of CPU time, reducing it from 45 seconds to 35 seconds. This is our first big optimization!

The `UnsegmentedText` class has been refactored to use simple functions and a dataclass containing the extracted details.

I've also fixed #3454 - we no longer log missing titles if they're just empty strings. The output of `make load-data` should no longer print hundreds of errors for this case.