### PR TITLE
Refactoring and fix for forced updates

### DIFF
--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -265,25 +265,11 @@ def load_map_data(additional_info_dir, db):
 
 def load_html_texts(change_tracker: ChangeTracker, data_dir: Path, db: Database, html_dir: Path):
     print('Loading HTML texts')
-
-    force = change_tracker.is_any_function_changed(
-        [textdata.TextInfoModel, textdata.ArangoTextInfoModel]
-    )
-
-    if force:
-        print('This might take a while')
-        db['html_text'].truncate()
-
     with textdata.ArangoTextInfoModel(db=db) as tim:
         for lang_dir in tqdm(html_dir.glob('*')):
             if not lang_dir.is_dir:
                 continue
-            tim.process_lang_dir(
-                lang_dir=lang_dir,
-                data_dir=data_dir,
-                files_to_process=change_tracker.changed_or_new,
-                force=force,
-            )
+            tim.process_lang_dir(lang_dir=lang_dir, data_dir=data_dir, files_to_process=change_tracker.changed_or_new)
 
 
 def load_json_file(db, change_tracker, json_file):

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -176,12 +176,6 @@ class TestTextInfoModel:
         text_info.process_lang_dir(language_path, base_path, files_to_process)
         assert text_info.added_documents[0]['path'] == path
 
-    def test_missing_publication_date_is_none(self, text_info, base_path, language_path, sutta_path, files_to_process):
-        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
-        add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
-        assert text_info.added_documents[0]['publication_date'] is None
-
     def test_extracts_english_title(self, text_info, base_path, language_path, sutta_path, files_to_process):
         html = """
         <html>

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from data_loader.textdata import TextInfoModel, should_not_process_file
+from data_loader.textdata import TextInfoModel, should_process_file
 
 
 class TextInfoModelSpy(TextInfoModel):
@@ -306,10 +306,10 @@ class TestShouldNotProcessFile:
 
         files_to_process = {'html_text/en/pli/sutta/mn/mn1.html': 0}
 
-        should_not = should_not_process_file(
+        should = should_process_file(
             data_dir=base_path,
             files_to_process=files_to_process,
             force=False,
             html_file=html_file)
 
-        assert not should_not
+        assert should

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -134,22 +134,6 @@ class TestTextInfoModel:
                 files_to_process=files_to_process
             )
 
-    @pytest.mark.parametrize(
-        "html,author_long_name",
-        [
-            ("<html><meta name='author' content='Bhikkhu Bodhi'></html>", 'Bhikkhu Bodhi'),
-            ("<html><meta author='Bhikkhu Bodhi'></html>", 'Bhikkhu Bodhi'),
-            ("<html></html>", None),
-        ]
-    )
-    def test_extracts_author_long_name_from_html(
-            self, text_info, base_path, language_path, sutta_path,
-            files_to_process, html, author_long_name
-    ):
-        add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
-        assert text_info.added_documents[0]['author'] == author_long_name
-
     def test_logs_missing_authors_long_name(
             self, text_info, sutta_path, language_path, base_path, files_to_process, caplog
     ):
@@ -191,17 +175,6 @@ class TestTextInfoModel:
         add_html_file(sutta_path, html)
         text_info.process_lang_dir(language_path, base_path, files_to_process)
         assert text_info.added_documents[0]['path'] == path
-
-    def test_extracts_publication_date(self, text_info, base_path, language_path, sutta_path, files_to_process):
-        html = """
-        <html>
-        <head><meta author='Bhikkhu Bodhi'></head>
-        <body><span class='publication-date'>1962</span></body>
-        </html>
-        """
-        add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
-        assert text_info.added_documents[0]['publication_date'] == '1962'
 
     def test_missing_publication_date_is_none(self, text_info, base_path, language_path, sutta_path, files_to_process):
         html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -157,7 +157,7 @@ class TestTextInfoModel:
         add_html_file(sutta_path, html)
         text_info.process_lang_dir(language_path, base_path, files_to_process)
         assert caplog.records[0].levelno == logging.CRITICAL
-        assert caplog.records[0].message == f"Author not found: {str(sutta_path)}"
+        assert caplog.records[0].message == f"Could not find author in file: {str(sutta_path)}"
 
     def test_retrieves_author_short_name(self, text_info, base_path, language_path, sutta_path, files_to_process):
         html = """<html><head><meta author='Bhikkhu Bodhi'></head></html>"""

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from data_loader.textdata import TextInfoModel
+from data_loader.textdata import TextInfoModel, should_not_process_file
 
 
 class TextInfoModelSpy(TextInfoModel):
@@ -297,3 +297,19 @@ class TestTextInfoModel:
                       for document in text_info.added_documents]
 
         assert file_names == ['mn1.html', 'mn2.html']
+
+
+class TestShouldNotProcessFile:
+    def test_single_file_no_force(self, base_path):
+        html_file = Path(base_path / 'html_text/en/pli/sutta/mn/mn1.html')
+        add_html_file(html_file, "<html/>")
+
+        files_to_process = {'html_text/en/pli/sutta/mn/mn1.html': 0}
+
+        should_not = should_not_process_file(
+            data_dir=base_path,
+            files_to_process=files_to_process,
+            force=False,
+            html_file=html_file)
+
+        assert not should_not

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -109,30 +109,18 @@ class TestTextInfoModel:
 
     def test_file_not_in_files_to_process_does_not_add_text_info(self, text_info, base_path, language_path, sutta_path):
         add_html_file(sutta_path, "<html><meta name='author' content='Bhikkhu Bodhi'></html>")
-        text_info.process_lang_dir(
-            lang_dir=language_path,
-            data_dir=base_path,
-            files_to_process={}
-        )
+        text_info.process_lang_dir(lang_dir=language_path, data_dir=base_path, files_to_process={})
         assert not text_info.added_documents
 
     def test_type_error_raised_when_files_to_process_is_none(self, text_info, base_path, language_path, sutta_path):
         add_html_file(sutta_path, "<html><meta name='author' content='Bhikkhu Bodhi'></html>")
         with pytest.raises(TypeError):
-            text_info.process_lang_dir(
-                lang_dir=language_path,
-                data_dir=base_path,
-                files_to_process=None
-            )
+            text_info.process_lang_dir(lang_dir=language_path, data_dir=base_path, files_to_process=None)
 
     def test_type_error_when_data_dir_is_none(self, text_info, language_path, sutta_path, files_to_process):
         add_html_file(sutta_path, "<html><meta name='author' content='Bhikkhu Bodhi'></html>")
         with pytest.raises(TypeError):
-            text_info.process_lang_dir(
-                lang_dir=language_path,
-                data_dir=None,
-                files_to_process=files_to_process
-            )
+            text_info.process_lang_dir(lang_dir=language_path, data_dir=None, files_to_process=files_to_process)
 
     def test_logs_missing_authors_long_name(
             self, text_info, sutta_path, language_path, base_path, files_to_process, caplog
@@ -275,29 +263,6 @@ class TestTextInfoModel:
 
         assert file_names == ['mn1.html', 'mn3.html']
 
-    def test_force_flag_causes_all_files_to_be_added(self, text_info, base_path):
-        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
-
-        paths = [
-            Path('html_text/en/pli/sutta/mn/mn1.html'),
-            Path('html_text/en/pli/sutta/mn/mn2.html'),
-        ]
-
-        for path in paths:
-            add_html_file(base_path / path, html)
-
-        files_to_process = {
-            'html_text/en/pli/sutta/mn/mn1.html': 0,
-        }
-
-        language_path = base_path / 'html_text/en'
-        text_info.process_lang_dir(language_path, base_path, files_to_process, force=True)
-
-        file_names = [Path(document['file_path']).name
-                      for document in text_info.added_documents]
-
-        assert file_names == ['mn1.html', 'mn2.html']
-
 
 class TestShouldProcessFile:
     def test_file_should_be_processed_when_in_files_to_process(self, base_path):
@@ -305,19 +270,11 @@ class TestShouldProcessFile:
         absolute_path = base_path / relative_path
         absolute_path.touch()
         files_to_process = {'abc.html' : 0}
-        assert should_process_file(base_path, files_to_process, False, absolute_path)
+        assert should_process_file(base_path, files_to_process, absolute_path)
 
     def test_file_should_not_be_processed_when_not_in_files_to_process(self, base_path):
         relative_path = Path('abc.html')
         absolute_path = base_path / relative_path
         absolute_path.touch()
         files_to_process = {'xyz.html' : 0,}
-        assert not should_process_file(base_path, files_to_process, False, absolute_path)
-
-    def test_file_should_be_processed_when_forced(self, base_path):
-        relative_path = Path('abc.html')
-        absolute_path = base_path / relative_path
-        absolute_path.touch()
-        files_to_process = {'xyz.html' : 0,}
-        assert should_process_file(base_path, files_to_process, True, absolute_path)
-
+        assert not should_process_file(base_path, files_to_process, absolute_path)

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -176,45 +176,6 @@ class TestTextInfoModel:
         text_info.process_lang_dir(language_path, base_path, files_to_process)
         assert text_info.added_documents[0]['path'] == path
 
-    def test_extracts_english_title(self, text_info, base_path, language_path, sutta_path, files_to_process):
-        html = """
-        <html>
-        <head><meta author='Bhikkhu Bodhi'></head>
-        <body><header><h1>1. The Root of All Things</h1></header></body>
-        </html>
-        """
-        add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
-        assert text_info.added_documents[0]['name'] == 'The Root of All Things'
-
-    def test_extracts_chinese_title(self, text_info, base_path, language_path, sutta_path, files_to_process):
-        html = """
-        <html>
-        <head><meta name='author' content='Taishō Tripiṭaka'></head>
-        <body><header><h1><span class='t-headname'>解脫戒經</span></h1></header></body>
-        </html>
-        """
-        add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
-        assert text_info.added_documents[0]['name'] == '解脫戒經'
-
-    def test_extracts_chinese_mirrored_title(self, text_info, base_path):
-        sutta_relative = 'html_text/lzh/sutta/ma/ma43.html'
-        sutta_path = base_path / sutta_relative
-        language_path = base_path / 'html_text/lzh/'
-        files_to_process = {str(sutta_relative): 0}
-
-        html = ("<html><head><meta name='author' content='Taishō Tripiṭaka'></head><body><header>"
-                "<h1 class='mirror-row'>"
-                "<span class='mirror-left latin'>43. No Need for Thought</span>"
-                "<span class='mirror-right'>（四三）不思經</span>"
-                "</h1></header></body></html>")
-
-        add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
-
-        assert text_info.added_documents[0]['name'] == '（四三）不思經 (43. No Need for Thought)'
-
     def test_logs_missing_title_when_there_is_no_header_tag(
             self, text_info, sutta_path, language_path, base_path, files_to_process, caplog
     ):
@@ -250,21 +211,6 @@ class TestTextInfoModel:
         add_html_file(sutta_path, html)
         text_info.process_lang_dir(language_path, base_path, files_to_process)
         assert not caplog.records
-
-    def test_extracts_chinese_volpage(self, text_info, base_path):
-        sutta_relative = 'html_text/lzh/sutta/ma/ma43.html'
-        sutta_path = base_path / sutta_relative
-        language_path = base_path / 'html_text/lzh/'
-        files_to_process = {str(sutta_relative): 0}
-
-        html = ("<html><head><meta name='author' content='Taishō Tripiṭaka'></head><body><header>"
-                "<a class='ref t' id='t0485b21' href='#t0485b21'>T 0485b21</a>"
-                "</h1></header></body></html>")
-
-        add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
-
-        assert text_info.added_documents[0]['volpage'] == 'T 0485b21'
 
     def test_volpage_none_when_legacy_translation(
             self, text_info, base_path, language_path, sutta_path, files_to_process

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -212,15 +212,6 @@ class TestTextInfoModel:
         text_info.process_lang_dir(language_path, base_path, files_to_process)
         assert not caplog.records
 
-    def test_volpage_none_when_legacy_translation(
-            self, text_info, base_path, language_path, sutta_path, files_to_process
-    ):
-        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
-        add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
-
-        assert text_info.added_documents[0]['volpage'] is None
-
     def test_sets_file_path(
             self, text_info, base_path, language_path, sutta_path, files_to_process
     ):

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -299,17 +299,25 @@ class TestTextInfoModel:
         assert file_names == ['mn1.html', 'mn2.html']
 
 
-class TestShouldNotProcessFile:
-    def test_single_file_no_force(self, base_path):
-        html_file = Path(base_path / 'html_text/en/pli/sutta/mn/mn1.html')
-        add_html_file(html_file, "<html/>")
+class TestShouldProcessFile:
+    def test_file_should_be_processed_when_in_files_to_process(self, base_path):
+        relative_path = Path('abc.html')
+        absolute_path = base_path / relative_path
+        absolute_path.touch()
+        files_to_process = {'abc.html' : 0}
+        assert should_process_file(base_path, files_to_process, False, absolute_path)
 
-        files_to_process = {'html_text/en/pli/sutta/mn/mn1.html': 0}
+    def test_file_should_not_be_processed_when_not_in_files_to_process(self, base_path):
+        relative_path = Path('abc.html')
+        absolute_path = base_path / relative_path
+        absolute_path.touch()
+        files_to_process = {'xyz.html' : 0,}
+        assert not should_process_file(base_path, files_to_process, False, absolute_path)
 
-        should = should_process_file(
-            data_dir=base_path,
-            files_to_process=files_to_process,
-            force=False,
-            html_file=html_file)
+    def test_file_should_be_processed_when_forced(self, base_path):
+        relative_path = Path('abc.html')
+        absolute_path = base_path / relative_path
+        absolute_path.touch()
+        files_to_process = {'xyz.html' : 0,}
+        assert should_process_file(base_path, files_to_process, True, absolute_path)
 
-        assert should

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -153,7 +153,7 @@ class TestTextInfoModel:
     def test_logs_missing_authors_long_name(
             self, text_info, sutta_path, language_path, base_path, files_to_process, caplog
     ):
-        html = "<html></html>"
+        html = "<html><body><header><h1></h1></header></body></html>"
         add_html_file(sutta_path, html)
         text_info.process_lang_dir(language_path, base_path, files_to_process)
         assert caplog.records[0].levelno == logging.CRITICAL

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -19,27 +19,23 @@ class TestExtractDetails:
         assert details.authors_long_name is None
 
     def test_extracts_title(self):
-        html = "<html><body><header><h1>Don't Think</h1></header></body></html>"
+        html = "<html><body><header><h1>1. The Root of All Things</h1></header></body></html>"
         details = extract_details(html)
-        assert details.title == "Don't Think"
+        assert details.title == 'The Root of All Things'
 
     def test_extracts_chinese_title(self):
-        html = ("<html><body><header>"
-                "<h1 class='mirror-row'>"
+        html = ("<html><body><header><h1 class='mirror-row'>"
                 "<span class='mirror-left latin'>43. No Need for Thought</span>"
                 "<span class='mirror-right'>（四三）不思經</span>"
-                "</h1>"
-                "</header></body></html>")
+                "</h1></header></body></html>")
 
         details = extract_details(html, is_chinese_root=True)
 
         assert details.title == '（四三）不思經 (43. No Need for Thought)'
 
     def test_chinese_title_only_has_right_hand_side(self):
-        html = ("<html><body><header>"
-                "<h1 class='mirror-row'>"
-                "<span class='mirror-right'>（四三）不思經</span>"
-                "</h1>"
+        html = ("<html><body><header><h1 class='mirror-row'>"
+                "<span class='mirror-right'>（四三）不思經</span></h1>"
                 "</header></body></html>")
 
         details = extract_details(html, is_chinese_root=True)
@@ -47,11 +43,9 @@ class TestExtractDetails:
         assert details.title == '（四三）不思經'
 
     def test_chinese_title_only_has_left_hand_side(self):
-        html = ("<html><body><header>"
-                "<h1 class='mirror-row'>"
+        html = ("<html><body><header><h1 class='mirror-row'>"
                 "<span class='mirror-left latin'>43. No Need for Thought</span>"
-                "</h1>"
-                "</header></body></html>")
+                "</h1></header></body></html>")
 
         details = extract_details(html, is_chinese_root=True)
 

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -82,7 +82,7 @@ class TestExtractDetails:
         assert details.publication_date is None
 
     def test_extracts_volpage_from_chinese_root(self):
-        html = ("<html><head><meta name='author' content='Taishō Tripiṭaka'></head><body><header>"
+        html = ("<html></head><body><header><h1>"
                 "<a class='ref t' id='t0485b21' href='#t0485b21'>T 0485b21</a>"
                 "</h1></header></body></html>")
 
@@ -90,7 +90,7 @@ class TestExtractDetails:
         assert details.volume_page == 'T 0485b21'
 
     def test_volpage_is_none_when_not_chinese_root(self):
-        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
+        html = "<html/>"
         details = extract_details(html)
         assert details.volume_page is None
 

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -23,6 +23,17 @@ class TestExtractDetails:
         details = extract_details(html)
         assert details.title == "Don't Think"
 
+    def test_extracts_chinese_title(self):
+        html = ("<html><head><meta name='author' content='Taishō Tripiṭaka'></head><body><header>"
+                "<h1 class='mirror-row'>"
+                "<span class='mirror-left latin'>43. No Need for Thought</span>"
+                "<span class='mirror-right'>（四三）不思經</span>"
+                "</h1></header></body></html>")
+
+        details = extract_details(html, is_chinese_root=True)
+
+        assert details.title == '（四三）不思經 (43. No Need for Thought)'
+
     def test_title_is_empty_due_to_regex(self):
         html = "<html><body><header><h1>11.358–405</h1></header></body></html>"
         details = extract_details(html)

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -35,6 +35,28 @@ class TestExtractDetails:
 
         assert details.title == '（四三）不思經 (43. No Need for Thought)'
 
+    def test_chinese_title_only_has_right_hand_side(self):
+        html = ("<html><body><header>"
+                "<h1 class='mirror-row'>"
+                "<span class='mirror-right'>（四三）不思經</span>"
+                "</h1>"
+                "</header></body></html>")
+
+        details = extract_details(html, is_chinese_root=True)
+
+        assert details.title == '（四三）不思經'
+
+    def test_chinese_title_only_has_left_hand_side(self):
+        html = ("<html><body><header>"
+                "<h1 class='mirror-row'>"
+                "<span class='mirror-left latin'>43. No Need for Thought</span>"
+                "</h1>"
+                "</header></body></html>")
+
+        details = extract_details(html, is_chinese_root=True)
+
+        assert details.title == 'No Need for Thought'
+
     def test_title_is_empty_due_to_regex(self):
         html = "<html><body><header><h1>11.358–405</h1></header></body></html>"
         details = extract_details(html)

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -5,42 +5,42 @@ from data_loader.unsegmented_texts import extract_details, find_title_tag
 class TestExtractDetails:
     def test_extracts_authors_long_name_from_content_attribute(self):
         html = "<html><meta name='author' content='Bhikkhu Bodhi'></html>"
-        details = extract_details(html, language='en')
+        details = extract_details(html)
         assert details.authors_long_name == 'Bhikkhu Bodhi'
 
     def test_extracts_authors_long_name_from_author_attribute(self):
         html = "<html><meta author='Bhikkhu Bodhi'></html>"
-        details = extract_details(html, language='en')
+        details = extract_details(html)
         assert details.authors_long_name == 'Bhikkhu Bodhi'
 
     def test_authors_long_name_is_none_when_missing(self):
         html = "<html></html>"
-        details = extract_details(html, language='en')
+        details = extract_details(html)
         assert details.authors_long_name is None
 
     def test_extracts_title(self):
         html = "<html><body><header><h1>Don't Think</h1></header></body></html>"
-        details = extract_details(html, language='en')
+        details = extract_details(html)
         assert details.title == "Don't Think"
 
     def test_title_is_empty_due_to_regex(self):
         html = "<html><body><header><h1>11.358–405</h1></header></body></html>"
-        details = extract_details(html, language='en')
+        details = extract_details(html)
         assert details.title == ''
 
     def test_has_title_tags_true_when_present(self):
         html = '<html><header><h1>1. The Root of All Things</h1></header></html>'
-        details = extract_details(html, language='en')
+        details = extract_details(html)
         assert details.has_title_tags is True
 
     def test_has_title_tags_false_if_h1_tag_missing(self):
         html = "<html><body><header></header><body></html>"
-        details = extract_details(html, language='en')
+        details = extract_details(html)
         assert details.has_title_tags is False
 
     def test_has_title_tags_false_if_header_tag_missing(self):
         html = "<html><body><body></html>"
-        details = extract_details(html, language='en')
+        details = extract_details(html)
         assert details.has_title_tags is False
 
     def test_extracts_publication_date(self):
@@ -49,7 +49,7 @@ class TestExtractDetails:
                 "<body><span class='publication-date'>1962</span></body>"
                 "</html>")
 
-        details = extract_details(html, language='en')
+        details = extract_details(html)
         assert details.publication_date == '1962'
 
     def test_extracts_volpage_from_chinese_root(self):
@@ -62,7 +62,7 @@ class TestExtractDetails:
 
     def test_volpage_is_none_when_not_chinese_root(self):
         html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
-        details = extract_details(html, language='en')
+        details = extract_details(html)
         assert details.volume_page is None
 
 

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -78,13 +78,14 @@ class TestExtractDetails:
         assert details.has_title_tags is False
 
     def test_extracts_publication_date(self):
-        html = ("<html>"
-                "<head><meta author='Bhikkhu Bodhi'></head>"
-                "<body><span class='publication-date'>1962</span></body>"
-                "</html>")
-
+        html = "<html><body><span class='publication-date'>1962</span></body></html>"
         details = extract_details(html)
         assert details.publication_date == '1962'
+
+    def test_publication_date_is_none_when_missing(self):
+        html = '<html/>'
+        details = extract_details(html)
+        assert details.publication_date is None
 
     def test_extracts_volpage_from_chinese_root(self):
         html = ("<html><head><meta name='author' content='Taishō Tripiṭaka'></head><body><header>"

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -24,11 +24,12 @@ class TestExtractDetails:
         assert details.title == "Don't Think"
 
     def test_extracts_chinese_title(self):
-        html = ("<html><head><meta name='author' content='Taishō Tripiṭaka'></head><body><header>"
+        html = ("<html><body><header>"
                 "<h1 class='mirror-row'>"
                 "<span class='mirror-left latin'>43. No Need for Thought</span>"
                 "<span class='mirror-right'>（四三）不思經</span>"
-                "</h1></header></body></html>")
+                "</h1>"
+                "</header></body></html>")
 
         details = extract_details(html, is_chinese_root=True)
 

--- a/server/server/data_loader/tests/test_unsegmented_texts.py
+++ b/server/server/data_loader/tests/test_unsegmented_texts.py
@@ -57,7 +57,7 @@ class TestExtractDetails:
                 "<a class='ref t' id='t0485b21' href='#t0485b21'>T 0485b21</a>"
                 "</h1></header></body></html>")
 
-        details = extract_details(html, language='lzh')
+        details = extract_details(html, is_chinese_root=True)
         assert details.volume_page == 'T 0485b21'
 
     def test_volpage_is_none_when_not_chinese_root(self):

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -138,28 +138,6 @@ class ArangoTextInfoModel(TextInfoModel):
             self.db['html_text'].import_bulk_logged(self.queue)
             self.queue.clear()
 
-    def update_code_points(self, lang_uid: str, unicode_points: dict[str, set[str]], force: bool = False) -> None:
-        keys = ('normal', 'bold', 'italic')
-        try:
-            existing = self.db['unicode_points'].get(lang_uid)
-            if existing and not force:
-                for key in keys:
-                    unicode_points[key].update(existing.get(key, []))
-
-            doc = {key: ''.join(sorted(set(unicode_points[key]))) for key in keys}
-            doc['_key'] = lang_uid
-        except Exception as e:
-            print(unicode_points)
-            raise e
-
-        if existing or force:
-            try:
-                self.db['unicode_points'].replace(doc)
-            except DocumentReplaceError:
-                self.db['unicode_points'].insert(doc)
-        else:
-            self.db['unicode_points'].insert(doc)
-
     def __enter__(self):
         return self
 

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from arango.exceptions import DocumentReplaceError
 
 from data_loader import util
-from data_loader.unsegmented_texts import extract_details
+from data_loader.unsegmented_texts import extract_details, TextDetails
 
 logger = logging.getLogger(__name__)
 
@@ -77,15 +77,14 @@ class TextInfoModel:
             "uid": uid,
             "lang": lang_uid,
             "path": path,
-            "name": text_details.title,
             "author": author_long_name,
             "author_short": author_short,
             "author_uid": author_uid,
-            "publication_date": text_details.publication_date,
-            "volpage": text_details.volume_page,
             "mtime": self.last_modified(html_file),
             "file_path": str(html_file.resolve()),
         }
+
+        add_text_details(document, text_details)
 
         return document
 
@@ -103,6 +102,12 @@ class TextInfoModel:
             f for f in all_files if f.stem != 'metadata'
         ]
         return files
+
+
+def add_text_details(document: dict, details: TextDetails) -> None:
+    document['name'] = details.title
+    document['publication_date'] = details.publication_date
+    document['volpage'] = details.volume_page
 
 
 class ArangoTextInfoModel(TextInfoModel):

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -30,12 +30,10 @@ class TextInfoModel:
         files = self._files_for_language(lang_dir)
 
         for html_file in files:
-            if not should_process_file(data_dir, files_to_process, force, html_file):
-                continue
-
-            logger.info('Adding file: {!s}'.format(html_file))
-            document = self.create_document(html_file, lang_uid)
-            self.add_document(document)
+            if should_process_file(data_dir, files_to_process, force, html_file):
+                logger.info('Adding file: {!s}'.format(html_file))
+                document = self.create_document(html_file, lang_uid)
+                self.add_document(document)
 
     def create_document(self, html_file, lang_uid):
         uid = html_file.stem
@@ -88,8 +86,9 @@ class TextInfoModel:
 
 
 def should_process_file(data_dir, files_to_process, force, html_file):
-    should_not = not force and str(html_file.relative_to(data_dir)) not in files_to_process
-    return not should_not
+    if force:
+        return True
+    return str(html_file.relative_to(data_dir)) in files_to_process
 
 def log_missing_details(details: TextDetails, file_name: str) -> None:
     if not details.has_title_tags:

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -49,18 +49,15 @@ class TextInfoModel:
         with html_file.open('r', encoding='utf8') as f:
             html = f.read()
 
-        is_chinese_root = (lang_uid == 'lzh')
-        text_details = extract_details(html, is_chinese_root=is_chinese_root)
+        text_details = extract_details(html, is_chinese_root=(lang_uid == 'lzh'))
 
         if not text_details.has_title_tags:
             logger.error(f'Could not find title in file: {str(html_file)}')
 
-        author_long_name = text_details.authors_long_name
+        if not text_details.authors_long_name:
+            logging.critical(f'Could not find author in file: {str(html_file)}')
 
-        if not author_long_name:
-            logging.critical(f'Author not found: {str(html_file)}')
-
-        author_data = self.get_author_by_name(author_long_name, html_file)
+        author_data = self.get_author_by_name(text_details.authors_long_name, html_file)
 
         if author_data:
             author_uid = author_data['uid']
@@ -73,13 +70,11 @@ class TextInfoModel:
         else:
             path = f'{lang_uid}/{uid}'
 
-
-
         document = {
             "uid": uid,
             "lang": lang_uid,
             "path": path,
-            "author": author_long_name,
+            "author": text_details.authors_long_name,
             "author_short": author_short,
             "author_uid": author_uid,
             "mtime": self.last_modified(html_file),

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -52,6 +52,9 @@ class TextInfoModel:
         is_chinese_root = (lang_uid == 'lzh')
         text_details = extract_details(html, is_chinese_root=is_chinese_root)
 
+        if not text_details.has_title_tags:
+            logger.error(f'Could not find title in file: {str(html_file)}')
+
         author_long_name = text_details.authors_long_name
 
         if not author_long_name:
@@ -70,8 +73,7 @@ class TextInfoModel:
         else:
             path = f'{lang_uid}/{uid}'
 
-        if not text_details.has_title_tags:
-            logger.error(f'Could not find title in file: {str(html_file)}')
+
 
         document = {
             "uid": uid,

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -30,7 +30,7 @@ class TextInfoModel:
         files = self._files_for_language(lang_dir)
 
         for html_file in files:
-            if should_not_process_file(data_dir, files_to_process, force, html_file):
+            if not should_process_file(data_dir, files_to_process, force, html_file):
                 continue
 
             logger.info('Adding file: {!s}'.format(html_file))
@@ -87,8 +87,9 @@ class TextInfoModel:
         return files
 
 
-def should_not_process_file(data_dir, files_to_process, force, html_file):
-    return not force and str(html_file.relative_to(data_dir)) not in files_to_process
+def should_process_file(data_dir, files_to_process, force, html_file):
+    should_not = not force and str(html_file.relative_to(data_dir)) not in files_to_process
+    return not should_not
 
 def log_missing_details(details: TextDetails, file_name: str) -> None:
     if not details.has_title_tags:

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -50,12 +50,7 @@ class TextInfoModel:
             html = f.read()
 
         text_details = extract_details(html, is_chinese_root=(lang_uid == 'lzh'))
-
-        if not text_details.has_title_tags:
-            logger.error(f'Could not find title in file: {str(html_file)}')
-
-        if not text_details.authors_long_name:
-            logging.critical(f'Could not find author in file: {str(html_file)}')
+        log_missing_details(text_details, str(html_file))
 
         author_data = self.get_author_by_name(text_details.authors_long_name, html_file)
 
@@ -99,6 +94,13 @@ class TextInfoModel:
             f for f in all_files if f.stem != 'metadata'
         ]
         return files
+
+
+def log_missing_details(details: TextDetails, file_name: str) -> None:
+    if not details.has_title_tags:
+        logger.error(f'Could not find title in file: {file_name}')
+    if not details.authors_long_name:
+        logging.critical(f'Could not find author in file: {file_name}')
 
 
 def add_text_details(document: dict, details: TextDetails) -> None:

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -49,7 +49,8 @@ class TextInfoModel:
         with html_file.open('r', encoding='utf8') as f:
             html = f.read()
 
-        text_details = extract_details(html, lang_uid, is_chinese_root=(lang_uid == 'lzh'))
+        is_chinese_root = (lang_uid == 'lzh')
+        text_details = extract_details(html, is_chinese_root=is_chinese_root)
 
         author_long_name = text_details.authors_long_name
 

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -30,18 +30,12 @@ class TextInfoModel:
         files = self._files_for_language(lang_dir)
 
         for html_file in files:
-            try:
-                if should_not_process_file(data_dir, files_to_process, force, html_file):
-                    continue
+            if should_not_process_file(data_dir, files_to_process, force, html_file):
+                continue
 
-                logger.info('Adding file: {!s}'.format(html_file))
-                document = self.create_document(html_file, lang_uid)
-
-                self.add_document(document)
-
-            except Exception as e:
-                print('An exception occurred: {!s}'.format(html_file))
-                raise
+            logger.info('Adding file: {!s}'.format(html_file))
+            document = self.create_document(html_file, lang_uid)
+            self.add_document(document)
 
     def create_document(self, html_file, lang_uid):
         uid = html_file.stem

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -31,7 +31,7 @@ class TextInfoModel:
 
         for html_file in files:
             try:
-                if should_process_file(data_dir, files_to_process, force, html_file):
+                if should_not_process_file(data_dir, files_to_process, force, html_file):
                     continue
 
                 logger.info('Adding file: {!s}'.format(html_file))
@@ -93,7 +93,7 @@ class TextInfoModel:
         return files
 
 
-def should_process_file(data_dir, files_to_process, force, html_file):
+def should_not_process_file(data_dir, files_to_process, force, html_file):
     return not force and str(html_file.relative_to(data_dir)) not in files_to_process
 
 def log_missing_details(details: TextDetails, file_name: str) -> None:

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -31,7 +31,7 @@ class TextInfoModel:
 
         for html_file in files:
             try:
-                if self._should_process_file(data_dir, files_to_process, force, html_file):
+                if should_process_file(data_dir, files_to_process, force, html_file):
                     continue
 
                 logger.info('Adding file: {!s}'.format(html_file))
@@ -83,9 +83,6 @@ class TextInfoModel:
     def last_modified(self, html_file):
         return html_file.stat().st_mtime
 
-    def _should_process_file(self, data_dir, files_to_process, force, html_file):
-        return not force and str(html_file.relative_to(data_dir)) not in files_to_process
-
     def _files_for_language(self, lang_dir):
         all_files = sorted(
             lang_dir.glob('**/*.html'), key=lambda f: util.numericsortkey(f.stem)
@@ -95,6 +92,9 @@ class TextInfoModel:
         ]
         return files
 
+
+def should_process_file(data_dir, files_to_process, force, html_file):
+    return not force and str(html_file.relative_to(data_dir)) not in files_to_process
 
 def log_missing_details(details: TextDetails, file_name: str) -> None:
     if not details.has_title_tags:

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -19,18 +19,13 @@ class TextInfoModel:
     def add_document(self, doc):
         raise NotImplementedError
 
-    def process_lang_dir(self,
-            lang_dir: Path,
-            data_dir: Path = None,
-            files_to_process: dict[str, int] | None = None,
-            force: bool = False
-    ):
+    def process_lang_dir(self, lang_dir: Path, data_dir: Path = None, files_to_process: dict[str, int] | None = None):
         lang_uid = lang_dir.stem
 
         files = self._files_for_language(lang_dir)
 
         for html_file in files:
-            if should_process_file(data_dir, files_to_process, force, html_file):
+            if should_process_file(data_dir, files_to_process, html_file):
                 logger.info('Adding file: {!s}'.format(html_file))
                 document = self.create_document(html_file, lang_uid)
                 self.add_document(document)
@@ -85,9 +80,7 @@ class TextInfoModel:
         return files
 
 
-def should_process_file(data_dir, files_to_process, force, html_file):
-    if force:
-        return True
+def should_process_file(data_dir, files_to_process, html_file):
     return str(html_file.relative_to(data_dir)) in files_to_process
 
 def log_missing_details(details: TextDetails, file_name: str) -> None:

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -49,7 +49,7 @@ class TextInfoModel:
         with html_file.open('r', encoding='utf8') as f:
             html = f.read()
 
-        text_details = extract_details(html, lang_uid)
+        text_details = extract_details(html, lang_uid, is_chinese_root=(lang_uid == 'lzh'))
 
         author_long_name = text_details.authors_long_name
 

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -62,7 +62,10 @@ def extract_title(title_tag: HtHtmlElement | None, is_chinese_root: bool) -> str
         left_side = title_tag.select_one('.mirror-left')
         right_side = title_tag.select_one('.mirror-right')
         if left_side and right_side:
-            return right_side.text_content() + ' (' + left_side.text_content() + ')'
+            right_text = right_side.text_content()
+            left_text = left_side.text_content()
+            chinese_title = f'{right_text} ({left_text})'
+            return chinese_title
 
     return normalise_title(title_tag.text_content())
 

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -59,15 +59,25 @@ def extract_title(title_tag: HtHtmlElement | None, is_chinese_root: bool) -> str
         return ''
 
     if is_chinese_root:
-        left_side = title_tag.select_one('.mirror-left')
-        right_side = title_tag.select_one('.mirror-right')
-        if left_side and right_side:
-            right_text = right_side.text_content()
-            left_text = left_side.text_content()
-            mirrored_title = f'{right_text} ({left_text})'
-            return mirrored_title
+        title = extract_side_by_side_title(title_tag)
+
+        if title:
+            return title
 
     return normalise_title(title_tag.text_content())
+
+
+def extract_side_by_side_title(title_tag: HtHtmlElement) -> str | None:
+    left_side = title_tag.select_one('.mirror-left')
+    right_side = title_tag.select_one('.mirror-right')
+
+    if not (left_side and right_side):
+        return None
+
+    left_text = left_side.text_content()
+    right_text = right_side.text_content()
+
+    return f'{right_text} ({left_text})'
 
 
 def find_title_tag(root: HtHtmlElement) -> HtHtmlElement | None:

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -64,8 +64,8 @@ def extract_title(title_tag: HtHtmlElement | None, is_chinese_root: bool) -> str
         if left_side and right_side:
             right_text = right_side.text_content()
             left_text = left_side.text_content()
-            chinese_title = f'{right_text} ({left_text})'
-            return chinese_title
+            mirrored_title = f'{right_text} ({left_text})'
+            return mirrored_title
 
     return normalise_title(title_tag.text_content())
 

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -18,7 +18,7 @@ class TextDetails:
     volume_page: str | None
 
 
-def extract_details(html: str, language: str = 'en', is_chinese_root: bool = False) -> TextDetails:
+def extract_details(html: str, is_chinese_root: bool = False) -> TextDetails:
     root = sc_html.fromstring(html)
     title_tag = find_title_tag(root)
     title = extract_title(title_tag, is_chinese_root)
@@ -28,7 +28,7 @@ def extract_details(html: str, language: str = 'en', is_chinese_root: bool = Fal
         has_title_tags=bool(title_tag),
         authors_long_name=extract_authors_long_name(root),
         publication_date=extract_publication_date(root),
-        volume_page=extract_volpage(root, language)
+        volume_page=extract_volpage(root, is_chinese_root)
     )
 
 
@@ -85,8 +85,8 @@ def normalise_title(title: str) -> str:
     return regex.sub(r'[\d\.\{\} –-]*', '', title, 1)
 
 
-def extract_volpage(root, language: str) -> str | None:
-    if language == 'lzh':
+def extract_volpage(root: HtHtmlElement, is_chinese_root: bool) -> str | None:
+    if is_chinese_root:
         e = root.next_in_order()
         while e is not None:
             if e.tag == 'a' and e.select_one('.t'):

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -18,10 +18,10 @@ class TextDetails:
     volume_page: str | None
 
 
-def extract_details(html: str, language: str) -> TextDetails:
+def extract_details(html: str, language: str = 'en', is_chinese_root: bool = False) -> TextDetails:
     root = sc_html.fromstring(html)
     title_tag = find_title_tag(root)
-    title = extract_title(title_tag, language)
+    title = extract_title(title_tag, is_chinese_root)
 
     return TextDetails(
         title=title,
@@ -54,11 +54,11 @@ def extract_publication_date(root) -> str | None:
     return None
 
 
-def extract_title(title_tag: HtHtmlElement | None, language: str) -> str:
+def extract_title(title_tag: HtHtmlElement | None, is_chinese_root: bool) -> str:
     if title_tag is None:
         return ''
 
-    if language == 'lzh':
+    if is_chinese_root:
         left_side = title_tag.select_one('.mirror-left')
         right_side = title_tag.select_one('.mirror-right')
         if left_side and right_side:

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -59,9 +59,7 @@ def extract_title(title_tag: HtHtmlElement | None, is_chinese_root: bool) -> str
         return ''
 
     if is_chinese_root:
-        title = extract_side_by_side_title(title_tag)
-
-        if title:
+        if title := extract_side_by_side_title(title_tag):
             return title
 
     return normalise_title(title_tag.text_content())

--- a/server/server/data_loader/unsegmented_texts.py
+++ b/server/server/data_loader/unsegmented_texts.py
@@ -64,7 +64,7 @@ def extract_title(title_tag: HtHtmlElement | None, language: str) -> str:
         if left_side and right_side:
             return right_side.text_content() + ' (' + left_side.text_content() + ')'
 
-    return regex.sub(r'[\d\.\{\} –-]*', '', title_tag.text_content(), 1)
+    return normalise_title(title_tag.text_content())
 
 
 def find_title_tag(root: HtHtmlElement) -> HtHtmlElement | None:
@@ -78,6 +78,11 @@ def find_title_tag(root: HtHtmlElement) -> HtHtmlElement | None:
         return None
 
     return h1
+
+
+def normalise_title(title: str) -> str:
+    # This may return an empty string e.g. when given a title like "11.358–405"
+    return regex.sub(r'[\d\.\{\} –-]*', '', title, 1)
 
 
 def extract_volpage(root, language: str) -> str | None:


### PR DESCRIPTION
Sorry to combine these changes. There's quite a bit of refactoring here, but do take a look at the last commit.

There I've removed the forcing of updates as per issue #3463. This is a material change to how loading unsegmented texts works. It should be much faster, less than a second on my machine when there are no updates to process. We do need to check that any new changes to the unsegmented texts are indeed processed.