### PR TITLE
Reworked path handling in `load_html_texts()` and reduced coupling with ChangeTracker

### DIFF
--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -725,7 +725,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     )
 
     printer.print_stage("Loading html_text")
-    load_html_texts(change_tracker, data_dir, db, html_dir)
+    load_html_texts(change_tracker, db, html_dir)
 
     printer.print_stage('Make yellow brick road')
     make_yellow_brick_road(db)

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -36,7 +36,6 @@ from . import (
     currencies,
     dictionaries,
     paragraphs,
-    textdata,
     homepage,
     languages,
     order,
@@ -49,6 +48,7 @@ from . import (
 from .change_tracker import ChangeTracker
 from .generate_sitemap import generate_sitemap
 from .observability import StagePrinter
+from .textdata import load_html_texts
 from .util import json_load
 import re
 from data_loader.extra_info import process_extra_info_file
@@ -261,18 +261,6 @@ def load_map_data(additional_info_dir, db):
     ]
     db['map_data'].truncate()
     db.collection('map_data').import_bulk_logged(map_doc, wipe=True)
-
-
-def load_html_texts(change_tracker: ChangeTracker, data_dir: Path, db: Database, html_dir: Path):
-    print('Loading HTML texts')
-    with textdata.ArangoTextInfoModel(db=db) as tim:
-        for lang_dir in tqdm(html_dir.glob('*')):
-            if lang_dir.is_dir:
-                tim.process_lang_dir(
-                    lang_dir=lang_dir,
-                    data_dir=data_dir,
-                    files_to_process=change_tracker.changed_or_new
-                )
 
 
 def load_json_file(db, change_tracker, json_file):

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -267,9 +267,12 @@ def load_html_texts(change_tracker: ChangeTracker, data_dir: Path, db: Database,
     print('Loading HTML texts')
     with textdata.ArangoTextInfoModel(db=db) as tim:
         for lang_dir in tqdm(html_dir.glob('*')):
-            if not lang_dir.is_dir:
-                continue
-            tim.process_lang_dir(lang_dir=lang_dir, data_dir=data_dir, files_to_process=change_tracker.changed_or_new)
+            if lang_dir.is_dir:
+                tim.process_lang_dir(
+                    lang_dir=lang_dir,
+                    data_dir=data_dir,
+                    files_to_process=change_tracker.changed_or_new
+                )
 
 
 def load_json_file(db, change_tracker, json_file):

--- a/server/server/data_loader/change_tracker.py
+++ b/server/server/data_loader/change_tracker.py
@@ -1,7 +1,7 @@
 import gc
 import hashlib
 import inspect
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Callable
 
@@ -62,6 +62,11 @@ class ChangeTracker:
         if check_calling_function and self.is_function_changed(who_is_calling()):
             return True
         return any(self.is_file_new_or_changed(file, False) for file in files)
+
+    def changed_files(self, paths: Iterable[Path]) -> Iterator[Path]:
+        for path in paths:
+            if self.is_file_new_or_changed(path, check_calling_function=False):
+                yield path
 
     def is_any_function_changed(self, functions: Iterable[Callable]) -> bool:
         return any(self.is_function_changed(function) for function in functions)

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -1,13 +1,10 @@
 from pathlib import Path
 
 import pytest
-from arango.database import Database
 
 from common.arangodb import get_db, delete_db
 from common.utils import current_app
 from data_loader import arangoload
-from data_loader.arangoload import load_html_texts
-from data_loader.change_tracker import ChangeTracker
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -46,115 +43,3 @@ def test_do_entire_run(data_load_app):
         save_as_csv(printer.stages, "load-data-run.csv")
 
 
-class TestLoadHtmlTexts:
-    @pytest.fixture
-    def database(self):
-        app_ = current_app()
-        app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
-
-        with app_.app_context():
-            db = get_db()
-            db.collection('mtimes').truncate()
-            db.collection('html_text').truncate()
-            yield db
-
-    @pytest.fixture
-    def sc_data_dir(self, tmp_path) -> Path:
-        return tmp_path
-
-    @pytest.fixture
-    def html_dir(self, sc_data_dir) -> Path:
-        path = sc_data_dir / 'html_text'
-        path.mkdir()
-        return path
-
-    @pytest.fixture
-    def html(self) -> str:
-        return (
-        "<html>"
-        "<head>"
-        "<meta author='Bhikkhu Bodhi'>"
-        "</head>"
-        "<body>"
-        "<header><h1>1. The Root of All Things</h1></header>"
-        "<span class='publication-date'>2009</span>"
-        "</body>"
-        "</html>"
-    )
-
-    @pytest.fixture
-    def tracker(self, sc_data_dir, database):
-        return ChangeTracker(base_dir=sc_data_dir, db=database)
-
-    @pytest.mark.skip('Long running test.')
-    def test_load_from_repository(self, database):
-        sc_data_dir = Path('/opt/sc/sc-flask/sc-data/')
-        html_dir = Path('/opt/sc/sc-flask/sc-data/html_text')
-        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
-
-    def test_load_empty_html_dir(self, tracker, database, sc_data_dir, html_dir):
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
-        assert database.collection('html_text').count() == 0
-
-    def test_load_empty_language_dir(self, tracker, database, sc_data_dir, html_dir):
-        language_dir = html_dir / 'en'
-        language_dir.mkdir()
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
-        assert database.collection('html_text').count() == 0
-
-    def test_load_one_text(self, database, sc_data_dir, html_dir, html):
-        language_dir = html_dir / 'en'
-        language_dir.mkdir()
-
-        sutta_path = language_dir / 'mn1.html'
-        sutta_path.write_text(html)
-
-        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
-
-        assert database.collection('html_text').count() == 1
-
-    def test_skip_unmodified_text(self, database, sc_data_dir, html_dir, html):
-        language_dir = html_dir / 'en'
-        language_dir.mkdir()
-
-        sutta_path = language_dir / 'mn1.html'
-        sutta_path.write_text(html)
-
-        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
-        tracker.update_mtimes()
-        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
-
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
-
-        assert database.collection('html_text').count() == 0
-
-    def test_skip_files_not_in_language_subdirectories(self, database, sc_data_dir, html_dir, html):
-        skip_path = html_dir / 'skip_me.html'
-        skip_path.write_text(html)
-
-        language_dir = html_dir / 'en'
-        language_dir.mkdir()
-        ok_path = language_dir / 'mn1.html'
-        ok_path.write_text(html)
-
-        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
-
-        assert database.collection('html_text').count() == 1
-
-    def test_load_files_in_subdirectories(self, database, sc_data_dir, html_dir, html):
-        language_dir = html_dir / 'en'
-        language_dir.mkdir()
-
-        collection_dir = language_dir / 'mn'
-        collection_dir.mkdir()
-
-        sutta_path = collection_dir / 'mn1.html'
-        sutta_path.write_text(html)
-
-        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
-
-        assert database.collection('html_text').count() == 1

--- a/server/server/data_loader/tests/test_arangoload.py
+++ b/server/server/data_loader/tests/test_arangoload.py
@@ -1,10 +1,13 @@
 from pathlib import Path
 
 import pytest
+from arango.database import Database
 
 from common.arangodb import get_db, delete_db
 from common.utils import current_app
 from data_loader import arangoload
+from data_loader.arangoload import load_html_texts
+from data_loader.change_tracker import ChangeTracker
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -41,3 +44,117 @@ def test_do_entire_run(data_load_app):
         printer = arangoload.run(no_pull=False)
         assert len(printer.stages) == 51
         save_as_csv(printer.stages, "load-data-run.csv")
+
+
+class TestLoadHtmlTexts:
+    @pytest.fixture
+    def database(self):
+        app_ = current_app()
+        app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
+
+        with app_.app_context():
+            db = get_db()
+            db.collection('mtimes').truncate()
+            db.collection('html_text').truncate()
+            yield db
+
+    @pytest.fixture
+    def sc_data_dir(self, tmp_path) -> Path:
+        return tmp_path
+
+    @pytest.fixture
+    def html_dir(self, sc_data_dir) -> Path:
+        path = sc_data_dir / 'html_text'
+        path.mkdir()
+        return path
+
+    @pytest.fixture
+    def html(self) -> str:
+        return (
+        "<html>"
+        "<head>"
+        "<meta author='Bhikkhu Bodhi'>"
+        "</head>"
+        "<body>"
+        "<header><h1>1. The Root of All Things</h1></header>"
+        "<span class='publication-date'>2009</span>"
+        "</body>"
+        "</html>"
+    )
+
+    @pytest.fixture
+    def tracker(self, sc_data_dir, database):
+        return ChangeTracker(base_dir=sc_data_dir, db=database)
+
+    @pytest.mark.skip('Long running test.')
+    def test_load_from_repository(self, database):
+        sc_data_dir = Path('/opt/sc/sc-flask/sc-data/')
+        html_dir = Path('/opt/sc/sc-flask/sc-data/html_text')
+        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
+        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+
+    def test_load_empty_html_dir(self, tracker, database, sc_data_dir, html_dir):
+        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+        assert database.collection('html_text').count() == 0
+
+    def test_load_empty_language_dir(self, tracker, database, sc_data_dir, html_dir):
+        language_dir = html_dir / 'en'
+        language_dir.mkdir()
+        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+        assert database.collection('html_text').count() == 0
+
+    def test_load_one_text(self, database, sc_data_dir, html_dir, html):
+        language_dir = html_dir / 'en'
+        language_dir.mkdir()
+
+        sutta_path = language_dir / 'mn1.html'
+        sutta_path.write_text(html)
+
+        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
+        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+
+        assert database.collection('html_text').count() == 1
+
+    def test_skip_unmodified_text(self, database, sc_data_dir, html_dir, html):
+        language_dir = html_dir / 'en'
+        language_dir.mkdir()
+
+        sutta_path = language_dir / 'mn1.html'
+        sutta_path.write_text(html)
+
+        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
+        tracker.update_mtimes()
+        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
+
+        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+
+        assert database.collection('html_text').count() == 0
+
+    def test_skip_files_not_in_language_subdirectories(self, database, sc_data_dir, html_dir, html):
+        skip_path = html_dir / 'skip_me.html'
+        skip_path.write_text(html)
+
+        language_dir = html_dir / 'en'
+        language_dir.mkdir()
+        ok_path = language_dir / 'mn1.html'
+        ok_path.write_text(html)
+
+        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
+        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+
+        assert database.collection('html_text').count() == 1
+
+    def test_load_files_in_subdirectories(self, database, sc_data_dir, html_dir, html):
+        language_dir = html_dir / 'en'
+        language_dir.mkdir()
+
+        collection_dir = language_dir / 'mn'
+        collection_dir.mkdir()
+
+        sutta_path = collection_dir / 'mn1.html'
+        sutta_path.write_text(html)
+
+        tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
+        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+
+        assert database.collection('html_text').count() == 1

--- a/server/server/data_loader/tests/test_changetracker.py
+++ b/server/server/data_loader/tests/test_changetracker.py
@@ -1,4 +1,6 @@
-from data_loader.change_tracker import whoami, who_is_calling, function_source
+import common.utils
+from common import arangodb
+from data_loader.change_tracker import whoami, who_is_calling, function_source, ChangeTracker
 
 
 def test_whomai():
@@ -35,3 +37,62 @@ def test_function_source():
         pass
 
     assert function_source(bar) == '    def bar():\n        pass\n'
+
+class TestChangeTracker:
+    def test_new_file_is_changed(self, tmp_path):
+        app_ = common.utils.current_app()
+        app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
+
+        with app_.app_context():
+            db = arangodb.get_db()
+            db.collection('mtimes').truncate()
+
+            tracker = ChangeTracker(base_dir=tmp_path, db=db)
+            tracker.update_mtimes()
+
+            new_file = tmp_path / 'new_file.txt'
+            new_file.touch()
+
+            tracker = ChangeTracker(base_dir=tmp_path, db=db)
+
+            assert tracker.is_file_new_or_changed(path=new_file, check_calling_function=False)
+
+    def test_old_file_is_not_changed(self, tmp_path):
+        app_ = common.utils.current_app()
+        app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
+
+        with app_.app_context():
+            db = arangodb.get_db()
+            db.collection('mtimes').truncate()
+
+            new_file = tmp_path / 'new_file.txt'
+            new_file.touch()
+
+            tracker = ChangeTracker(base_dir=tmp_path, db=db)
+            tracker.update_mtimes()
+
+            tracker = ChangeTracker(base_dir=tmp_path, db=db)
+
+            assert not tracker.is_file_new_or_changed(path=new_file, check_calling_function=False)
+
+    def test_adding_file_to_mtimes_collection_makes_it_not_changed(self, tmp_path):
+        app_ = common.utils.current_app()
+        app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
+
+        with app_.app_context():
+            db = arangodb.get_db()
+            db.collection('mtimes').truncate()
+
+            new_file = tmp_path / 'new_file.txt'
+            new_file.touch()
+
+            mtimes_doc = {
+                '_key': 'new_file.txt',
+                'path': 'new_file.txt',
+                'mtime': new_file.stat().st_mtime_ns,
+                }
+
+            db.collection('mtimes').insert(mtimes_doc)
+
+            tracker = ChangeTracker(base_dir=tmp_path, db=db)
+            assert not tracker.is_file_new_or_changed(path=new_file, check_calling_function=False)

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from data_loader.textdata import TextInfoModel, should_process_file
+from data_loader.textdata import TextInfoModel, should_process_file, files_for_language
 
 
 class TextInfoModelSpy(TextInfoModel):
@@ -278,3 +278,15 @@ class TestShouldProcessFile:
         absolute_path.touch()
         files_to_process = {'xyz.html' : 0,}
         assert not should_process_file(base_path, files_to_process, absolute_path)
+
+
+class TestFilesForLanguage:
+    @pytest.fixture
+    def lang_dir(self, tmp_path) -> Path:
+        return tmp_path
+
+    def test_one_html_file(self, lang_dir):
+        html_file = lang_dir / 'abc.html'
+        html_file.touch()
+        files = files_for_language(lang_dir)
+        assert files[0] == html_file

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -1,10 +1,9 @@
 import logging
-from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
-from data_loader.textdata import TextInfoModel, should_process_file, files_for_language
+from data_loader.textdata import TextInfoModel, should_process_file
 
 
 class TextInfoModelSpy(TextInfoModel):
@@ -278,23 +277,3 @@ class TestShouldProcessFile:
         absolute_path.touch()
         files_to_process = {'xyz.html' : 0,}
         assert not should_process_file(base_path, files_to_process, absolute_path)
-
-
-class TestFilesForLanguage:
-    @pytest.fixture
-    def lang_dir(self, tmp_path) -> Path:
-        return tmp_path
-
-    def test_one_html_file(self, lang_dir):
-        html_file = lang_dir / 'abc.html'
-        html_file.touch()
-        files = files_for_language(lang_dir)
-        assert files == [html_file]
-
-    def test_metadata_is_after_normal_file(self, lang_dir):
-        html_file = lang_dir / 'abc.html'
-        html_file.touch()
-        metadata_file = lang_dir / 'metadata.html'
-        metadata_file.touch()
-        files = files_for_language(lang_dir)
-        assert files == [metadata_file, html_file]

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -6,7 +6,7 @@ import pytest
 from common.arangodb import get_db
 from common.utils import current_app
 from data_loader.change_tracker import ChangeTracker
-from data_loader.textdata import TextInfoModel, should_process_file, load_html_texts
+from data_loader.textdata import TextInfoModel, load_html_texts, language_directories, html_files
 
 
 class TextInfoModelSpy(TextInfoModel):
@@ -49,8 +49,7 @@ class TextInfoModelSpy(TextInfoModel):
 
 def add_html_file(path: Path, html: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open('w') as f:
-        path.write_text(html)
+    path.write_text(html)
 
 
 @pytest.fixture
@@ -94,49 +93,18 @@ def sutta_path(base_path, sutta_relative) -> Path:
     return base_path / sutta_relative
 
 
-@pytest.fixture
-def files_to_process(sutta_relative) -> dict[str, int]:
-    return {str(sutta_relative): 0}
-
-
 class TestTextInfoModel:
-    def test_empty_lang_dir_does_not_add_text_info(self, text_info, tmp_path):
-        text_info.process_lang_dir(lang_dir=tmp_path)
-        assert not text_info.added_documents
-
-    def test_lang_dir_with_empty_language_does_not_add_text_info(self, text_info, collection_path):
-        collection_path.mkdir(parents=True)
-        text_info.process_lang_dir(collection_path)
-        assert not text_info.added_documents
-
-    def test_file_not_in_files_to_process_does_not_add_text_info(self, text_info, base_path, language_path, sutta_path):
-        add_html_file(sutta_path, "<html><meta name='author' content='Bhikkhu Bodhi'></html>")
-        text_info.process_lang_dir(lang_dir=language_path, data_dir=base_path, files_to_process={})
-        assert not text_info.added_documents
-
-    def test_type_error_raised_when_files_to_process_is_none(self, text_info, base_path, language_path, sutta_path):
-        add_html_file(sutta_path, "<html><meta name='author' content='Bhikkhu Bodhi'></html>")
-        with pytest.raises(TypeError):
-            text_info.process_lang_dir(lang_dir=language_path, data_dir=base_path, files_to_process=None)
-
-    def test_type_error_when_data_dir_is_none(self, text_info, language_path, sutta_path, files_to_process):
-        add_html_file(sutta_path, "<html><meta name='author' content='Bhikkhu Bodhi'></html>")
-        with pytest.raises(TypeError):
-            text_info.process_lang_dir(lang_dir=language_path, data_dir=None, files_to_process=files_to_process)
-
-    def test_logs_missing_authors_long_name(
-            self, text_info, sutta_path, language_path, base_path, files_to_process, caplog
-    ):
+    def test_logs_missing_authors_long_name(self, text_info, sutta_path, caplog):
         html = "<html><body><header><h1></h1></header></body></html>"
         add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
+        text_info.load_language([sutta_path], 'en')
         assert caplog.records[0].levelno == logging.CRITICAL
         assert caplog.records[0].message == f"Could not find author in file: {str(sutta_path)}"
 
-    def test_retrieves_author_short_name(self, text_info, base_path, language_path, sutta_path, files_to_process):
+    def test_retrieves_author_short_name(self, text_info, sutta_path):
         html = """<html><head><meta author='Bhikkhu Bodhi'></head></html>"""
         add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
+        text_info.load_language([sutta_path], 'en')
 
     @pytest.mark.parametrize(
         "author,author_uid",
@@ -145,12 +113,10 @@ class TestTextInfoModel:
             ('No such author', None),
          ]
     )
-    def test_retrieves_author_uid(
-            self, text_info, base_path, language_path, sutta_path, files_to_process, author, author_uid
-    ):
+    def test_retrieves_author_uid(self, text_info, sutta_path, author, author_uid):
         html = f"<html><head><meta author='{author}'></head></html>"
         add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
+        text_info.load_language([sutta_path], 'en')
         assert text_info.added_documents[0]['author_uid'] == author_uid
 
     @pytest.mark.parametrize(
@@ -160,24 +126,20 @@ class TestTextInfoModel:
             ('No such author', 'en/mn1'),
         ]
     )
-    def test_generates_path(self, text_info, base_path, language_path, sutta_path, files_to_process, author, path):
+    def test_generates_path(self, text_info, sutta_path, author, path):
         html = f"<html><head><meta author='{author}'></head></html>"
         add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
+        text_info.load_language([sutta_path], 'en')
         assert text_info.added_documents[0]['path'] == path
 
-    def test_logs_missing_title_when_there_is_no_header_tag(
-            self, text_info, sutta_path, language_path, base_path, files_to_process, caplog
-    ):
+    def test_logs_missing_title_when_there_is_no_header_tag(self, text_info, sutta_path, caplog):
         html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
         add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
+        text_info.load_language([sutta_path], 'en')
         assert caplog.records[0].levelno == logging.ERROR
         assert caplog.records[0].message == f"Could not find title in file: {str(sutta_path)}"
 
-    def test_logs_missing_title_when_there_is_no_h1_tag(
-                self, text_info, sutta_path, language_path, base_path, files_to_process, caplog
-        ):
+    def test_logs_missing_title_when_there_is_no_h1_tag(self, text_info, sutta_path, caplog):
             html = (
                 "<html>"
                 "<head><meta author='Bhikkhu Bodhi'>"
@@ -186,12 +148,12 @@ class TestTextInfoModel:
                 "</html>"
             )
             add_html_file(sutta_path, html)
-            text_info.process_lang_dir(language_path, base_path, files_to_process)
+            text_info.load_language([sutta_path], 'en')
             assert caplog.records[0].levelno == logging.ERROR
             assert caplog.records[0].message == f"Could not find title in file: {str(sutta_path)}"
 
     def test_does_not_log_missing_title_when_it_is_an_empty_string(
-            self, text_info, sutta_path, language_path, base_path, files_to_process, caplog
+            self, text_info, sutta_path, caplog
     ):
         html = ("<html>"
                 "<head><meta author='Bhikkhu Bodhi'><head>"
@@ -199,24 +161,20 @@ class TestTextInfoModel:
                 "</html>")
 
         add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
+        text_info.load_language([sutta_path], 'en')
         assert not caplog.records
 
-    def test_sets_file_path(
-            self, text_info, base_path, language_path, sutta_path, files_to_process
-    ):
+    def test_sets_file_path(self, text_info, sutta_path):
         html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
         add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
+        text_info.load_language([sutta_path], 'en')
 
         assert text_info.added_documents[0]['file_path'] == str(sutta_path)
 
-    def test_sets_last_modified(
-            self, text_info, base_path, language_path, sutta_path, files_to_process
-    ):
+    def test_sets_last_modified(self, text_info, sutta_path):
         html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
         add_html_file(sutta_path, html)
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
+        text_info.load_language([sutta_path], 'en')
 
         assert text_info.added_documents[0]['mtime'] == sutta_path.stat().st_mtime
 
@@ -225,75 +183,32 @@ class TestTextInfoModel:
         html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
 
         paths = [
-            Path('html_text/en/pli/sutta/mn/mn1.html'),
-            Path('html_text/en/pli/sutta/mn/mn2.html'),
-            Path('html_text/en/pli/sutta/mn/mn3.html'),
+            base_path / Path('html_text/en/pli/sutta/mn/mn1.html'),
+            base_path / Path('html_text/en/pli/sutta/mn/mn2.html'),
+            base_path / Path('html_text/en/pli/sutta/mn/mn3.html'),
         ]
 
-        files_to_process = dict()
         for path in paths:
-            files_to_process[str(path)] = 0
-            add_html_file(base_path / path, html)
+            add_html_file(path, html)
 
-        language_path = base_path / 'html_text/en'
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
+        text_info.load_language(paths, 'en')
 
         assert len(text_info.added_documents) == 3
 
-    def test_files_not_in_files_to_process_are_skipped(self, text_info, base_path):
-        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
 
-        paths = [
-            Path('html_text/en/pli/sutta/mn/mn1.html'),
-            Path('html_text/en/pli/sutta/mn/mn2.html'),
-            Path('html_text/en/pli/sutta/mn/mn3.html'),
-        ]
+@pytest.fixture
+def database():
+    app_ = current_app()
+    app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
 
-        for path in paths:
-            add_html_file(base_path / path, html)
-
-        files_to_process = {
-            'html_text/en/pli/sutta/mn/mn1.html' : 0,
-            'html_text/en/pli/sutta/mn/mn3.html' : 0,
-        }
-
-        language_path = base_path / 'html_text/en'
-        text_info.process_lang_dir(language_path, base_path, files_to_process)
-
-        file_names = [Path(document['file_path']).name
-                 for document in text_info.added_documents]
-
-        assert sorted(file_names) == sorted(['mn1.html', 'mn3.html'])
-
-
-class TestShouldProcessFile:
-    def test_file_should_be_processed_when_in_files_to_process(self, base_path):
-        relative_path = Path('abc.html')
-        absolute_path = base_path / relative_path
-        absolute_path.touch()
-        files_to_process = {'abc.html' : 0}
-        assert should_process_file(base_path, files_to_process, absolute_path)
-
-    def test_file_should_not_be_processed_when_not_in_files_to_process(self, base_path):
-        relative_path = Path('abc.html')
-        absolute_path = base_path / relative_path
-        absolute_path.touch()
-        files_to_process = {'xyz.html' : 0,}
-        assert not should_process_file(base_path, files_to_process, absolute_path)
+    with app_.app_context():
+        db = get_db()
+        db.collection('mtimes').truncate()
+        db.collection('html_text').truncate()
+        yield db
 
 
 class TestLoadHtmlTexts:
-    @pytest.fixture
-    def database(self):
-        app_ = current_app()
-        app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
-
-        with app_.app_context():
-            db = get_db()
-            db.collection('mtimes').truncate()
-            db.collection('html_text').truncate()
-            yield db
-
     @pytest.fixture
     def sc_data_dir(self, tmp_path) -> Path:
         return tmp_path
@@ -327,16 +242,16 @@ class TestLoadHtmlTexts:
         sc_data_dir = Path('/opt/sc/sc-flask/sc-data/')
         html_dir = Path('/opt/sc/sc-flask/sc-data/html_text')
         tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+        load_html_texts(change_tracker=tracker, db=database, html_dir=html_dir)
 
     def test_load_empty_html_dir(self, tracker, database, sc_data_dir, html_dir):
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+        load_html_texts(change_tracker=tracker, db=database, html_dir=html_dir)
         assert database.collection('html_text').count() == 0
 
     def test_load_empty_language_dir(self, tracker, database, sc_data_dir, html_dir):
         language_dir = html_dir / 'en'
         language_dir.mkdir()
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+        load_html_texts(change_tracker=tracker, db=database, html_dir=html_dir)
         assert database.collection('html_text').count() == 0
 
     def test_load_one_text(self, database, sc_data_dir, html_dir, html):
@@ -347,7 +262,7 @@ class TestLoadHtmlTexts:
         sutta_path.write_text(html)
 
         tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+        load_html_texts(change_tracker=tracker, db=database, html_dir=html_dir)
 
         assert database.collection('html_text').count() == 1
 
@@ -362,7 +277,7 @@ class TestLoadHtmlTexts:
         tracker.update_mtimes()
         tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
 
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+        load_html_texts(change_tracker=tracker, db=database, html_dir=html_dir)
 
         assert database.collection('html_text').count() == 0
 
@@ -376,7 +291,7 @@ class TestLoadHtmlTexts:
         ok_path.write_text(html)
 
         tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+        load_html_texts(change_tracker=tracker, db=database, html_dir=html_dir)
 
         assert database.collection('html_text').count() == 1
 
@@ -391,6 +306,70 @@ class TestLoadHtmlTexts:
         sutta_path.write_text(html)
 
         tracker = ChangeTracker(base_dir=sc_data_dir, db=database)
-        load_html_texts(change_tracker=tracker, db=database, data_dir=sc_data_dir, html_dir=html_dir)
+        load_html_texts(change_tracker=tracker, db=database, html_dir=html_dir)
 
         assert database.collection('html_text').count() == 1
+
+
+class TestLanguageDirectories:
+    def test_empty_html_directory(self, tmp_path):
+        assert not language_directories(html_dir=tmp_path)
+
+    def test_with_language_directory(self, tmp_path):
+        directories = [
+            tmp_path / 'en',
+            tmp_path / 'lzh',
+        ]
+
+        for directory in directories:
+            directory.mkdir()
+
+        assert language_directories(html_dir=tmp_path) == directories
+
+    def test_only_return_directories(self, tmp_path):
+        directory = tmp_path / 'en'
+        directory.mkdir()
+        file = tmp_path / 'abc.txt'
+        file.touch()
+        assert language_directories(html_dir=tmp_path) == [directory]
+
+
+class TestHtmlFiles:
+    @pytest.fixture
+    def language_directory(self, tmp_path):
+        return tmp_path
+
+    def test_all_files_changed(self, language_directory, database):
+        files = [
+            language_directory / 'abc.html',
+            language_directory / 'def.html',
+            language_directory / 'hij.html',
+        ]
+
+        for file in files:
+            file.touch()
+
+        tracker = ChangeTracker(language_directory, database)
+
+        assert sorted(html_files(language_directory, tracker)) == files
+
+    def test_one_new_file(self, language_directory, database):
+        files = [
+            language_directory / 'abc.html',
+            language_directory / 'def.html',
+        ]
+
+        for file in files:
+            file.touch()
+
+        tracker = ChangeTracker(language_directory, database)
+        tracker.update_mtimes()
+
+        new_file = language_directory / 'hij.html'
+        new_file.touch()
+
+        tracker = ChangeTracker(language_directory, database)
+
+        files.append(new_file)
+
+        assert sorted(html_files(language_directory, tracker)) == [new_file]

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -261,7 +261,7 @@ class TestTextInfoModel:
         file_names = [Path(document['file_path']).name
                  for document in text_info.added_documents]
 
-        assert file_names == ['mn1.html', 'mn3.html']
+        assert sorted(file_names) == sorted(['mn1.html', 'mn3.html'])
 
 
 class TestShouldProcessFile:

--- a/server/server/data_loader/tests/test_textdata.py
+++ b/server/server/data_loader/tests/test_textdata.py
@@ -289,4 +289,12 @@ class TestFilesForLanguage:
         html_file = lang_dir / 'abc.html'
         html_file.touch()
         files = files_for_language(lang_dir)
-        assert files[0] == html_file
+        assert files == [html_file]
+
+    def test_metadata_is_after_normal_file(self, lang_dir):
+        html_file = lang_dir / 'abc.html'
+        html_file.touch()
+        metadata_file = lang_dir / 'metadata.html'
+        metadata_file.touch()
+        files = files_for_language(lang_dir)
+        assert files == [metadata_file, html_file]

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -31,7 +31,7 @@ class TextInfoModel:
                 self.add_document(document)
 
     def create_document(self, html_file, language_code):
-        uid = html_file.stem
+        sutta_uid = html_file.stem
 
         with html_file.open('r', encoding='utf8') as f:
             html = f.read()
@@ -48,12 +48,12 @@ class TextInfoModel:
             author_uid = None
             author_short = None
         if author_uid:
-            path = f'{language_code}/{uid}/{author_uid}'
+            path = f'{language_code}/{sutta_uid}/{author_uid}'
         else:
-            path = f'{language_code}/{uid}'
+            path = f'{language_code}/{sutta_uid}'
 
         document = {
-            "uid": uid,
+            "uid": sutta_uid,
             "lang": language_code,
             "path": path,
             "author": text_details.authors_long_name,

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -1,9 +1,6 @@
 import logging
 from pathlib import Path
 
-from arango.exceptions import DocumentReplaceError
-
-from data_loader import util
 from data_loader.unsegmented_texts import extract_details, TextDetails
 
 logger = logging.getLogger(__name__)
@@ -21,10 +18,9 @@ class TextInfoModel:
 
     def process_lang_dir(self, lang_dir: Path, data_dir: Path = None, files_to_process: dict[str, int] | None = None):
         language_code = lang_dir.stem
+        html_files = lang_dir.glob('**/*.html')
 
-        files = files_for_language(lang_dir)
-
-        for html_file in files:
+        for html_file in html_files:
             if should_process_file(data_dir, files_to_process, html_file):
                 logger.info('Adding file: {!s}'.format(html_file))
                 document = self.create_document(html_file, language_code)
@@ -69,14 +65,6 @@ class TextInfoModel:
 
     def last_modified(self, html_file):
         return html_file.stat().st_mtime
-
-
-def files_for_language(lang_dir: Path) -> list[Path]:
-    all_files = list(lang_dir.glob('**/*.html'))
-    files = [f for f in all_files if f.stem == 'metadata'] + [
-        f for f in all_files if f.stem != 'metadata'
-    ]
-    return files
 
 
 def should_process_file(data_dir, files_to_process, html_file):

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -71,7 +71,7 @@ class TextInfoModel:
         return html_file.stat().st_mtime
 
 
-def files_for_language(lang_dir: Path):
+def files_for_language(lang_dir: Path) -> list[Path]:
     all_files = sorted(
         lang_dir.glob('**/*.html'), key=lambda f: util.numericsortkey(f.stem)
     )

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -20,23 +20,23 @@ class TextInfoModel:
         raise NotImplementedError
 
     def process_lang_dir(self, lang_dir: Path, data_dir: Path = None, files_to_process: dict[str, int] | None = None):
-        lang_uid = lang_dir.stem
+        language_code = lang_dir.stem
 
         files = files_for_language(lang_dir)
 
         for html_file in files:
             if should_process_file(data_dir, files_to_process, html_file):
                 logger.info('Adding file: {!s}'.format(html_file))
-                document = self.create_document(html_file, lang_uid)
+                document = self.create_document(html_file, language_code)
                 self.add_document(document)
 
-    def create_document(self, html_file, lang_uid):
+    def create_document(self, html_file, language_code):
         uid = html_file.stem
 
         with html_file.open('r', encoding='utf8') as f:
             html = f.read()
 
-        text_details = extract_details(html, is_chinese_root=(lang_uid == 'lzh'))
+        text_details = extract_details(html, is_chinese_root=(language_code == 'lzh'))
         log_missing_details(text_details, str(html_file))
 
         author_data = self.get_author_by_name(text_details.authors_long_name, html_file)
@@ -48,13 +48,13 @@ class TextInfoModel:
             author_uid = None
             author_short = None
         if author_uid:
-            path = f'{lang_uid}/{uid}/{author_uid}'
+            path = f'{language_code}/{uid}/{author_uid}'
         else:
-            path = f'{lang_uid}/{uid}'
+            path = f'{language_code}/{uid}'
 
         document = {
             "uid": uid,
-            "lang": lang_uid,
+            "lang": language_code,
             "path": path,
             "author": text_details.authors_long_name,
             "author_short": author_short,

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -72,9 +72,7 @@ class TextInfoModel:
 
 
 def files_for_language(lang_dir: Path) -> list[Path]:
-    all_files = sorted(
-        lang_dir.glob('**/*.html'), key=lambda f: util.numericsortkey(f.stem)
-    )
+    all_files = list(lang_dir.glob('**/*.html'))
     files = [f for f in all_files if f.stem == 'metadata'] + [
         f for f in all_files if f.stem != 'metadata'
     ]

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -1,6 +1,10 @@
 import logging
 from pathlib import Path
 
+from arango.database import Database
+from tqdm import tqdm
+
+from data_loader.change_tracker import ChangeTracker
 from data_loader.unsegmented_texts import extract_details, TextDetails
 
 logger = logging.getLogger(__name__)
@@ -122,3 +126,15 @@ class ArangoTextInfoModel(TextInfoModel):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.flush_documents()
+
+
+def load_html_texts(change_tracker: ChangeTracker, data_dir: Path, db: Database, html_dir: Path):
+    print('Loading HTML texts')
+    with ArangoTextInfoModel(db=db) as tim:
+        for lang_dir in tqdm(html_dir.glob('*')):
+            if lang_dir.is_dir:
+                tim.process_lang_dir(
+                    lang_dir=lang_dir,
+                    data_dir=data_dir,
+                    files_to_process=change_tracker.changed_or_new
+                )

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -22,7 +22,7 @@ class TextInfoModel:
     def process_lang_dir(self, lang_dir: Path, data_dir: Path = None, files_to_process: dict[str, int] | None = None):
         lang_uid = lang_dir.stem
 
-        files = self._files_for_language(lang_dir)
+        files = files_for_language(lang_dir)
 
         for html_file in files:
             if should_process_file(data_dir, files_to_process, html_file):
@@ -70,18 +70,20 @@ class TextInfoModel:
     def last_modified(self, html_file):
         return html_file.stat().st_mtime
 
-    def _files_for_language(self, lang_dir):
-        all_files = sorted(
-            lang_dir.glob('**/*.html'), key=lambda f: util.numericsortkey(f.stem)
-        )
-        files = [f for f in all_files if f.stem == 'metadata'] + [
-            f for f in all_files if f.stem != 'metadata'
-        ]
-        return files
+
+def files_for_language(lang_dir: Path):
+    all_files = sorted(
+        lang_dir.glob('**/*.html'), key=lambda f: util.numericsortkey(f.stem)
+    )
+    files = [f for f in all_files if f.stem == 'metadata'] + [
+        f for f in all_files if f.stem != 'metadata'
+    ]
+    return files
 
 
 def should_process_file(data_dir, files_to_process, html_file):
     return str(html_file.relative_to(data_dir)) in files_to_process
+
 
 def log_missing_details(details: TextDetails, file_name: str) -> None:
     if not details.has_title_tags:


### PR DESCRIPTION
I've reworked the path handling and the `process_lang_dir()` method has been much simplified. 

`ChangeTracker` has a new method: `changed_files()` which takes an iterable of Paths and yields the ones that have changed.

By removing some printing and logging I've got the `tqdm()` progress bar to work properly.

We're getting quite close to finishing the refactoring of `load_html_texts()`