### PR TITLE
fix: fix formatting in SCParallels class to prepend 'sag' to generated strings for single and multiple items.

### DIFF
--- a/client/elements/suttaplex/card/sc-parallel-list.js
+++ b/client/elements/suttaplex/card/sc-parallel-list.js
@@ -225,11 +225,11 @@ export class SCParallels extends LitLocalized(LitElement) {
         .sort(compareArray)
         .map(item => {
           if (item.length === 1) {
-            return `sag#${item[0].toString()}`;
+            return `sag#sag${item[0].toString()}`;
           } else if (item.length === 2) {
-            return `sag#${item[0].toString()}.${item[1].toString()}`;
+            return `sag#sag${item[0].toString()}.${item[1].toString()}`;
           } else {
-            return `sag#${item[0].toString()}.${item[1].toString()}-#${item[2].toString()}.${item[3].toString()}`;
+            return `sag#sag${item[0].toString()}.${item[1].toString()}-#sag${item[2].toString()}.${item[3].toString()}`;
           }
         });
     } else if (rootKeys[0].match(/dhp/)) {


### PR DESCRIPTION
This fix addresses an issue caused by a change in the format of sag entries in parallels.json.