### PR TITLE
docs: add LICENSE file to reference site Licensing page

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,5 @@
+# License
+
+All code created for and supported by SuttaCentral is dedicated to the Public Domain by means of the [Creative Commons Public Domain (CC0) license](https://creativecommons.org/public-domain/cc0/).
+
+For more information about SuttaCentral licensing, please see https://suttacentral.net/licensing.


### PR DESCRIPTION
### Summary

I noticed LICENSE files were missing in a few repositories despite the website having an [explicit page on licensing](https://suttacentral.net/licensing).

### Details

- to be explicit in all repositories about licensing
  - the licensing details have otherwise already existed and are often made explicit with translators etc, this just places a reference directly in the repo

- based on the one added [in the `bilara-data` repo](https://github.com/suttacentral/bilara-data/blob/b6c29f1b2131207b8cfff5a4eaed64c7c0894ce6/LICENSE.md) after I had mentioned it in https://github.com/suttacentral/bilara-data/pull/4753 & https://github.com/suttacentral/bilara-data/pull/4739
  - basically only changed a few words to indicate that this is repository contains code rather than Bilara translations
    - otherwise the site's licensing terms are the same for code and Bilara translations, CC0. only "legacy" translations are different (they retain original copyright, if applicable)
    
#### Verification

This will look nearly identical to how [`bilara-data`](https://github.com/suttacentral/bilara-data/blob/b6c29f1b2131207b8cfff5a4eaed64c7c0894ce6/) currently looks with the "View license" link in GitHub side metadata and in the "License" tab next to the "README" tab

### Future Work

For more explicitness, if desired:
1. [ ] License headers could be added per-file