### PR TITLE
refactor: rename `deploy.yml` and steps for clarity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout master repo
+      - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Initialize docker
+      - name: Install Docker
         uses: docker/setup-docker-action@v4
-        
+
       - name: Build
         run: |
           make prepare-tests
           # docker wait sc-frontend
+
+      # split debug logging into separate steps so that it is in its own sections and easier to read and parse
+      - name: Debug log - compose logs
+        run: |
           docker compose logs
+      - name: Debug log - docker ps
+        run: |
           docker ps
 
       # - name: Test
       #   run: make test
-       


### PR DESCRIPTION
## Summary

Rename the CI workflow and its steps for greater clarity / explicitness

Noticed this after taking a look at CI and suggesting some improvements in https://github.com/suttacentral/suttacentral/pull/3549#discussion_r2778027843

## Details

- rename `deploy.yml` to `ci.yml` as this workflow does not deploy anything
  - deployment should also generally not happen on PRs, rather after merge to `main`
    - a staging deploy could be done as a PR step exclusively for trusted users or on its own protected branch
- rename some steps for clarity as well
  - "Checkout master repo" -> "Checkout repo" as `main` is the default branch these days. that's also the name of a branch, not the repo
  - "Initialize docker" -> "Install Docker" - to be more explicit - "initialize" is a bit ambiguous wording and doesn't match [the action's own wording](https://github.com/docker/setup-docker-action)

- split out debug logging steps
  - this way they appear as separate sections in the GHA logs and can be separately expanded or contracted
    - as prior art, see also https://github.com/argoproj/argo-workflows/pull/11752 and https://github.com/argoproj/argo-workflows/pull/11670
  - and have more explicit naming too