### PR TITLE
clean(make): remove outdated `extract-static-strings` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,6 @@ rebuild-frontend:
 bundle-analyzer:
 	docker compose run sc-frontend npm run build --report
 
-rebuild-static-pages:
-	cd client && npm run extract-static-strings
-
 run-preview-env:
 	@make clean-all
 	@make create-network


### PR DESCRIPTION
## Summary

Remove outdated `make rebuild-static-pages` command that uses the no longer existent `npm run extract-static-strings` script.

## Details

- it was removed from the `package.json` in 3182f7e50d05331b3b7cf884d6d55d022fba7fac (https://github.com/suttacentral/suttacentral/pull/2035), so `make rebuild-static-pages` will always error and doesn't otherwise do anything
  - this `make` command is [the only remaining place](https://github.com/search?q=repo%3Asuttacentral%2Fsuttacentral%20extract-static-strings&type=code) that uses it
  
## Verification
- Found to be unused by search and historical analysis (see above)