### PR TITLE
style(client): configure ESLint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,4 @@ generatedPoFiles/
 .prod.env
 environment_prod.yml
 .history
-client/.eslintrc.json
-client/.eslintrc.js
-client/.prettierrc
 client/files/fonts/woff2_compress

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,12 @@ rebuild-frontend:
 bundle-analyzer:
 	docker compose run sc-frontend npm run build --report
 
+lint-client:
+	docker compose run sc-frontend npm run lint
+
+test-client:
+	docker compose run sc-frontend npm run test
+
 run-preview-env:
 	@make clean-all
 	@make create-network

--- a/README.md
+++ b/README.md
@@ -189,24 +189,8 @@ class InitialMigration(Migration):
 
 ### 2.1 Style guidelines
 
-- Based on the [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript) for JS code...
+* `npm run lint:fix`
 
-#### General considerations:
+* Comments explaining a function's purpose should be written on the line directly above the function declaration.
 
-- Use [template strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).
-
-- Use [ES6 fat arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
-
-- Use [ES6 classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) (`class MyElement extends Polymer.Element`) instead of the old `Polymer({...})` syntax when declaring an element inside your \<script> tags.
-
-- Use `const`/`let` instead of `var` when declaring a variable.
-
-- Use `===` and `!==` instead of `==` and `!=` when comparing values to avoid [type coercion](http://webreflection.blogspot.com/2010/10/javascript-coercion-demystified.html).
-
-- Comments explaining a function's purpose should be written on the line directly above the function declaration.
-
-- Internal HTML imports should come after external ones (from bower_components) and be separated by a newline.
-
-- When commenting Components at the top-level (above `<dom-module>`), keep HTML comment tags (`\<!--` & `-->`) on their own separate lines.
-
-- Try to keep line width under 120 characters.
+* When commenting Components at the top-level (above `<dom-module>`), keep HTML comment tags (`\<!--` & `-->`) on their own separate lines.

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,0 +1,44 @@
+module.exports = {
+  parser: "@babel/eslint-parser",
+  // configure browser, node, and test globals
+  env: {
+    "browser": true,
+    "node": true,
+    "mocha": true,
+  },
+  extends: [
+    "eslint-config-airbnb-base",
+    "eslint-config-prettier", // TODO: change to "plugin:prettier/recommended": https://github.com/prettier/eslint-plugin-prettier/blob/ca076d95aaf69aaf9c95abcc1692f8269197f248/README.md#configuration-legacy-eslintrc
+  ],
+  plugins: [
+    "eslint-plugin-compat",
+    "eslint-plugin-import",
+    "eslint-plugin-json",
+    "eslint-plugin-lit",
+    "eslint-plugin-prettier",
+    "eslint-plugin-promise",
+    "eslint-plugin-unused-imports",
+    "eslint-plugin-wc",
+  ],
+  rules: {
+    // necessary configurations
+    "import/no-extraneous-dependencies": ["error", {
+      // make sure dev files' imports are considered devDeps: https://github.com/import-js/eslint-plugin-import/issues/1263#issuecomment-706680017
+      "devDependencies": [
+        "test/**/*.js",
+        "webpack.*.js",
+        "vite.config.js",
+        "web-test-runner.config.js",
+      ]
+    }],
+    // preferences
+    // TODO: only override some of the Airbnb preferences: https://github.com/airbnb/javascript/blob/366bfa66380c08304101c6add46355696e90b348/packages/eslint-config-airbnb-base/rules/style.js#L336
+    "no-restricted-syntax": ["off"],
+    "import/prefer-default-export": ["off"],
+    // to remove
+    // TODO: this should be done for all non-render methods
+    "class-methods-use-this": ["off"],
+    // TODO: remove this and use private methods instead
+    "no-underscore-dangle": ["off"],
+  },
+}

--- a/client/babel.config.js
+++ b/client/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [['@babel/preset-env', { targets: 'defaults' }]],
+  plugins: [
+    ['@babel/plugin-transform-runtime'],
+  ]
+}

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,8 @@
   "version": "2.5.3",
   "private": true,
   "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "build": "NODE_OPTIONS=--max-old-space-size=8192 webpack --progress --config webpack.prod.js",
     "dev": "vite",
     "test": "web-test-runner \"test/**/*.test.js\" --node-resolve"


### PR DESCRIPTION

## Summary

Configure ESLint to run on all client code

This is currently a draft PR as I am still working on the configuration:
- went from ~2k lint errors initially down to ~600
- ~100 are auto-fixable, so 500 either need manual fixes or config changes
- this is not including `prettier` yet, that will have its own set of changes once I get through plain ESLint   

## Details

- all shared configs and plugins were installed in devDeps, but there was no configuration or scripts to run
  - add `lint` and `lint:fix` scripts
    - add `make lint-client` command
  - add an `.eslintrc.js` config
    - remove `.gitignore` lines for it
      - this might be why there was no config previously 😕 the ignores were added in 4ca35ec9b6004b1b759f90be46f57c4a84794282 (#2142)
        - some of these files duplicate each other, but it would make more sense to allow them and either auto-error in CI or check in code review
          - right now in the `.gitignore`, it's very easy to make a change and not realize it isn't tracked - I'd suggest moving all `client` ignores to a nested `.gitignore` in the `client` directory for better locality (ditto for `server`)
    - this will need to be migrated to newer `eslint.config.js` once all the configs and plugins are upgraded
      - the Airbnb config [does not yet support newer ESLint](https://github.com/airbnb/javascript/blob/05aabc4f8fca0921efcc2e93174b1fd31929caaa/packages/eslint-config-airbnb-base/package.json#L83); might need to use another similar shared config that is up-to-date
  - add a `babel.config.js` for `@babel/eslint-parser` to read
    - the separate Webpack and Vite configs should ideally be removed and this be the only one config

- replace most of README client style guide with instruction to just run lint
   - the deleted lines are now done automatically (as I previously suggested [in dev chat](https://discourse.suttacentral.net/chat/c/-/12/5193))

## Future Work
- [ ] Run these in CI
- [ ] Configure `prettier` as a formatter as well
  - Similar to ESLint, all the deps and [config](https://github.com/suttacentral/suttacentral/blob/723f847a99b3bd2d2440598a88056fdee7ef1f17/client/package.json#L21) already exist, there are just no CI or commands for it (although there is [a `pre-commit` hook](https://github.com/suttacentral/suttacentral/blob/723f847a99b3bd2d2440598a88056fdee7ef1f17/client/package.json#L12) for it)
- [ ] Check if there is a lint rule for ensuring a Lit component is properly imported/instantiated when it is used in Lit HTML
  - to automatically detect issues like https://github.com/suttacentral/suttacentral/pull/3577#discussion_r2898522538
- [ ] ESLint, plugins, and config upgrades, as mentioned above 
- [ ] If we want to follow the back-end's use of performant Rust tooling (like `uv` (#3557) and `ruff`), we could also switch to `oxlint` and `oxfmt`
  - I didn't do so here as there were many ESLint plugins _already_ installed, just no configuration or scripts for them, so using them would remain faithful to prior intent and perhaps existing style in the codebase (though given the errors, some pieces have clearly diverged due to lack of tooling usage)
  - Also, not all the Lit plugins are necessarily compatible with the `oxc` stack
  - Alternatively, there are other Rust-based linters and formatters like Biome too