### PR TITLE
Use multi-stage build

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,7 @@
 services:
   sc-flask:
+    build:
+      target: dev
     env_file:
       - server/env/.dev.env
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,7 @@
 services:
   sc-flask:
+    build:
+      target: prod
     restart: always
     env_file:
       - server/env/.prod.env

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,7 @@
 services:
   sc-flask:
+    build:
+      target: test
     volumes:
       - ./client/:/opt/sc/frontend
     env_file:

--- a/server/Dockerfile-flask
+++ b/server/Dockerfile-flask
@@ -6,9 +6,6 @@ FROM python:3.11.3
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.9.30 /uv /uvx /bin/
 
-
-RUN apt-get update && apt-get install -y pngnq && apt-get install -y python3-enchant
-
 RUN mkdir -p /opt/sc/sockets
 RUN mkdir -p /opt/sc/sc-flask
 

--- a/server/Dockerfile-flask
+++ b/server/Dockerfile-flask
@@ -1,14 +1,16 @@
-# Using the python image is redundant now that we have a setup with uv.
-# Perhaps we should update to something else such as the astral images:
+# TODO: Use distroless uv image
 # https://docs.astral.sh/uv/guides/integration/docker/
-FROM python:3.11.3
+# Create the production image
+FROM python:3.11.3 AS prod
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.9.30 /uv /uvx /bin/
 
+# Create required directories
 RUN mkdir -p /opt/sc/sockets
 RUN mkdir -p /opt/sc/sc-flask
 
+# Application code will be installed here.
 WORKDIR /opt/sc/sc-flask
 
 # Enable bytecode compilation for better start-up performance at the cost of longer build time
@@ -17,7 +19,7 @@ ENV UV_COMPILE_BYTECODE=1
 # Copy from the cache instead of hard linking due to the cache mount
 ENV UV_LINK_MODE=copy
 
-# Omit development dependencies
+# Omit development dependencies for production
 ENV UV_NO_DEV=1
 
 # Copy dependency manifests and install them into a virtual environment
@@ -27,7 +29,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     
 # Copy source code and editable install packages into the .venv
 COPY src/ ./src
-COPY tests/ ./tests
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked
 
@@ -46,3 +47,19 @@ COPY entrypoint.sh uwsgi.ini ./
 ENV FLASK_APP="sc_flask.wsgi:app"
 
 CMD ["bash", "entrypoint.sh"]
+
+# Create a test environment based on production.
+FROM prod AS test
+
+# Install development dependencies in .venv
+ENV UV_NO_DEV=0
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-install-project
+
+# Make our unit and integration tests available
+COPY tests/ ./tests
+
+# Create a dev environment based on test.
+FROM test as dev
+
+# TODO: Install anything extra that dev may require.

--- a/server/Dockerfile-flask
+++ b/server/Dockerfile-flask
@@ -60,6 +60,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY tests/ ./tests
 
 # Create a dev environment based on test.
-FROM test as dev
+FROM test AS dev
 
 # TODO: Install anything extra that dev may require.


### PR DESCRIPTION
I've never done this before, but it seemed to work and I'd love some feedback.

There are now three stages in the build process, starting with `prod`, then building `test` on `prod` and `dev` on `test`.

The `dev` target is just a placeholder at this point and duplicates `test`.

I'm not using the distroless `uv` as a base just yet.

**Note on branching**

I've created the new branch from `update_build_config`. The process, as I understand it, is to merge PR #3575, then delete the `update_build_config` branch and then the base for this PR will become `main`.

I might have that completely wrong. Let me know, @agilgur5 !