### PR TITLE
clean(deps): remove unused `pyenchant` dep

### DIFF
--- a/server/Dockerfile-flask
+++ b/server/Dockerfile-flask
@@ -26,7 +26,7 @@ ENV UV_NO_DEV=1
 COPY pyproject.toml uv.lock README.md ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-install-project
-    
+
 # Copy source code and editable install packages into the .venv
 COPY src/ ./src
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
     "pluggy==1.0.0",
     "py==1.11.0",
     "pyee==8.2.2",
-    "pyenchant==3.2.2",
     "pyjwt==2.6.0",
     "pykakasi==2.2.1",
     "pyparsing==3.0.9",

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -488,17 +488,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyenchant"
-version = "3.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b1/a3/86763b6350727ca81c8fcc5bb5bccee416e902e0085dc7a902c81233717e/pyenchant-3.2.2.tar.gz", hash = "sha256:1cf830c6614362a78aab78d50eaf7c6c93831369c52e1bb64ffae1df0341e637", size = 49580, upload-time = "2021-10-05T17:25:25.553Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/4c/a741dddab6ad96f257d90cb4d23067ffadac526c9cab3a99ca6ce3c05477/pyenchant-3.2.2-py3-none-any.whl", hash = "sha256:5facc821ece957208a81423af7d6ec7810dad29697cb0d77aae81e4e11c8e5a6", size = 55660, upload-time = "2021-10-05T17:25:19.548Z" },
-    { url = "https://files.pythonhosted.org/packages/01/44/1e9a273d230abf5c961750a75e42b449adfb61eb446f80b6523955d2a4a2/pyenchant-3.2.2-py3-none-win32.whl", hash = "sha256:5a636832987eaf26efe971968f4d1b78e81f62bca2bde0a9da210c7de43c3bce", size = 11884084, upload-time = "2021-10-05T17:25:23.844Z" },
-    { url = "https://files.pythonhosted.org/packages/49/96/2087455de16b08e86fa7ce70b53ddac5fcc040c899d9ebad507a0efec52d/pyenchant-3.2.2-py3-none-win_amd64.whl", hash = "sha256:6153f521852e23a5add923dbacfbf4bebbb8d70c4e4bad609a8e0f9faeb915d1", size = 11890882, upload-time = "2021-10-05T17:25:17.013Z" },
-]
-
-[[package]]
 name = "pyjwt"
 version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -746,7 +735,6 @@ dependencies = [
     { name = "pluggy" },
     { name = "py" },
     { name = "pyee" },
-    { name = "pyenchant" },
     { name = "pyjwt" },
     { name = "pykakasi" },
     { name = "pyparsing" },
@@ -826,7 +814,6 @@ requires-dist = [
     { name = "pluggy", specifier = "==1.0.0" },
     { name = "py", specifier = "==1.11.0" },
     { name = "pyee", specifier = "==8.2.2" },
-    { name = "pyenchant", specifier = "==3.2.2" },
     { name = "pyjwt", specifier = "==2.6.0" },
     { name = "pykakasi", specifier = "==2.2.1" },
     { name = "pyparsing", specifier = "==3.0.9" },


### PR DESCRIPTION
## Summary

Remove unused `pyenchant` / `enchant` / `python3-enchant` dep from `pyproject.toml`, `uv.lock`, and `Dockerfile-flask`

I originally discovered this while reviewing https://github.com/suttacentral/suttacentral/pull/3562#discussion_r2839157388

## Details

- it was installed in the container via `apt-get` (as `python3-enchant`) and in the Python env
- it is [not used](https://github.com/search?q=repo%3Asuttacentral%2Fsuttacentral%20pyenchant&type=code) in the codebase
  - it was added in 6f73d48742f909cfccc2f29467b6850882161b24 + 9fd276c1b4276eba163252efec4ef06aebbb584c (#2636), then its usage was commented out a week later in b0cf29a6f9aa67df9d78dadb1ad7c667729b3509 (https://github.com/suttacentral/suttacentral/pull/2641), then the commented out pieces were removed two weeks later in dc39bf7cacfb173c47ef6e10ec537e062edd107b (https://github.com/suttacentral/suttacentral/pull/2647), and then the import line was removed a month later in da65047ddee38ac52abecf89b6fff1db54a6b382 (https://github.com/suttacentral/suttacentral/pull/2683)
    - but it was never removed from the dependencies list until now
- it (and other deps) pops up as unused / unimported if you run a dependency checker like [FawltyDeps](https://github.com/tweag/FawltyDeps) (e.g. `uvx fawltydeps`)

## Verification
 
 - Code search (see above)
 - Historical analysis (see above)
 - Ran `uvx falwtydeps` (see above)