### PR TITLE
refactor(deps): split Python devDeps into their own group

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -19,9 +19,6 @@ dependencies = [
     "fonttools==4.38.0",
     "jinja2==3.1.2",
     "lxml[cssselect]==4.9.1",
-    "pytest==7.2.0",
-    "pytest-flask==1.2.0",
-    "pytest-sugar==0.9.6",
     "python-arango==7.5.3",
     "regex==2022.10.31",
     "requests==2.31.0",
@@ -31,6 +28,13 @@ dependencies = [
     "unidecode==1.3.7",
     "uwsgi==2.0.21",
     "zhconv==1.4.3",
+]
+
+[dependency-groups]
+dev = [
+    "pytest==7.2.0",
+    "pytest-flask==1.2.0",
+    "pytest-sugar==0.9.6",
 ]
 
 [build-system]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -589,9 +589,6 @@ dependencies = [
     { name = "fonttools" },
     { name = "jinja2" },
     { name = "lxml", extra = ["cssselect"] },
-    { name = "pytest" },
-    { name = "pytest-flask" },
-    { name = "pytest-sugar" },
     { name = "python-arango" },
     { name = "regex" },
     { name = "requests" },
@@ -601,6 +598,13 @@ dependencies = [
     { name = "unidecode" },
     { name = "uwsgi" },
     { name = "zhconv" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-flask" },
+    { name = "pytest-sugar" },
 ]
 
 [package.metadata]
@@ -619,9 +623,6 @@ requires-dist = [
     { name = "fonttools", specifier = "==4.38.0" },
     { name = "jinja2", specifier = "==3.1.2" },
     { name = "lxml", extras = ["cssselect"], specifier = "==4.9.1" },
-    { name = "pytest", specifier = "==7.2.0" },
-    { name = "pytest-flask", specifier = "==1.2.0" },
-    { name = "pytest-sugar", specifier = "==0.9.6" },
     { name = "python-arango", specifier = "==7.5.3" },
     { name = "regex", specifier = "==2022.10.31" },
     { name = "requests", specifier = "==2.31.0" },
@@ -631,6 +632,13 @@ requires-dist = [
     { name = "unidecode", specifier = "==1.3.7" },
     { name = "uwsgi", specifier = "==2.0.21" },
     { name = "zhconv", specifier = "==1.4.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = "==7.2.0" },
+    { name = "pytest-flask", specifier = "==1.2.0" },
+    { name = "pytest-sugar", specifier = "==0.9.6" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Use `dependency-groups.dev` in `pyproject.toml` for devDeps and remove them from `dependencies`

~This is currently a draft PR as they may be more to move or to synchronize after all my clean-up PRs (#3591, #3588, #3587, #3578)~
- ✅ Those have all been merged and this has been updated and is ready to review now.

## Details

- `pytest*` deps are only used during dev and not needed during prod
  - c.f. https://docs.astral.sh/uv/concepts/projects/dependencies/#development-dependencies
  - before `uv` / `pyproject.toml` (#3557), in the previous `requirements.txt`, one convention was to split out a `requirements-dev.txt`, but that could result in conflicts and other issues

## Future Work

- [ ] I was thinking that `faker` might be a dev dep too, but it appears to be used in prod code inside of models' [`generate` methods](https://github.com/suttacentral/suttacentral/blob/0c60a09c9bbc1c2716512e23e339fa2d772857da/server/server/common/models.py#L93).
  - Those could be moved into extended test models instead, but they actually aren't used there either and are only used in a [`_generate_models` helper function](https://github.com/suttacentral/suttacentral/blob/0c60a09c9bbc1c2716512e23e339fa2d772857da/server/server/common/utils.py#L63), whose uses seem to be dead code? So possibly all that code and it can be removed entirely?
  