### PR TITLE
Remove shell dependencies

### DIFF
--- a/server/Dockerfile-flask
+++ b/server/Dockerfile-flask
@@ -26,12 +26,12 @@ ENV UV_NO_DEV=1
 # Copy dependency manifests and install them into a virtual environment
 COPY pyproject.toml uv.lock README.md ./
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project
+    ["/bin/uv", "sync", "--locked", "--no-install-project"]
     
 # Copy source code and editable install packages into the .venv
 COPY src/ ./src
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked
+    ["/bin/uv", "sync", "--locked"]
 
 # Make our uv managed .venv the default Python to avoid confusion
 # with the system environment provided by the docker image.
@@ -55,7 +55,7 @@ FROM prod AS test
 # Install development dependencies in .venv
 ENV UV_NO_DEV=0
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project
+    ["/bin/uv", "sync", "--locked", "--no-install-project"]
 
 # Make our unit and integration tests available
 COPY tests/ ./tests

--- a/server/Dockerfile-flask
+++ b/server/Dockerfile-flask
@@ -6,9 +6,10 @@ FROM python:3.11.3 AS prod
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.9.30 /uv /uvx /bin/
 
-# Create required directories
-RUN mkdir -p /opt/sc/sockets
-RUN mkdir -p /opt/sc/sc-flask
+# Create directory to write socket files to.
+# Using `WORKDIR` rather than `RUN mkdir` avoids
+# the need to run a shell command.
+WORKDIR /opt/sc/sockets
 
 # Application code will be installed here.
 WORKDIR /opt/sc/sc-flask

--- a/server/Dockerfile-flask
+++ b/server/Dockerfile-flask
@@ -23,6 +23,9 @@ ENV UV_LINK_MODE=copy
 # Omit development dependencies for production
 ENV UV_NO_DEV=1
 
+# Ensure python stdout/stderr are written to terminal logs
+ENV PYTHONUNBUFFERED=1
+
 # Copy dependency manifests and install them into a virtual environment
 COPY pyproject.toml uv.lock README.md ./
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -41,13 +44,13 @@ ENV PATH="/opt/sc/sc-flask/.venv/bin:$PATH"
 
 # Copy over the remaining files required to run the application.
 COPY scripts/ ./scripts
-COPY entrypoint.sh uwsgi.ini ./
+COPY uwsgi.ini ./
 
 # Some commands such as sc_flask.manage require FLASK_APP to be set.
 # Flask and uwsgi do not.
 ENV FLASK_APP="sc_flask.wsgi:app"
 
-CMD ["bash", "entrypoint.sh"]
+CMD ["/bin/uv", "run", "scripts/entrypoint.py"]
 
 # Create a test environment based on production.
 FROM prod AS test

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-uv run python -m sc_flask.manage migrate
-touch /tmp/.done.info
-uv run uwsgi --ini uwsgi.ini

--- a/server/scripts/entrypoint.py
+++ b/server/scripts/entrypoint.py
@@ -1,0 +1,30 @@
+import subprocess
+from pathlib import Path
+
+def run_migrate():
+    print("Running migrate")
+    # There is surely a way to invoke this directly in python,
+    # but for now, just imitate the previous entrypoint.sh script.
+    subprocess.run(["uv", "run", "python", "-m", "sc_flask.manage", "migrate"])
+
+def notify_wait_for_flask_is_done():
+    Path('/tmp/.done.info').touch()
+    print("Flask is ready")
+
+def start_uwsgi():
+    print("Starting uwsgi")
+    # We can run this with the pyuwsgi package like so:
+    # pyuwsgi.run(["--ini", "uwsgi.ini"])
+    # To avoid a merge conflict with pyproject.toml and uv.lock
+    # we'll do it this way for now.
+    subprocess.run(["uv", "run", "uwsgi", "--ini", "uwsgi.ini"])
+
+def entrypoint():
+    run_migrate()
+    # Flask is not actually ready, but this is the point
+    # at which entrypoint.sh would indicate that it is.
+    notify_wait_for_flask_is_done()
+    start_uwsgi()
+
+if __name__ == "__main__":
+    entrypoint()


### PR DESCRIPTION
Another step towards a distroless production image:

- No more RUN commands that depend on the shell.
- The `entrypoint.sh` script has been rewritten in Python.

Note that we use `subprocess.run` in the new python script. These can be removed by:

- Running `sc_flask.migrate` directly.
- Using the `pyuwsgi` package. 

Changing the CLI invocation to some other form will work in the first case.

The latter works fine, but I decided against modifying `pyproject.toml` and `uv.lock` to avoid the inevitable merge conflict.