### PR TITLE
Remove change tracker function hash checks

### DIFF
--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -106,6 +106,9 @@ def generate_relationship_edges(
 ):
     relationship_files = list(relationship_dir.glob('*.json'))
 
+    # It's hard to say if this check ever worked or whether this conditional
+    # was always false. Now that I've removed the function hash check in
+    # ChangeTracker this might exit here when it did not before.
     if not change_tracker.is_any_file_new_or_changed(relationship_files):
         return
 
@@ -712,7 +715,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     load_fallen_leaves_files(db, structure_dir / 'fallen-leaves')
 
     printer.print_stage("Building and loading navigation from structure_dir")
-    navigation.add_navigation_docs_and_edges(change_tracker, db, structure_dir, sc_bilara_data_dir)
+    navigation.add_navigation_docs_and_edges(db, structure_dir, sc_bilara_data_dir)
 
     printer.print_stage("Loading child ranges from structure_dir")
     load_child_range(db, structure_dir)

--- a/server/src/data_loader/change_tracker.py
+++ b/server/src/data_loader/change_tracker.py
@@ -1,9 +1,5 @@
-import gc
-import hashlib
-import inspect
 from collections.abc import Iterable, Iterator
 from pathlib import Path
-from typing import Callable
 
 from arango.database import Database
 
@@ -13,19 +9,7 @@ class ChangeTracker:
         self.base_dir = base_dir
         self.db = db
 
-        self.old_function_hashes = {
-            doc['_key']: doc['hash']
-            for doc in db.aql.execute(
-                '''
-            FOR doc IN function_hashes
-                RETURN doc
-        '''
-            )
-        }
-        self.new_function_hashes = {}
-
         # Extract the mtimes from arangodb
-
         self.old_mtimes = {
             entry['path']: entry['mtime']
             for entry in db.aql.execute(
@@ -37,7 +21,6 @@ class ChangeTracker:
         }
 
         # Get the mtimes from the file system
-
         self.new_mtimes = {}
         for path in base_dir.glob('**/*'):
             if path.is_dir():
@@ -53,33 +36,16 @@ class ChangeTracker:
         print(f'{len(self.changed_or_new)} files to be processed')
         print(f'{len(self.deleted)} files to be deleted')
 
-    def is_file_new_or_changed(self, path: Path, check_calling_function: bool = True) -> bool:
-        if check_calling_function and self.is_function_changed(who_is_calling()):
-            return True
+    def is_file_new_or_changed(self, path: Path) -> bool:
         return str(path.relative_to(self.base_dir)) in self.changed_or_new
 
-    def is_any_file_new_or_changed(self, files: list[Path], check_calling_function: bool = True) -> bool:
-        if check_calling_function and self.is_function_changed(who_is_calling()):
-            return True
-        return any(self.is_file_new_or_changed(file, False) for file in files)
+    def is_any_file_new_or_changed(self, files: list[Path]) -> bool:
+        return any(self.is_file_new_or_changed(file) for file in files)
 
     def changed_files(self, paths: Iterable[Path]) -> Iterator[Path]:
         for path in paths:
-            if self.is_file_new_or_changed(path, check_calling_function=False):
+            if self.is_file_new_or_changed(path):
                 yield path
-
-    def is_any_function_changed(self, functions: Iterable[Callable]) -> bool:
-        return any(self.is_function_changed(function) for function in functions)
-
-    def is_function_changed(self, function: Callable | None) -> bool:
-        key = f'{function.__module__}.{function.__qualname__}'
-        return self.is_thing_changed(key, function)
-
-    def is_thing_changed(self, key: str, thing: Callable) -> bool:
-        function_hash = hashlib.md5(function_source(thing).encode()).hexdigest()
-
-        self.new_function_hashes[key] = function_hash
-        return self.old_function_hashes.get(key) != function_hash
 
     def update_mtimes(self) -> None:
         # Update mtimes in arangodb
@@ -98,36 +64,3 @@ class ChangeTracker:
             ],
             on_duplicate="replace",
         )
-        self.db['function_hashes'].truncate()
-        docs = [{'_key': k, 'hash': v} for k, v in self.new_function_hashes.items()]
-        self.db['function_hashes'].import_bulk_logged(docs, wipe=True)
-
-
-def function_source(function: Callable) -> str:
-    return ''.join(inspect.getsourcelines(function)[0])
-
-
-def who_is_calling(depth: int = 2) -> Callable | None:
-    """Return the calling function at given stack depth
-    
-    adapted from https://stackoverflow.com/a/4506081/4092906
-    """
-    frame_info = inspect.stack()[depth]
-    frame = frame_info.frame
-    code = frame.f_code
-    globs = frame.f_globals
-    functype = type(lambda: 0)
-    funcs = []
-    for func in gc.get_referrers(code):
-        if type(func) is functype and getattr(func, "__code__", None) is code and getattr(func, "__globals__", None) is globs:
-            funcs.append(func)
-            if len(funcs) > 1:
-                return None
-    return funcs[0] if funcs else None
-
-
-def whoami() -> Callable | None:
-    """
-    Returns the function that calls it
-    """
-    return who_is_calling(depth=2)

--- a/server/src/data_loader/navigation.py
+++ b/server/src/data_loader/navigation.py
@@ -10,7 +10,7 @@ from data_loader.extra_info import process_extra_info_file
 from data_loader.util import json_load
 
 
-def add_navigation_docs_and_edges(change_tracker, db, structure_dir, sc_bilara_data_dir):
+def add_navigation_docs_and_edges(db, structure_dir, sc_bilara_data_dir):
     tree_dir = structure_dir / 'tree'
 
     names_files = sorted((sc_bilara_data_dir / 'root' / 'misc' / 'site' / 'name').glob('**/*.json'))
@@ -22,23 +22,20 @@ def add_navigation_docs_and_edges(change_tracker, db, structure_dir, sc_bilara_d
     super_extra_info = process_extra_info_file(structure_dir / 'super_extra_info.json')
     text_extra_info = process_extra_info_file(structure_dir / 'text_extra_info.json')
 
-    if change_tracker.is_any_function_changed(
-            [_perform_update_queries, _process_super_tree_file, _process_tree_files, _process_names_files]
-    ):
-        nav_details_docs = _process_names_files(names_files, root_languages, super_extra_info, text_extra_info)
+    nav_details_docs = _process_names_files(names_files, root_languages, super_extra_info, text_extra_info)
 
-        nav_details_edges = _process_tree_files(tree_files) + _process_super_tree_file(super_tree_file)
+    nav_details_edges = _process_tree_files(tree_files) + _process_super_tree_file(super_tree_file)
 
-        db['super_nav_details'].truncate()
-        db['super_nav_details_edges'].truncate()
-        db['super_nav_details'].import_bulk(nav_details_docs)
-        db['super_nav_details_edges'].import_bulk(
-            nav_details_edges,
-            from_prefix='super_nav_details',
-            to_prefix='super_nav_details',
-        )
+    db['super_nav_details'].truncate()
+    db['super_nav_details_edges'].truncate()
+    db['super_nav_details'].import_bulk(nav_details_docs)
+    db['super_nav_details_edges'].import_bulk(
+        nav_details_edges,
+        from_prefix='super_nav_details',
+        to_prefix='super_nav_details',
+    )
 
-        _perform_update_queries(db)
+    _perform_update_queries(db)
 
 
 def _perform_update_queries(db):

--- a/server/src/migrations/migrations/remove_function_hashes_collection_058.py
+++ b/server/src/migrations/migrations/remove_function_hashes_collection_058.py
@@ -1,0 +1,11 @@
+from common.arangodb import get_db
+from migrations.base import Migration
+
+# Why is every migration called SecondMigration? Copy & paste?
+class SecondMigration(Migration):
+    migration_id = 'remove_function_hashes_collection_058'
+    tasks = ['remove_collections']
+
+    def remove_collections(self):
+        db = get_db()
+        db.delete_collection('function_hashes')

--- a/server/tests/data_loader/test_changetracker.py
+++ b/server/tests/data_loader/test_changetracker.py
@@ -1,137 +1,116 @@
+import pytest
+from arango.database import Database
+
 import common.utils
 from common import arangodb
-from data_loader.change_tracker import whoami, who_is_calling, function_source, ChangeTracker
+from data_loader.change_tracker import ChangeTracker
+
+@pytest.fixture
+def mtimes_db():
+    app_ = common.utils.current_app()
+    app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
+
+    with app_.app_context():
+        db = arangodb.get_db()
+        db.collection('mtimes').truncate()
+        yield db
 
 
-def test_whomai():
-    assert whoami() == test_whomai
+class TestIsFileNewOrChanged:
+    def test_true_when_new(self, mtimes_db, tmp_path):
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        tracker.update_mtimes()
+        new_file = tmp_path / 'new_file.txt'
+        new_file.touch()
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        assert tracker.is_file_new_or_changed(path=new_file)
+
+    def test_true_when_changed(self, mtimes_db, tmp_path):
+        new_file = tmp_path / 'new_file.txt'
+        new_file.touch()
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        tracker.update_mtimes()
+        new_file.touch()
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        assert tracker.is_file_new_or_changed(path=new_file)
+
+    def test_false_when_not_new_or_changed(self, mtimes_db, tmp_path):
+        new_file = tmp_path / 'new_file.txt'
+        new_file.touch()
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        tracker.update_mtimes()
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        assert not tracker.is_file_new_or_changed(path=new_file)
 
 
-class Foo:
-    def method_returning_caller(self):
-        return who_is_calling()
+class TestIsAnyFileNewOrChanged:
+    def test_true_when_one_new(self, mtimes_db, tmp_path):
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        tracker.update_mtimes()
+        new_file = tmp_path / 'new_file.txt'
+        new_file.touch()
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        assert tracker.is_any_file_new_or_changed(files=[new_file])
 
-    def method_returns_itself(self):
-        return whoami()
+    def test_true_when_one_changed(self, mtimes_db, tmp_path):
+        new_file = tmp_path / 'new_file.txt'
+        new_file.touch()
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        tracker.update_mtimes()
+        new_file.touch()
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        assert tracker.is_any_file_new_or_changed(files=[new_file])
 
+    def test_false_when_none_new_or_changed(self, mtimes_db, tmp_path):
+        new_file = tmp_path / 'new_file.txt'
+        new_file.touch()
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        tracker.update_mtimes()
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        assert not tracker.is_any_file_new_or_changed(files=[new_file])
 
-def test_method_call():
-    foo = Foo()
-    assert foo.method_returning_caller() == test_method_call
-    assert foo.method_returns_itself() == Foo.method_returns_itself
-
-
-def test_nested_call():
-    def nested_returning_itself():
-        return whoami()
-
-    def nested_returning_caller():
-        return who_is_calling()
-
-    assert nested_returning_itself() == nested_returning_itself
-    assert nested_returning_caller() == test_nested_call
-
-
-def test_function_source():
-    def bar():
-        pass
-
-    assert function_source(bar) == '    def bar():\n        pass\n'
 
 class TestChangeTracker:
-    def test_new_file_is_changed(self, tmp_path):
-        app_ = common.utils.current_app()
-        app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
+    def test_adding_file_to_mtimes_collection_makes_it_not_changed(self, mtimes_db, tmp_path):
+        new_file = tmp_path / 'new_file.txt'
+        new_file.touch()
+        mtimes_doc = {
+            '_key': 'new_file.txt',
+            'path': 'new_file.txt',
+            'mtime': new_file.stat().st_mtime_ns,
+            }
+        mtimes_db.collection('mtimes').insert(mtimes_doc)
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        assert not tracker.is_file_new_or_changed(path=new_file)
 
-        with app_.app_context():
-            db = arangodb.get_db()
-            db.collection('mtimes').truncate()
+    def test_changed_files(self, mtimes_db, tmp_path):
+        unchanged = [
+            tmp_path / 'abc.txt',
+            tmp_path / 'def.txt',
+            tmp_path / 'hij.txt',
+        ]
 
-            tracker = ChangeTracker(base_dir=tmp_path, db=db)
-            tracker.update_mtimes()
+        for path in unchanged:
+            path.touch()
 
-            new_file = tmp_path / 'new_file.txt'
-            new_file.touch()
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
+        tracker.update_mtimes()
 
-            tracker = ChangeTracker(base_dir=tmp_path, db=db)
+        changed = [
+            tmp_path / '123.txt',
+            tmp_path / '456.txt',
+            tmp_path / '789.txt',
+        ]
 
-            assert tracker.is_file_new_or_changed(path=new_file, check_calling_function=False)
-
-    def test_old_file_is_not_changed(self, tmp_path):
-        app_ = common.utils.current_app()
-        app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
-
-        with app_.app_context():
-            db = arangodb.get_db()
-            db.collection('mtimes').truncate()
-
-            new_file = tmp_path / 'new_file.txt'
-            new_file.touch()
-
-            tracker = ChangeTracker(base_dir=tmp_path, db=db)
-            tracker.update_mtimes()
-
-            tracker = ChangeTracker(base_dir=tmp_path, db=db)
-
-            assert not tracker.is_file_new_or_changed(path=new_file, check_calling_function=False)
-
-    def test_adding_file_to_mtimes_collection_makes_it_not_changed(self, tmp_path):
-        app_ = common.utils.current_app()
-        app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
-
-        with app_.app_context():
-            db = arangodb.get_db()
-            db.collection('mtimes').truncate()
-
-            new_file = tmp_path / 'new_file.txt'
-            new_file.touch()
-
-            mtimes_doc = {
-                '_key': 'new_file.txt',
-                'path': 'new_file.txt',
-                'mtime': new_file.stat().st_mtime_ns,
-                }
-
-            db.collection('mtimes').insert(mtimes_doc)
-
-            tracker = ChangeTracker(base_dir=tmp_path, db=db)
-            assert not tracker.is_file_new_or_changed(path=new_file, check_calling_function=False)
-
-    def test_changed_files(self, tmp_path):
-        app_ = common.utils.current_app()
-        app_.config['ARANGO_DB'] = 'suttacentral_data_load_tests'
-
-        with app_.app_context():
-            db = arangodb.get_db()
-            db.collection('mtimes').truncate()
-
-            unchanged = [
-                tmp_path / 'abc.txt',
-                tmp_path / 'def.txt',
-                tmp_path / 'hij.txt',
-            ]
-
-            for path in unchanged:
-                path.touch()
-
-            tracker = ChangeTracker(base_dir=tmp_path, db=db)
-            tracker.update_mtimes()
-
-            changed = [
-                tmp_path / '123.txt',
-                tmp_path / '456.txt',
-                tmp_path / '789.txt',
-            ]
-
-            for path in changed:
-                path.touch()
+        for path in changed:
+            path.touch()
 
 
-            tracker = ChangeTracker(base_dir=tmp_path, db=db)
+        tracker = ChangeTracker(base_dir=tmp_path, db=mtimes_db)
 
-            to_check = [
-                tmp_path / 'abc.txt',
-                tmp_path / '123.txt',
-            ]
+        to_check = [
+            tmp_path / 'abc.txt',
+            tmp_path / '123.txt',
+        ]
 
-            assert list(tracker.changed_files(to_check)) == [tmp_path / '123.txt']
+        assert list(tracker.changed_files(to_check)) == [tmp_path / '123.txt']


### PR DESCRIPTION
The ChangeTracker used to store function hashes and compare them.

The `is_file_new_or_changed()` and `is_any_file_new_or_changed()` methods would check the hashes of the source code, though the method names might not suggest this. There was a flag, `check_calling_functions` that was `True` by default.

Testing showed that the `data_loader.navigation` module used `ChangeTracker.is_any_function_changed()` which could never be true. The `super_nav_details` and `super_nav_details_edges` collections would be populated anyway so I've removed that check.

I've added a migration to remove the `function_hashes` and removed any code relating to the collection, associated methods and their tests.

This completes issue #3486