### PR TITLE
Deploying for production - fix errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMPOSE     := docker-compose -f docker-compose.yml
+COMPOSE     := docker compose -f docker-compose.yml
 COMPOSEDEV  := $(COMPOSE) -f docker-compose.dev.yml
 COMPOSETEST := $(COMPOSE) -f docker-compose.test.yml
 COMPOSEPROD := $(COMPOSE) -f docker-compose.prod.yml
@@ -52,7 +52,7 @@ install-requirements:
 # Starts containers so that we are ready to run tests in them.
 prepare-tests:
 	@make create-network
-	-@docker-compose -f docker-compose.yml -f docker-compose.test.yml up -d
+	-@docker compose -f docker-compose.yml -f docker-compose.test.yml up -d
 	@echo "waiting for all services to fully start"
 	@bash wait_for_flask.sh
 # Run tests
@@ -63,7 +63,7 @@ test-server:
 	@docker exec -t sc-flask pytest server/
 
 test-api:
-	docker-compose run --entrypoint "python /opt/sc/api-tester/run-tests.py" sc-api-tester
+	docker compose run --entrypoint "python /opt/sc/api-tester/run-tests.py" sc-api-tester
 
 migrate:
 	@docker exec -t sc-flask bash -c "cd server && python manage.py migrate"
@@ -92,10 +92,10 @@ list_routes:
 	@docker exec -t sc-flask bash -c "cd server && python manage.py list_routes"
 
 rebuild-frontend:
-	docker-compose run sc-frontend npm run build
+	docker compose run sc-frontend npm run build
 
 bundle-analyzer:
-	docker-compose run sc-frontend npm run build --report
+	docker compose run sc-frontend npm run build --report
 
 rebuild-static-pages:
 	cd client && npm run extract-static-strings

--- a/server/server/search/texts.py
+++ b/server/server/search/texts.py
@@ -350,7 +350,7 @@ def import_texts_to_arangodb():
         "ro", "ru", "si", "sk", "sl", "sld", "sr", "sv", "ta", "th",
         "uig", "vi", "vu", "xto"
     ]
-    languages = sorted(languages, key=lambda x: order.index(x["uid"]))
+    # languages = sorted(languages, key=lambda x: order.index(x["uid"]))
 
     for lang in tqdm(languages):
         loader = TextLoader(lang)


### PR DESCRIPTION
Fix flow "Deploying for production" (https://github.com/suttacentral/suttacentral#deploying-for-production)

1. Compose V1 is no longer supported as of June 2023 — use docker compose instead of docker-compose.

2. Add the missing commit 9aec02e9d from the main branch, which was blocking execution of `make index-arangosearch`