### PR TITLE
Add tests for `import_bulk_load()` and fix defects

### DIFF
--- a/server/src/common/arangodb.py
+++ b/server/src/common/arangodb.py
@@ -37,13 +37,11 @@ def explain_error(coll, e, docs, kwargs):
 
 
 def import_bulk_logged(self, docs, wipe=False, *args, **kwargs):
-    if 'overwrite' in args:
+    if 'overwrite' in kwargs:
         raise ValueError('Overwrite not allowed as it is ambiguous, use "wipe=True" to clear collection')
     try:
-        results = self.import_bulk(docs, overwrite=wipe, *args, **kwargs)
+        _ = self.import_bulk(docs, overwrite=wipe, *args, **kwargs)
     except DocumentInsertError as e:
-        logging.error(kwargs)
-
         explained = explain_error(self, e, docs, kwargs)
         if not explained:
             logging.error(
@@ -53,16 +51,6 @@ def import_bulk_logged(self, docs, wipe=False, *args, **kwargs):
     except Exception as e:
         logging.error(f'{self.name}: error inserting documents: {e}: {docs}')
         raise
-
-    for outcome, doc in zip(results, docs):
-        if isinstance(outcome, Exception):
-            if '_key' in doc:
-                if doc["_key"] in outcome.error_message:
-                    logging.error(f'Error inserting document: {outcome.error_message}')
-                else:
-                    logging.error(f'Error inserting document: {outcome.error_message}; key: {doc["_key"]}')
-            else:
-                logging.error(f'Error inserting document: {outcome.error_message}, {doc}')
 
 
 StandardCollection.import_bulk_logged = import_bulk_logged

--- a/server/tests/common/test_arangodb.py
+++ b/server/tests/common/test_arangodb.py
@@ -85,6 +85,9 @@ def duplicates() -> list[dict]:
 
 
 class TestImportBulkLogged:
+    def test_can_import_no_documents(self, collection):
+        collection.import_bulk_logged([])
+
     def test_can_import_valid_documents(self, collection, two_documents):
         collection.import_bulk_logged(two_documents)
         assert collection.count() == 2

--- a/server/tests/common/test_arangodb.py
+++ b/server/tests/common/test_arangodb.py
@@ -125,9 +125,8 @@ class TestImportBulkLogged:
 
         assert "already in the collection" in caplog.messages[0]
 
-    def test_cant_explain_bad_attribute_name(self, collection, caplog):
-        bad_attribute_name = {'_key': 'jude-the-obscure', 'name': 'Jude the Obscure', 'colour': 'apricot'}
+    def test_cant_explain_single_document_instead_of_list(self, collection, one_document, caplog):
         with pytest.raises(DocumentInsertError):
-            collection.import_bulk_logged(bad_attribute_name)
+            collection.import_bulk_logged(one_document)
 
         assert "you may proceed to panic and/or despair" in caplog.messages[0]

--- a/server/tests/common/test_arangodb.py
+++ b/server/tests/common/test_arangodb.py
@@ -1,8 +1,13 @@
+from typing import Generator
+
 import pytest
-from arango import ArangoClient
-from arango.database import Database
+from arango import ArangoClient, DocumentInsertError, Response
+from arango.collection import StandardCollection
+from arango.database import Database, StandardDatabase
+from arango.request import Request
 
 from common import arangodb
+from common.arangodb import explain_error
 from common.utils import app_context
 
 
@@ -31,3 +36,111 @@ class TestArangoDB:
 
     def test_db(self, arango):
         assert isinstance(arango.db, Database)
+
+
+@pytest.fixture
+def client() -> ArangoClient:
+    return ArangoClient()
+
+
+@pytest.fixture
+def sys_db(client) -> StandardDatabase:
+    return client.db('_system', username='root', password='test')
+
+
+@pytest.fixture
+def database(client, sys_db) -> Generator[StandardDatabase, None, None]:
+    db_name = 'arangodb_test'
+    if sys_db.has_database(db_name):
+        sys_db.delete_database(db_name)
+    sys_db.create_database(db_name)
+    yield client.db(db_name, username='root', password='test')
+    sys_db.delete_database(db_name)
+
+
+@pytest.fixture
+def collection(database) -> StandardCollection:
+    return database.create_collection('roses')
+
+
+@pytest.fixture
+def one_document() -> dict:
+    return {'_key': 'bright-spirit', 'name': 'Bright Spirit', 'colour': 'salmon and gold'}
+
+
+@pytest.fixture
+def two_documents() -> list[dict]:
+    return [
+        {'_key': 'mr-lincoln', 'name': 'Mr Lincoln', 'colour': 'red'},
+        {'_key': 'charles-darwin', 'name': 'Charles Darwin', 'colour': 'yellow'},
+    ]
+
+
+@pytest.fixture
+def duplicates() -> list[dict]:
+    return [
+        {'_key': 'mr-lincoln', 'name': 'Mr Lincoln', 'colour': 'red'},
+        {'_key': 'mr-lincoln', 'name': 'Mr Lincoln', 'colour': 'red'},
+    ]
+
+
+@pytest.fixture
+def bad_attribute_name() -> dict:
+    return {'_key': 'jude-the-obscure', 'name': 'Jude the Obscure', 'colour': 'apricot'}
+
+
+class TestImportBulkLogged:
+    def test_can_import_valid_documents(self, collection, two_documents):
+        collection.import_bulk_logged(two_documents)
+        assert collection.count() == 2
+
+    def test_passing_overwrite_results_in_type_error(self, collection, two_documents):
+        with pytest.raises(TypeError):
+            collection.import_bulk_logged(two_documents, overwrite=True)
+
+    def test_does_not_delete_existing_documents_by_default(self, collection, two_documents, one_document):
+        collection.insert(one_document)
+        collection.import_bulk_logged(two_documents)
+        assert collection.count() == 3
+
+    def test_deletes_existing_documents_when_wipe_is_true(self, collection, two_documents, one_document):
+        collection.insert(one_document)
+        collection.import_bulk_logged(two_documents, wipe=True)
+        assert collection.count() == 2
+
+    def test_explains_key_contains_illegal_characters(self, collection, caplog):
+        bad_key = [{'_key': 'gallipoli?century', 'name': 'Gallipoli Century', 'colour': 'deep red'}]
+
+        with pytest.raises(DocumentInsertError):
+            collection.import_bulk_logged(bad_key)
+
+        assert caplog.messages[0] == "{}"
+        assert "contains illegal characters" in caplog.messages[1]
+
+    def test_explains_unique_constraint_violated(self, collection, duplicates, caplog):
+        duplicates = [
+            {'_key': 'mr-lincoln', 'name': 'Mr Lincoln', 'colour': 'red'},
+            {'_key': 'mr-lincoln', 'name': 'Mr Lincoln', 'colour': 'red'},
+        ]
+
+        with pytest.raises(DocumentInsertError):
+            collection.import_bulk_logged(duplicates)
+
+        assert caplog.messages[0] == "{}"
+        assert "unique constraint violated" in caplog.messages[1]
+
+    def test_explains_already_in_collection(self, collection, two_documents, caplog):
+        collection.import_bulk_logged(two_documents)
+
+        with pytest.raises(DocumentInsertError):
+            collection.import_bulk_logged(two_documents)
+
+        assert caplog.messages[0] == "{}"
+        assert "already in the collection" in caplog.messages[1]
+
+    def test_cant_explain_bad_attribute_name(self, collection, bad_attribute_name, caplog):
+        with pytest.raises(DocumentInsertError):
+            collection.import_bulk_logged(bad_attribute_name)
+
+        assert caplog.messages[0] == "{}"
+        assert "you may proceed to panic and/or despair" in caplog.messages[1]

--- a/server/tests/common/test_arangodb.py
+++ b/server/tests/common/test_arangodb.py
@@ -76,14 +76,6 @@ def two_documents() -> list[dict]:
     ]
 
 
-@pytest.fixture
-def duplicates() -> list[dict]:
-    return [
-        {'_key': 'mr-lincoln', 'name': 'Mr Lincoln', 'colour': 'red'},
-        {'_key': 'mr-lincoln', 'name': 'Mr Lincoln', 'colour': 'red'},
-    ]
-
-
 class TestImportBulkLogged:
     def test_can_import_no_documents(self, collection):
         collection.import_bulk_logged([])
@@ -114,7 +106,7 @@ class TestImportBulkLogged:
 
         assert "contains illegal characters" in caplog.messages[0]
 
-    def test_explains_unique_constraint_violated(self, collection, duplicates, caplog):
+    def test_explains_unique_constraint_violated(self, collection, caplog):
         duplicates = [
             {'_key': 'mr-lincoln', 'name': 'Mr Lincoln', 'colour': 'red'},
             {'_key': 'mr-lincoln', 'name': 'Mr Lincoln', 'colour': 'red'},

--- a/server/tests/common/test_arangodb.py
+++ b/server/tests/common/test_arangodb.py
@@ -84,18 +84,13 @@ def duplicates() -> list[dict]:
     ]
 
 
-@pytest.fixture
-def bad_attribute_name() -> dict:
-    return {'_key': 'jude-the-obscure', 'name': 'Jude the Obscure', 'colour': 'apricot'}
-
-
 class TestImportBulkLogged:
     def test_can_import_valid_documents(self, collection, two_documents):
         collection.import_bulk_logged(two_documents)
         assert collection.count() == 2
 
     def test_passing_overwrite_results_in_type_error(self, collection, two_documents):
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError, match='Overwrite not allowed'):
             collection.import_bulk_logged(two_documents, overwrite=True)
 
     def test_does_not_delete_existing_documents_by_default(self, collection, two_documents, one_document):
@@ -114,8 +109,7 @@ class TestImportBulkLogged:
         with pytest.raises(DocumentInsertError):
             collection.import_bulk_logged(bad_key)
 
-        assert caplog.messages[0] == "{}"
-        assert "contains illegal characters" in caplog.messages[1]
+        assert "contains illegal characters" in caplog.messages[0]
 
     def test_explains_unique_constraint_violated(self, collection, duplicates, caplog):
         duplicates = [
@@ -126,8 +120,7 @@ class TestImportBulkLogged:
         with pytest.raises(DocumentInsertError):
             collection.import_bulk_logged(duplicates)
 
-        assert caplog.messages[0] == "{}"
-        assert "unique constraint violated" in caplog.messages[1]
+        assert "unique constraint violated" in caplog.messages[0]
 
     def test_explains_already_in_collection(self, collection, two_documents, caplog):
         collection.import_bulk_logged(two_documents)
@@ -135,12 +128,11 @@ class TestImportBulkLogged:
         with pytest.raises(DocumentInsertError):
             collection.import_bulk_logged(two_documents)
 
-        assert caplog.messages[0] == "{}"
-        assert "already in the collection" in caplog.messages[1]
+        assert "already in the collection" in caplog.messages[0]
 
-    def test_cant_explain_bad_attribute_name(self, collection, bad_attribute_name, caplog):
+    def test_cant_explain_bad_attribute_name(self, collection, caplog):
+        bad_attribute_name = {'_key': 'jude-the-obscure', 'name': 'Jude the Obscure', 'colour': 'apricot'}
         with pytest.raises(DocumentInsertError):
             collection.import_bulk_logged(bad_attribute_name)
 
-        assert caplog.messages[0] == "{}"
-        assert "you may proceed to panic and/or despair" in caplog.messages[1]
+        assert "you may proceed to panic and/or despair" in caplog.messages[0]


### PR DESCRIPTION
This is the start of work for issue #3618. 

I've written unit tests for the function and discovered a few issues along the way:

- It checks for `overwrite` parameter in `args` rather than `kwargs`.
- The `kwargs` variable is logged, probably for debugging and then forgotten.
- An attempt was made to use `insert_many()` and then abandoned. Some code remained that was unreachable.

These have been fixed now.