### PR TITLE
Introduce `Collection` wrapper class

### DIFF
--- a/server/src/common/collections.py
+++ b/server/src/common/collections.py
@@ -36,3 +36,6 @@ class Collection:
 
     def documents(self) -> Iterator[Any]:
         yield from (doc for doc in self._collection.all())
+
+    def clear(self) -> None:
+        self._collection.truncate()

--- a/server/src/common/collections.py
+++ b/server/src/common/collections.py
@@ -1,0 +1,35 @@
+from collections.abc import Sequence
+from typing import Any
+
+from arango.collection import StandardCollection
+from arango.database import StandardDatabase
+
+from common.arangodb import get_db
+from common.utils import current_app
+
+
+def database() -> StandardDatabase:
+    app = current_app()
+    with app.app_context():
+        return get_db()  # type: ignore
+
+
+class Collection:
+    """ SuttaCentral wrapper class for ArangoDB's collection API.
+    Exposes required functionality whilst hiding the rest.
+    """
+    def __init__(self, name: str):
+        self._collection: StandardCollection = database()[name]
+
+    @property
+    def name(self) -> str:
+        return self._collection.name
+
+    def recreate(self, documents: Sequence[dict[str, Any]]) -> None:
+        self._collection.import_bulk_logged(documents, wipe=True)
+
+    def __len__(self) -> int:
+        return len(self._collection)
+
+    def keys(self):
+        return self._collection.keys()

--- a/server/src/common/collections.py
+++ b/server/src/common/collections.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Sequence, Iterator
 from typing import Any
 
 from arango.collection import StandardCollection
@@ -31,5 +31,5 @@ class Collection:
     def __len__(self) -> int:
         return len(self._collection)
 
-    def keys(self):
-        return self._collection.keys()
+    def keys(self) -> Iterator[str]:
+        yield from (str(key) for key in self._collection.keys())

--- a/server/src/common/collections.py
+++ b/server/src/common/collections.py
@@ -33,3 +33,6 @@ class Collection:
 
     def keys(self) -> Iterator[str]:
         yield from (str(key) for key in self._collection.keys())
+
+    def documents(self) -> Iterator[Any]:
+        yield from (doc for doc in self._collection.all())

--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -780,7 +780,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     paragraphs.load_paragraphs(db, additional_info_dir)
 
     printer.print_stage("Loading biblio from additional_info")
-    biblio.load_biblios(db, additional_info_dir)
+    biblio.load_biblios(additional_info_dir)
 
     printer.print_stage("Loading epigraphs from additional_info")
     homepage.load_epigraphs(db, additional_info_dir)

--- a/server/src/data_loader/biblio.py
+++ b/server/src/data_loader/biblio.py
@@ -1,10 +1,9 @@
 from pathlib import Path
 
 from common.collections import Collection
-from .util import json_load
+from data_loader.util import json_load
 
 
-def load_biblios(db, additional_info_dir: Path):
-    print('Loading biblio data')
+def load_biblios(additional_info_dir: Path):
     data = json_load(additional_info_dir / 'biblio.json')
     Collection('biblios').recreate(data)

--- a/server/src/data_loader/biblio.py
+++ b/server/src/data_loader/biblio.py
@@ -1,12 +1,10 @@
 from pathlib import Path
 
+from common.collections import Collection
 from .util import json_load
 
 
 def load_biblios(db, additional_info_dir: Path):
     print('Loading biblio data')
-
-    biblio_collection = db['biblios']
     data = json_load(additional_info_dir / 'biblio.json')
-
-    biblio_collection.import_bulk_logged(data, wipe=True)
+    Collection('biblios').recreate(data)

--- a/server/tests/common/test_collections.py
+++ b/server/tests/common/test_collections.py
@@ -43,3 +43,10 @@ class TestCollection:
         documents = [BLUE_MOON, BRASS_BAND, CHINA_DOLL]
         collection.recreate(documents)
         assert set(doc['_key'] for doc in documents) == set(collection.keys())
+
+    def test_documents_are_retrievable(self):
+        collection = Collection(COLLECTION_NAME)
+        documents = [BLUE_MOON, BRASS_BAND, CHINA_DOLL]
+        collection.recreate(documents)
+        assert {doc['name'] for doc in collection.documents()} == {doc['name'] for doc in documents}
+        assert {doc['colour'] for doc in collection.documents()} == {doc['colour'] for doc in documents}

--- a/server/tests/common/test_collections.py
+++ b/server/tests/common/test_collections.py
@@ -50,3 +50,16 @@ class TestCollection:
         collection.recreate(documents)
         assert {doc['name'] for doc in collection.documents()} == {doc['name'] for doc in documents}
         assert {doc['colour'] for doc in collection.documents()} == {doc['colour'] for doc in documents}
+
+    def test_clear_empty_collection(self):
+        collection = Collection(COLLECTION_NAME)
+        collection.clear()
+        assert len(collection) == 0
+
+    def test_clear_populated_collection(self):
+        collection = Collection(COLLECTION_NAME)
+        documents = [BLUE_MOON, BRASS_BAND, CHINA_DOLL]
+        collection.recreate(documents)
+        collection.clear()
+        assert len(collection) == 0
+

--- a/server/tests/common/test_collections.py
+++ b/server/tests/common/test_collections.py
@@ -1,0 +1,45 @@
+import pytest
+
+from common.collections import Collection, database
+import pytest
+
+from common.collections import Collection, database
+
+COLLECTION_NAME = 'roses'
+
+BLUE_MOON = {'_key': 'blue-moon', 'name': 'Blue Moon', 'colour': 'ice lavender'}
+BRASS_BAND = {'_key': 'brass-band', 'name': 'Brass Band', 'colour': 'apricot with soft yellow reverse'}
+CHINA_DOLL = {'_key': 'china-doll', 'name': 'China Doll', 'colour': 'china pink'}
+GOLD_BUNNY = {'_key': 'gold-bunny', 'name': 'Gold Bunny', 'colour': 'soft gold'}
+
+
+@pytest.fixture(autouse=True)
+def create():
+    if not database().has_collection(COLLECTION_NAME):
+        database().create_collection(COLLECTION_NAME)
+    yield
+    database().delete_collection(COLLECTION_NAME)
+
+
+class TestCollection:
+    def test_open_collection(self):
+        collection = Collection(COLLECTION_NAME)
+        assert collection.name == COLLECTION_NAME
+
+    def test_recreate_with_no_documents(self):
+        collection = Collection(COLLECTION_NAME)
+        collection.recreate([])
+        assert len(collection) == 0
+
+    def test_recreate_adds_documents(self):
+        collection = Collection(COLLECTION_NAME)
+        collection.recreate([BLUE_MOON, BRASS_BAND, CHINA_DOLL])
+        expected_keys = {BLUE_MOON['_key'], BRASS_BAND['_key'], CHINA_DOLL['_key']}
+        assert expected_keys == set(collection.keys())
+
+    def test_recreate_replaces_documents(self):
+        collection = Collection(COLLECTION_NAME)
+        collection.recreate([GOLD_BUNNY])
+        collection.recreate([BLUE_MOON, BRASS_BAND, CHINA_DOLL])
+        expected_keys = {BLUE_MOON['_key'], BRASS_BAND['_key'], CHINA_DOLL['_key']}
+        assert expected_keys == set(collection.keys())

--- a/server/tests/common/test_collections.py
+++ b/server/tests/common/test_collections.py
@@ -33,13 +33,13 @@ class TestCollection:
 
     def test_recreate_adds_documents(self):
         collection = Collection(COLLECTION_NAME)
-        collection.recreate([BLUE_MOON, BRASS_BAND, CHINA_DOLL])
-        expected_keys = {BLUE_MOON['_key'], BRASS_BAND['_key'], CHINA_DOLL['_key']}
-        assert expected_keys == set(collection.keys())
+        documents = [BLUE_MOON, BRASS_BAND, CHINA_DOLL]
+        collection.recreate(documents)
+        assert set(doc['_key'] for doc in documents) == set(collection.keys())
 
     def test_recreate_replaces_documents(self):
         collection = Collection(COLLECTION_NAME)
         collection.recreate([GOLD_BUNNY])
-        collection.recreate([BLUE_MOON, BRASS_BAND, CHINA_DOLL])
-        expected_keys = {BLUE_MOON['_key'], BRASS_BAND['_key'], CHINA_DOLL['_key']}
-        assert expected_keys == set(collection.keys())
+        documents = [BLUE_MOON, BRASS_BAND, CHINA_DOLL]
+        collection.recreate(documents)
+        assert set(doc['_key'] for doc in documents) == set(collection.keys())

--- a/server/tests/data_loader/test_biblio.py
+++ b/server/tests/data_loader/test_biblio.py
@@ -1,10 +1,9 @@
 import json
-from bisect import bisect_left
 from pathlib import Path
 
 import pytest
 
-from common.collections import database, Collection
+from common.collections import Collection
 from data_loader.biblio import load_biblios
 
 
@@ -36,5 +35,5 @@ def biblios_data(tmp_path) -> Path:
 
 
 def test_load_biblios(biblios_data):
-    load_biblios(database(), biblios_data)
+    load_biblios(biblios_data)
     assert len(Collection('biblios')) == 3

--- a/server/tests/data_loader/test_biblio.py
+++ b/server/tests/data_loader/test_biblio.py
@@ -1,0 +1,40 @@
+import json
+from bisect import bisect_left
+from pathlib import Path
+
+import pytest
+
+from common.collections import database, Collection
+from data_loader.biblio import load_biblios
+
+
+@pytest.fixture
+def biblios_data(tmp_path) -> Path:
+    data = [
+        {
+            "uid": "xyz123",
+            "name": "Smith 1986",
+            "text": "<span class='author'>SMITH, Freddy</span> 1986. A book about nothing."
+        },
+        {
+            "uid": "xyz124",
+            "name": "Smith 1986",
+            "text": "<span class='author'>SMITH, Freddy</span> 1986. A book about nothing."
+        },
+        {
+            "uid": "xyz125",
+            "name": "Smith 1986",
+            "text": "<span class='author'>SMITH, Freddy</span> 1986. A book about nothing."
+        },
+    ]
+
+    path = tmp_path / 'biblio.json'
+    with path.open("w") as f:
+        json.dump(data, f)
+
+    return tmp_path
+
+
+def test_load_biblios(biblios_data):
+    load_biblios(database(), biblios_data)
+    assert len(Collection('biblios')) == 3


### PR DESCRIPTION
Part of Issue #3618 

- Create a wrapper class for collections
- Update first call site of `import_bulk_load()` to use the new class
- Added a nifty `database()` function that avoids clients of `Collection` knowing about our dependence on Flask.

The latter will likely end up in `common.arangodb` but I'll wait until #3623 is merged.