### PR TITLE
Paragraphs uses collections

### DIFF
--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -777,7 +777,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     currencies.load_currencies(db, additional_info_dir)
 
     printer.print_stage("Loading paragraphs from additional_info")
-    paragraphs.load_paragraphs(db, additional_info_dir)
+    paragraphs.load_paragraphs(additional_info_dir)
 
     printer.print_stage("Loading biblio from additional_info")
     biblio.load_biblios(additional_info_dir)

--- a/server/src/data_loader/paragraphs.py
+++ b/server/src/data_loader/paragraphs.py
@@ -1,11 +1,9 @@
 from pathlib import Path
 
-from .util import json_load
+from common.collections import Collection
+from data_loader.util import json_load
 
 
-def load_paragraphs(db, additional_info_dir: Path):
-    print('Loading paragraphs')
-
-    paragraphs_collection = db['paragraphs']
+def load_paragraphs(additional_info_dir: Path):
     data = json_load(additional_info_dir / 'paragraphs.json')
-    paragraphs_collection.import_bulk_logged(data, wipe=True)
+    Collection('paragraphs').recreate(data)

--- a/server/tests/data_loader/test_paragraphs.py
+++ b/server/tests/data_loader/test_paragraphs.py
@@ -50,13 +50,13 @@ class TestLoadParagraphs:
         db = database()
         paragraphs = Collection('paragraphs')
         paragraphs.clear()
-        load_paragraphs(db, two_records)
+        load_paragraphs(two_records)
         assert sorted(["Acip-vp", "Adhik-v"]) == sorted(doc['acronym'] for doc in paragraphs.documents())
 
     def test_deletes_existing_records_before_populating(self, one_record, two_records):
         db = database()
         paragraphs = Collection('paragraphs')
         paragraphs.clear()
-        load_paragraphs(db, one_record)
-        load_paragraphs(db, two_records)
+        load_paragraphs(one_record)
+        load_paragraphs(two_records)
         assert sorted(["Acip-vp", "Adhik-v"]) == sorted(doc['acronym'] for doc in paragraphs.documents())

--- a/server/tests/data_loader/test_paragraphs.py
+++ b/server/tests/data_loader/test_paragraphs.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from common.collections import database, Collection
+from data_loader.paragraphs import load_paragraphs
+
+CSSD = {
+    "uid": "cscd",
+    "acronym": "CSCD",
+    "description": "Paragraph numbers in Chaṭṭha Saṅgāyana CD (tipitaka.org), Vipassana Research Institute, 2008"
+}
+
+ACIP_VP = {
+    "uid": "acip-vp",
+    "acronym": "Acip-vp",
+    "description": "Asian Classics Input Project."
+}
+
+ADHIK_V = {
+    "uid": "adh-v",
+    "acronym": "Adhik-v",
+    "description": "Paragraph numbers in Adhikaraṇavastu, Gnoli 1978."
+}
+
+
+@pytest.fixture
+def one_record(tmp_path) -> Path:
+    data = [CSSD]
+    path = tmp_path / 'paragraphs.json'
+    with path.open("w") as f:
+        json.dump(data, f)
+
+    return tmp_path
+
+
+@pytest.fixture
+def two_records(tmp_path) -> Path:
+    data = [ACIP_VP, ADHIK_V]
+    path = tmp_path / 'paragraphs.json'
+    with path.open("w") as f:
+        json.dump(data, f)
+
+    return tmp_path
+
+
+class TestLoadParagraphs:
+    def test_populates_empty_collection(self, two_records):
+        db = database()
+        paragraphs = Collection('paragraphs')
+        paragraphs.clear()
+        load_paragraphs(db, two_records)
+        assert sorted(["Acip-vp", "Adhik-v"]) == sorted(doc['acronym'] for doc in paragraphs.documents())
+
+    def test_deletes_existing_records_before_populating(self, one_record, two_records):
+        db = database()
+        paragraphs = Collection('paragraphs')
+        paragraphs.clear()
+        load_paragraphs(db, one_record)
+        load_paragraphs(db, two_records)
+        assert sorted(["Acip-vp", "Adhik-v"]) == sorted(doc['acronym'] for doc in paragraphs.documents())


### PR DESCRIPTION
Part of Issue #3618

I refactored another call site for `import_bulk_load()` where `wipe=True`

Also some tidying:

- Use absolute imports
- Remove redundant `print()`