### PR TITLE
Use Collection in load_bilara_author_edition() and tidy.

### DIFF
--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -742,7 +742,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     update_root_title()
 
     printer.print_stage('Load bilara_author_edition from sc_bilara_data')
-    sc_bilara_data.load_bilara_author_edition(db, sc_bilara_data_dir)
+    sc_bilara_data.load_bilara_author_edition(sc_bilara_data_dir)
 
     printer.print_stage("Generating and loading relationships")
     generate_relationship_edges(

--- a/server/src/data_loader/sc_bilara_data.py
+++ b/server/src/data_loader/sc_bilara_data.py
@@ -4,6 +4,7 @@ from typing import Dict, Set, List
 
 from arango.database import Database
 
+from common.collections import Collection
 from data_loader.languages import process_languages
 from data_loader.util import json_load
 import shutil
@@ -145,7 +146,7 @@ def load_texts(db: Database, sc_bilara_data_dir: Path) -> None:
     docs = []
     lang_folder_idx = len(sc_bilara_data_dir.parts) + 1
 
-    folders: List[Path] = {folder for folder in sc_bilara_data_dir.glob('*') 
+    folders: List[Path] = {folder for folder in sc_bilara_data_dir.glob('*')
                            if not folder.name.startswith(('_', '.')) and not folder.name in {'name', 'blurb'}}
 
     files: List[Path] = []
@@ -177,14 +178,13 @@ def load_texts(db: Database, sc_bilara_data_dir: Path) -> None:
     db['sc_bilara_texts'].import_bulk(valid_texts)
 
 
-def load_bilara_author_edition(db: Database, sc_bilara_data_dir: Path) -> None:
-    db['bilara_author_edition'].truncate()
-    docs = load_bilara_author(db, sc_bilara_data_dir) + \
-        load_bilara_edition(db, sc_bilara_data_dir)
-    db.collection('bilara_author_edition').import_bulk_logged(docs, wipe=True)
+def load_bilara_author_edition(sc_bilara_data_dir: Path) -> None:
+    authors = load_bilara_author(sc_bilara_data_dir)
+    editions = load_bilara_edition(sc_bilara_data_dir)
+    Collection('bilara_author_edition').recreate(authors + editions)
 
 
-def load_bilara_author(db: Database, sc_bilara_data_dir: Path) -> List[dict]:
+def load_bilara_author(sc_bilara_data_dir: Path) -> List[dict]:
     author_file = sc_bilara_data_dir / '_author.json'
     authors: Dict[str, dict] = json_load(author_file)
 
@@ -196,7 +196,7 @@ def load_bilara_author(db: Database, sc_bilara_data_dir: Path) -> List[dict]:
     } for key, value in authors.items()]
 
 
-def load_bilara_edition(db: Database, sc_bilara_data_dir: Path) -> List[dict]:
+def load_bilara_edition(sc_bilara_data_dir: Path) -> List[dict]:
     edition_file = sc_bilara_data_dir / '_edition.json'
     editions: Dict[str, dict] = json_load(edition_file)
 

--- a/server/tests/data_loader/test_sc_bilara_data.py
+++ b/server/tests/data_loader/test_sc_bilara_data.py
@@ -1,0 +1,122 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from common.collections import database, Collection
+from data_loader.sc_bilara_data import load_bilara_author, load_bilara_edition, load_bilara_author_edition
+
+ONE_AUTHOR = {
+    'sujato': {'type': 'translator', 'name': 'Bhikkhu Sujato'},
+}
+
+THREE_AUTHORS = {
+    'brahmali': {'type': 'translator', 'name': 'Bhikkhu Brahmali'},
+    'karunika': {'type': 'translator', 'name': 'Ayyā Kāruṇikā, Ayyā Therikā'},
+    'sabbamitta': {'type': 'translator', 'name': 'Sabbamitta'},
+}
+
+ONE_EDITION = {
+    "ms": {
+        "type": "edition",
+        "is_root": True,
+        "language": "pli"
+    },
+}
+
+THREE_EDITIONS = {
+    "bj": {
+        "type": "edition",
+        "is_root": True,
+        "language": "pli"
+      },
+    "cbeta": {
+        "type": "edition",
+        "is_root": True,
+        "language": "lzh"
+      },
+    "pts": {
+        "type": "edition",
+        "is_root": True,
+        "language": "pra"
+      },
+}
+
+
+@pytest.fixture
+def one_author(tmp_path) -> Path:
+    path = tmp_path / '_author.json'
+    with path.open("w") as f:
+        json.dump(ONE_AUTHOR, f)
+    return tmp_path
+
+
+@pytest.fixture
+def one_edition(tmp_path) -> Path:
+    path = tmp_path / '_edition.json'
+    with path.open("w") as f:
+        json.dump(ONE_EDITION, f)
+    return tmp_path
+
+
+@pytest.fixture
+def one_author_three_editions(tmp_path) -> Path:
+    path = tmp_path / '_author.json'
+    with path.open("w") as f:
+        json.dump(ONE_AUTHOR, f)
+
+    path = tmp_path / '_edition.json'
+    with path.open("w") as f:
+        json.dump(THREE_EDITIONS, f)
+
+    return tmp_path
+
+
+@pytest.fixture
+def three_authors_one_edition(tmp_path) -> Path:
+    path = tmp_path / '_author.json'
+    with path.open("w") as f:
+        json.dump(THREE_AUTHORS, f)
+
+    path = tmp_path / '_edition.json'
+    with path.open("w") as f:
+        json.dump(ONE_EDITION, f)
+
+    return tmp_path
+
+
+class TestLoadBilaraAuthorEdition:
+    def test_adds_authors_and_editions(self, one_author_three_editions):
+        db = database()
+        load_bilara_author_edition(one_author_three_editions)
+        uids = [doc['uid'] for doc in Collection('bilara_author_edition').documents()]
+        assert sorted(uids) == ['bj', 'cbeta', 'pts', 'sujato']
+
+    def test_clears_collection_before_repopulating(self, one_author_three_editions, three_authors_one_edition):
+        db = database()
+        load_bilara_author_edition(one_author_three_editions)
+        load_bilara_author_edition(three_authors_one_edition)
+        uids = [doc['uid'] for doc in Collection('bilara_author_edition').documents()]
+        assert sorted(uids) == ['brahmali', 'karunika', 'ms', 'sabbamitta']
+
+
+class TestLoadBilaraAuthor:
+    def test_author_transform(self, one_author):
+        author = load_bilara_author(one_author)[0]
+        assert author == {
+            'long_name': 'Bhikkhu Sujato',
+            'short_name': 'sujato',
+            'type': 'author',
+            'uid': 'sujato'
+        }
+
+
+class TestLoadBilaraEdition:
+    def test_edition_transform(self, one_edition):
+        edition = load_bilara_edition(one_edition)[0]
+        assert edition == {
+            'type': 'edition',
+            'uid': 'ms',
+            'language': 'pli',
+            'is_root': True,
+        }


### PR DESCRIPTION
Part of Issue #3618

I wrote the tests first, then refactored using the `Collection` class. 

Along the way I discovered that we store two types of documents in the `bilara_author_edition`. Is is populated by transforming two files that preexisted in `bilara-data`. 

This is clearer than it was before. We can definitely improve the domain model here.