### PR TITLE
Loading guides files uses `Collection`

### DIFF
--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -14,6 +14,7 @@ from flask import current_app
 from tqdm import tqdm
 
 from common import arangodb
+from common.collections import Collection
 from common.queries import (
     BUILD_YELLOW_BRICK_ROAD,
     COUNT_YELLOW_BRICK_ROAD,
@@ -330,10 +331,9 @@ def make_yellow_brick_road(db: Database):
     db.aql.execute(COUNT_YELLOW_BRICK_ROAD)
 
 
-def load_guides_file(db: Database, guides_file: Path):
-    guides_content = json_load(guides_file)
-    db['guides'].truncate()
-    db.collection('guides').import_bulk(guides_content)
+def load_guides(file: Path) -> None:
+    docs = json_load(file)
+    Collection('guides').recreate(docs)
 
 
 def load_pali_reference_edition_file(db: Database, pali_reference_edition_file: Path):
@@ -691,7 +691,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     load_map_data(additional_info_dir, db)
 
     printer.print_stage('Loading guides.json')
-    load_guides_file(db, structure_dir / 'guides.json')
+    load_guides(structure_dir / 'guides.json')
 
     printer.print_stage('Loading pali_reference_edition.json')
     load_pali_reference_edition_file(db, misc_dir / 'pali_reference_edition.json')

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -1,10 +1,14 @@
+import json
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
 from common.arangodb import get_db, delete_db
+from common.collections import Collection, database
 from common.utils import current_app
 from data_loader import arangoload
+from data_loader.arangoload import load_guides_file
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -45,3 +49,62 @@ def test_do_entire_run(data_load_app):
         printer = arangoload.run(no_pull=False)
         assert len(printer.stages) == 51
         save_as_csv(printer.stages, "load-data-run.csv")
+
+
+class TestLoadGuidesFile:
+    @pytest.fixture
+    def empty_collection(self) -> Generator[Collection, None, None]:
+        coll = Collection('guides')
+        coll.clear()
+        yield coll
+        coll.clear()
+
+    @pytest.fixture
+    def with_existing_document(self, empty_collection):
+        empty_collection.recreate(
+            [
+                {
+                    'guide_uid': 'discourses-guide-sujato',
+                    'text_uid': 'sutta',
+                    'lang': 'en',
+                }
+            ]
+        )
+        return empty_collection
+
+    @pytest.fixture
+    def structure_dir(self, tmp_path) -> Path:
+        return tmp_path
+
+    @pytest.fixture
+    def file_location(self, structure_dir) -> Path:
+        return structure_dir / Path('guides.json')
+
+    @pytest.fixture
+    def data(self) -> list[dict]:
+        return [
+            {
+                'guide_uid': 'vinaya-guide-brahmali',
+                'text_uid': 'vinaya',
+                'lang': 'en'
+            },
+            {
+                'guide_uid': 'abhidhamma-guide-sujato',
+                'text_uid': 'abhidhamma',
+                'lang': 'en'
+            },
+        ]
+
+    @pytest.fixture
+    def with_data(self, file_location, data):
+        with file_location.open("w") as f:
+            json.dump(data, f)
+
+    def test_populates_empty_collection(self, empty_collection, with_data, file_location):
+        load_guides_file(database(), file_location)
+        assert sorted([doc['guide_uid'] for doc in Collection('guides').documents()]) == ['abhidhamma-guide-sujato', 'vinaya-guide-brahmali']
+
+    def test_recreates_collection(self, with_existing_document, with_data, file_location):
+        assert sorted([doc['guide_uid'] for doc in Collection('guides').documents()]) == ['discourses-guide-sujato']
+        load_guides_file(database(), file_location)
+        assert sorted([doc['guide_uid'] for doc in Collection('guides').documents()]) == ['abhidhamma-guide-sujato', 'vinaya-guide-brahmali']

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -8,7 +8,7 @@ from common.arangodb import get_db, delete_db
 from common.collections import Collection, database
 from common.utils import current_app
 from data_loader import arangoload
-from data_loader.arangoload import load_guides_file
+from data_loader.arangoload import load_guides
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -101,10 +101,10 @@ class TestLoadGuidesFile:
             json.dump(data, f)
 
     def test_populates_empty_collection(self, empty_collection, with_data, file_location):
-        load_guides_file(database(), file_location)
+        load_guides(file_location)
         assert sorted([doc['guide_uid'] for doc in Collection('guides').documents()]) == ['abhidhamma-guide-sujato', 'vinaya-guide-brahmali']
 
     def test_recreates_collection(self, with_existing_document, with_data, file_location):
         assert sorted([doc['guide_uid'] for doc in Collection('guides').documents()]) == ['discourses-guide-sujato']
-        load_guides_file(database(), file_location)
+        load_guides(file_location)
         assert sorted([doc['guide_uid'] for doc in Collection('guides').documents()]) == ['abhidhamma-guide-sujato', 'vinaya-guide-brahmali']


### PR DESCRIPTION
Added tests and refactored as part of issue #3618 

**Note:** At this point in `arangoload.py` we stop using `load_bulk_logged()` and just use `load_bulk()`. There will be a change in behavior as `Collection.recreate` uses `load_bulk_logged()`. At least now we're consistent.