### PR TITLE
Load pali reference edition file uses `Collection`

### DIFF
--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -14,6 +14,7 @@ from flask import current_app
 from tqdm import tqdm
 
 from common import arangodb
+from common.collections import Collection
 from common.queries import (
     BUILD_YELLOW_BRICK_ROAD,
     COUNT_YELLOW_BRICK_ROAD,
@@ -336,10 +337,9 @@ def load_guides_file(db: Database, guides_file: Path):
     db.collection('guides').import_bulk(guides_content)
 
 
-def load_pali_reference_edition_file(db: Database, pali_reference_edition_file: Path):
-    pali_reference_content = json_load(pali_reference_edition_file)
-    db['pali_reference_edition'].truncate()
-    db.collection('pali_reference_edition').import_bulk(pali_reference_content)
+def load_pali_reference_edition(file: Path) -> None:
+    docs = json_load(file)
+    Collection('pali_reference_edition').recreate(docs)
 
 
 def load_lzh_reference_edition_file(db: Database, lzh_reference_edition_file: Path):
@@ -694,7 +694,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     load_guides_file(db, structure_dir / 'guides.json')
 
     printer.print_stage('Loading pali_reference_edition.json')
-    load_pali_reference_edition_file(db, misc_dir / 'pali_reference_edition.json')
+    load_pali_reference_edition(misc_dir / 'pali_reference_edition.json')
 
     printer.print_stage('Loading lzh_reference_edition.json')
     load_lzh_reference_edition_file(db, misc_dir / 'lzh_reference_edition.json')

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -5,10 +5,10 @@ from typing import Generator
 import pytest
 
 from common.arangodb import get_db, delete_db
-from common.collections import Collection, database
+from common.collections import Collection
 from common.utils import current_app
 from data_loader import arangoload
-from data_loader.arangoload import load_pali_reference_edition_file
+from data_loader.arangoload import load_pali_reference_edition
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -108,10 +108,10 @@ class TestLoadPaliReferenceEdition:
             json.dump(data, f)
 
     def test_populates_empty_collection(self, empty_collection, with_data, file_location):
-        load_pali_reference_edition_file(database(), file_location)
+        load_pali_reference_edition(file_location)
         assert sorted([doc['edition_set'] for doc in Collection('pali_reference_edition').documents()]) == ['km', 'pts']
 
     def test_recreates_collection(self, with_existing_document, with_data, file_location):
         assert sorted([doc['edition_set'] for doc in Collection('pali_reference_edition').documents()]) == ['ms']
-        load_pali_reference_edition_file(database(), file_location)
+        load_pali_reference_edition(file_location)
         assert sorted([doc['edition_set'] for doc in Collection('pali_reference_edition').documents()]) == ['km', 'pts']

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -1,10 +1,14 @@
+import json
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
 from common.arangodb import get_db, delete_db
+from common.collections import Collection, database
 from common.utils import current_app
 from data_loader import arangoload
+from data_loader.arangoload import load_pali_reference_edition_file
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -45,3 +49,69 @@ def test_do_entire_run(data_load_app):
         printer = arangoload.run(no_pull=False)
         assert len(printer.stages) == 51
         save_as_csv(printer.stages, "load-data-run.csv")
+
+
+class TestLoadPaliReferenceEdition:
+    @pytest.fixture
+    def empty_collection(self) -> Generator[Collection, None, None]:
+        coll = Collection('pali_reference_edition')
+        coll.clear()
+        yield coll
+        coll.clear()
+
+    @pytest.fixture
+    def with_existing_document(self, empty_collection):
+        empty_collection.recreate(
+            [
+                {
+                    'edition_set': 'ms',
+                    'includes': 'ms',
+                    'name': 'Mahasaṅgīti Tipiṭaka, 2010'
+                },
+            ]
+        )
+        return empty_collection
+
+    @pytest.fixture
+    def misc_dir(self, tmp_path) -> Path:
+        return tmp_path
+
+    @pytest.fixture
+    def file_location(self, misc_dir) -> Path:
+        return misc_dir / Path('pali_reference_edition.json')
+
+    @pytest.fixture
+    def data(self) -> list[dict]:
+        return [
+            {
+                'edition_set': 'km',
+                'includes': 'km',
+                'name': 'Phratraipiṭakapāḷi (Cambodia), 1958–1969'
+            },
+            {
+                'edition_set': 'pts',
+                'includes': [
+                    'pts-cs',
+                    'pts-vp-pli',
+                    'pts-vp-pli1ed',
+                    'pts-vp-pli2ed',
+                    'pts-vp-en',
+                    'vnp'
+                ],
+                'name': 'Pali Text Society'
+            },
+        ]
+
+    @pytest.fixture
+    def with_data(self, file_location, data):
+        with file_location.open("w") as f:
+            json.dump(data, f)
+
+    def test_populates_empty_collection(self, empty_collection, with_data, file_location):
+        load_pali_reference_edition_file(database(), file_location)
+        assert sorted([doc['edition_set'] for doc in Collection('pali_reference_edition').documents()]) == ['km', 'pts']
+
+    def test_recreates_collection(self, with_existing_document, with_data, file_location):
+        assert sorted([doc['edition_set'] for doc in Collection('pali_reference_edition').documents()]) == ['ms']
+        load_pali_reference_edition_file(database(), file_location)
+        assert sorted([doc['edition_set'] for doc in Collection('pali_reference_edition').documents()]) == ['km', 'pts']


### PR DESCRIPTION
Added tests and refactored as part of issue #3618.

**Changed behavior:** this function originally used the stock `import_bulk()`