### PR TITLE
Load lzh reference edition file uses collection

### DIFF
--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -14,6 +14,7 @@ from flask import current_app
 from tqdm import tqdm
 
 from common import arangodb
+from common.collections import Collection
 from common.queries import (
     BUILD_YELLOW_BRICK_ROAD,
     COUNT_YELLOW_BRICK_ROAD,
@@ -342,10 +343,9 @@ def load_pali_reference_edition_file(db: Database, pali_reference_edition_file: 
     db.collection('pali_reference_edition').import_bulk(pali_reference_content)
 
 
-def load_lzh_reference_edition_file(db: Database, lzh_reference_edition_file: Path):
-    lzh_reference_content = json_load(lzh_reference_edition_file)
-    db['lzh_reference_edition'].truncate()
-    db.collection('lzh_reference_edition').import_bulk(lzh_reference_content)
+def load_lzh_reference_edition(file: Path) -> None:
+    docs = json_load(file)
+    Collection('lzh_reference_edition').recreate(docs)
 
 
 def load_root_edition_file(db: Database, root_edition_file: Path):
@@ -697,7 +697,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     load_pali_reference_edition_file(db, misc_dir / 'pali_reference_edition.json')
 
     printer.print_stage('Loading lzh_reference_edition.json')
-    load_lzh_reference_edition_file(db, misc_dir / 'lzh_reference_edition.json')
+    load_lzh_reference_edition(misc_dir / 'lzh_reference_edition.json')
 
     printer.print_stage('Loading root_edition.json')
     load_root_edition_file(db, misc_dir / 'root_edition.json')

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -1,10 +1,14 @@
+import json
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
 from common.arangodb import get_db, delete_db
+from common.collections import Collection, database
 from common.utils import current_app
 from data_loader import arangoload
+from data_loader.arangoload import load_lzh_reference_edition_file
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -45,3 +49,62 @@ def test_do_entire_run(data_load_app):
         printer = arangoload.run(no_pull=False)
         assert len(printer.stages) == 51
         save_as_csv(printer.stages, "load-data-run.csv")
+
+
+class TestLoadLzhReferenceEdition:
+    @pytest.fixture
+    def empty_collection(self) -> Generator[Collection, None, None]:
+        coll = Collection('lzh_reference_edition')
+        coll.clear()
+        yield coll
+        coll.clear()
+
+    @pytest.fixture
+    def with_existing_document(self, empty_collection):
+        empty_collection.recreate(
+            [
+                {
+                    "edition_set": "another",
+                    "includes": "abc",
+                    "name": "Some other edition of the Chinese"
+                },
+            ]
+        )
+        return empty_collection
+
+    @pytest.fixture
+    def misc_dir(self, tmp_path) -> Path:
+        return tmp_path
+
+    @pytest.fixture
+    def file_location(self, misc_dir) -> Path:
+        return misc_dir / Path('lzh_reference_edition.json')
+
+    @pytest.fixture
+    def data(self) -> list[dict]:
+        return [
+            {
+                "edition_set": "taisho",
+                "includes": "t",
+                "name": "The Taishō Tripiṭaka"
+            },
+            {
+                "edition_set": "yet",
+                "includes": "def",
+                "name": "Yet another edition of the Chinese"
+            },
+        ]
+
+    @pytest.fixture
+    def with_data(self, file_location, data):
+        with file_location.open("w") as f:
+            json.dump(data, f)
+
+    def test_populates_empty_collection(self, empty_collection, with_data, file_location):
+        load_lzh_reference_edition_file(database(), file_location)
+        assert sorted([doc['edition_set'] for doc in Collection('lzh_reference_edition').documents()]) == ['taisho', 'yet']
+
+    def test_recreates_collection(self, with_existing_document, with_data, file_location):
+        assert sorted([doc['edition_set'] for doc in Collection('lzh_reference_edition').documents()]) == ['another']
+        load_lzh_reference_edition_file(database(), file_location)
+        assert sorted([doc['edition_set'] for doc in Collection('lzh_reference_edition').documents()]) == ['taisho', 'yet']

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -8,7 +8,7 @@ from common.arangodb import get_db, delete_db
 from common.collections import Collection, database
 from common.utils import current_app
 from data_loader import arangoload
-from data_loader.arangoload import load_lzh_reference_edition_file
+from data_loader.arangoload import load_lzh_reference_edition
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -101,10 +101,10 @@ class TestLoadLzhReferenceEdition:
             json.dump(data, f)
 
     def test_populates_empty_collection(self, empty_collection, with_data, file_location):
-        load_lzh_reference_edition_file(database(), file_location)
+        load_lzh_reference_edition(file_location)
         assert sorted([doc['edition_set'] for doc in Collection('lzh_reference_edition').documents()]) == ['taisho', 'yet']
 
     def test_recreates_collection(self, with_existing_document, with_data, file_location):
         assert sorted([doc['edition_set'] for doc in Collection('lzh_reference_edition').documents()]) == ['another']
-        load_lzh_reference_edition_file(database(), file_location)
+        load_lzh_reference_edition(file_location)
         assert sorted([doc['edition_set'] for doc in Collection('lzh_reference_edition').documents()]) == ['taisho', 'yet']


### PR DESCRIPTION
Added tests and refactored as part of issue #3618.

Changed behavior: this function originally used the stock import_bulk()