### PR TITLE
Load text extra info file uses collection

### DIFF
--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -14,6 +14,7 @@ from flask import current_app
 from tqdm import tqdm
 
 from common import arangodb
+from common.collections import Collection
 from common.queries import (
     BUILD_YELLOW_BRICK_ROAD,
     COUNT_YELLOW_BRICK_ROAD,
@@ -354,10 +355,9 @@ def load_root_edition_file(db: Database, root_edition_file: Path):
     db.collection('root_edition').import_bulk(root_edition_content)
 
 
-def load_text_extra_info_file(db: Database, text_extra_info_file: Path):
+def load_text_extra_info(text_extra_info_file: Path) -> None:
     text_extra_info_content = json_load(text_extra_info_file)
-    db['text_extra_info'].truncate()
-    db.collection('text_extra_info').import_bulk(text_extra_info_content)
+    Collection('text_extra_info').recreate(text_extra_info_content)
 
 
 def load_shortcuts_file(db: Database, shortcuts_file: Path):
@@ -703,7 +703,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     load_root_edition_file(db, misc_dir / 'root_edition.json')
 
     printer.print_stage('Loading text_extra_info.json')
-    load_text_extra_info_file(db, structure_dir / 'text_extra_info.json')
+    load_text_extra_info(structure_dir / 'text_extra_info.json')
 
     printer.print_stage('Loading shortcuts.json')
     load_shortcuts_file(db, structure_dir / 'shortcuts.json')

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -1,10 +1,14 @@
+import json
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
 from common.arangodb import get_db, delete_db
+from common.collections import Collection, database
 from common.utils import current_app
 from data_loader import arangoload
+from data_loader.arangoload import load_text_extra_info_file
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -45,3 +49,74 @@ def test_do_entire_run(data_load_app):
         printer = arangoload.run(no_pull=False)
         assert len(printer.stages) == 51
         save_as_csv(printer.stages, "load-data-run.csv")
+
+
+class TestTextExtraInfo:
+    @pytest.fixture
+    def empty_collection(self) -> Generator[Collection, None, None]:
+        coll = Collection('text_extra_info')
+        coll.clear()
+        yield coll
+        coll.clear()
+
+    @pytest.fixture
+    def with_existing_document(self, empty_collection):
+        empty_collection.recreate(
+            [
+                {
+                    'uid': 'mn92',
+                    'acronym': 'MN 92',
+                    'alt_acronym': None,
+                    'volpage': 'PTS MN ii 146',
+                    'alt_volpage': None,
+                    'alt_name': None,
+                    'biblio_uid': None
+                },
+            ]
+        )
+        return empty_collection
+
+    @pytest.fixture
+    def structure_dir(self, tmp_path) -> Path:
+        return tmp_path
+
+    @pytest.fixture
+    def file_location(self, structure_dir) -> Path:
+        return structure_dir / Path('text_extra_info.json')
+
+    @pytest.fixture
+    def data(self) -> list[dict]:
+        return [
+            {
+                'uid': 'dn1',
+                'acronym': 'DN 1',
+                'alt_acronym': None,
+                'volpage': 'PTS DN i 1',
+                'alt_volpage': None,
+                'alt_name': None,
+                'biblio_uid': None
+            },
+            {
+                'uid': 'dn2',
+                'acronym': 'DN 2',
+                'alt_acronym': None,
+                'volpage': 'PTS DN i 47',
+                'alt_volpage': None,
+                'alt_name': None,
+                'biblio_uid': None
+            },
+        ]
+
+    @pytest.fixture
+    def with_data(self, file_location, data):
+        with file_location.open("w") as f:
+            json.dump(data, f)
+
+    def test_populates_empty_collection(self, empty_collection, with_data, file_location):
+        load_text_extra_info_file(database(), file_location)
+        assert sorted([doc['uid'] for doc in Collection('text_extra_info').documents()]) == ['dn1', 'dn2']
+
+    def test_recreates_collection(self, with_existing_document, with_data, file_location):
+        assert sorted([doc['uid'] for doc in Collection('text_extra_info').documents()]) == ['mn92']
+        load_text_extra_info_file(database(), file_location)
+        assert sorted([doc['uid'] for doc in Collection('text_extra_info').documents()]) == ['dn1', 'dn2']

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -8,7 +8,7 @@ from common.arangodb import get_db, delete_db
 from common.collections import Collection, database
 from common.utils import current_app
 from data_loader import arangoload
-from data_loader.arangoload import load_text_extra_info_file
+from data_loader.arangoload import load_text_extra_info
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -113,10 +113,10 @@ class TestTextExtraInfo:
             json.dump(data, f)
 
     def test_populates_empty_collection(self, empty_collection, with_data, file_location):
-        load_text_extra_info_file(database(), file_location)
+        load_text_extra_info(file_location)
         assert sorted([doc['uid'] for doc in Collection('text_extra_info').documents()]) == ['dn1', 'dn2']
 
     def test_recreates_collection(self, with_existing_document, with_data, file_location):
         assert sorted([doc['uid'] for doc in Collection('text_extra_info').documents()]) == ['mn92']
-        load_text_extra_info_file(database(), file_location)
+        load_text_extra_info(file_location)
         assert sorted([doc['uid'] for doc in Collection('text_extra_info').documents()]) == ['dn1', 'dn2']


### PR DESCRIPTION
Added tests and refactored as part of issue #3618.

Changed behavior: this function originally used the stock import_bulk()