### PR TITLE
Use `Collection` in `load_shortcuts()`

### DIFF
--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -361,8 +361,8 @@ def load_text_extra_info_file(db: Database, text_extra_info_file: Path):
     db.collection('text_extra_info').import_bulk(text_extra_info_content)
 
 
-def load_shortcuts_file(db: Database, shortcuts_file: Path):
-    shortcuts: Dict[str, dict] = json_load(shortcuts_file)
+def load_shortcuts(file: Path) -> None:
+    shortcuts: dict[str, list[str]] = json_load(file)
     docs = [{'uid': key, 'shortcuts': value, } for key, value in shortcuts.items()]
     Collection('shortcuts').recreate(docs)
 
@@ -707,7 +707,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     load_text_extra_info_file(db, structure_dir / 'text_extra_info.json')
 
     printer.print_stage('Loading shortcuts.json')
-    load_shortcuts_file(db, structure_dir / 'shortcuts.json')
+    load_shortcuts(structure_dir / 'shortcuts.json')
 
     printer.print_stage('Loading fallen-leaves files')
     load_fallen_leaves_files(db, structure_dir / 'fallen-leaves')

--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -14,6 +14,7 @@ from flask import current_app
 from tqdm import tqdm
 
 from common import arangodb
+from common.collections import Collection
 from common.queries import (
     BUILD_YELLOW_BRICK_ROAD,
     COUNT_YELLOW_BRICK_ROAD,
@@ -363,7 +364,7 @@ def load_text_extra_info_file(db: Database, text_extra_info_file: Path):
 def load_shortcuts_file(db: Database, shortcuts_file: Path):
     shortcuts: Dict[str, dict] = json_load(shortcuts_file)
     docs = [{'uid': key, 'shortcuts': value, } for key, value in shortcuts.items()]
-    db.collection('shortcuts').import_bulk(docs)
+    Collection('shortcuts').recreate(docs)
 
 
 def load_fallen_leaves_files(db: Database, fallen_leaves_file_dir: Path):

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -8,7 +8,7 @@ from common.arangodb import get_db, delete_db
 from common.collections import Collection, database
 from common.utils import current_app
 from data_loader import arangoload
-from data_loader.arangoload import load_shortcuts_file
+from data_loader.arangoload import load_shortcuts
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -92,10 +92,10 @@ class TestLoadShortcuts:
             json.dump(data, f)
 
     def test_populates_empty_collection(self, empty_collection, with_data, file_location):
-        load_shortcuts_file(database(), file_location)
+        load_shortcuts(file_location)
         assert next(Collection('shortcuts').documents())['shortcuts'] == ['sn2', 'sn3', 'sn4']
 
     def test_recreates_collection(self, with_existing_document, with_data, file_location):
         assert next(Collection('shortcuts').documents())['shortcuts'] == ['dn', 'mn', 'sn1']
-        load_shortcuts_file(database(), file_location)
+        load_shortcuts(file_location)
         assert next(Collection('shortcuts').documents())['shortcuts'] == ['sn2', 'sn3', 'sn4']

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -1,10 +1,14 @@
+import json
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
 from common.arangodb import get_db, delete_db
+from common.collections import Collection, database
 from common.utils import current_app
 from data_loader import arangoload
+from data_loader.arangoload import load_shortcuts_file
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -45,3 +49,59 @@ def test_do_entire_run(data_load_app):
         printer = arangoload.run(no_pull=False)
         assert len(printer.stages) == 51
         save_as_csv(printer.stages, "load-data-run.csv")
+
+
+class TestLoadShortcuts:
+    @pytest.fixture
+    def empty_collection(self) -> Generator[Collection, None, None]:
+        coll = Collection('shortcuts')
+        coll.clear()
+        yield coll
+        coll.clear()
+
+    @pytest.fixture
+    def with_existing_document(self, empty_collection):
+        empty_collection.recreate(
+            [
+                {
+                    'shortcuts': [
+                        'dn',
+                        'mn',
+                        'sn1',
+                    ]
+                },
+            ]
+        )
+        return empty_collection
+
+    @pytest.fixture
+    def structure_dir(self, tmp_path) -> Path:
+        return tmp_path
+
+    @pytest.fixture
+    def file_location(self, structure_dir) -> Path:
+        return structure_dir / Path('shortcuts.json')
+
+    @pytest.fixture
+    def data(self) -> dict[str, list[str]]:
+        return {'shortcuts': ['sn2', 'sn3', 'sn4']}
+
+    @pytest.fixture
+    def with_data(self, file_location, data):
+        with file_location.open("w") as f:
+            json.dump(data, f)
+
+    def test_populates_empty_collection(self, empty_collection, with_data, file_location):
+        load_shortcuts_file(database(), file_location)
+        assert next(Collection('shortcuts').documents())['shortcuts'] == ['sn2', 'sn3', 'sn4']
+
+    def test_doesnt_recreates_collection(self, with_existing_document, with_data, file_location):
+        assert next(Collection('shortcuts').documents())['shortcuts'] == ['dn', 'mn', 'sn1']
+        load_shortcuts_file(database(), file_location)
+        assert next(Collection('shortcuts').documents())['shortcuts'] == ['dn', 'mn', 'sn1']
+
+    def test_fails_silently(self, with_existing_document, with_data, file_location, caplog):
+        load_shortcuts_file(database(), file_location)
+        load_shortcuts_file(database(), file_location)
+        assert not caplog.messages
+        

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -95,13 +95,7 @@ class TestLoadShortcuts:
         load_shortcuts_file(database(), file_location)
         assert next(Collection('shortcuts').documents())['shortcuts'] == ['sn2', 'sn3', 'sn4']
 
-    def test_doesnt_recreates_collection(self, with_existing_document, with_data, file_location):
+    def test_recreates_collection(self, with_existing_document, with_data, file_location):
         assert next(Collection('shortcuts').documents())['shortcuts'] == ['dn', 'mn', 'sn1']
         load_shortcuts_file(database(), file_location)
-        assert next(Collection('shortcuts').documents())['shortcuts'] == ['dn', 'mn', 'sn1']
-
-    def test_fails_silently(self, with_existing_document, with_data, file_location, caplog):
-        load_shortcuts_file(database(), file_location)
-        load_shortcuts_file(database(), file_location)
-        assert not caplog.messages
-        
+        assert next(Collection('shortcuts').documents())['shortcuts'] == ['sn2', 'sn3', 'sn4']


### PR DESCRIPTION
Added tests and refactored as part of issue https://github.com/suttacentral/suttacentral/issues/3618.

Changed behavior: this function originally used the stock import_bulk() but did not truncate the collection so no updates would be written.

I take this to be a bug and have used `Collection.recreate()`