### PR TITLE
Load fallen leaves files uses collection

### DIFF
--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -14,6 +14,7 @@ from flask import current_app
 from tqdm import tqdm
 
 from common import arangodb
+from common.collections import Collection
 from common.queries import (
     BUILD_YELLOW_BRICK_ROAD,
     COUNT_YELLOW_BRICK_ROAD,
@@ -366,14 +367,13 @@ def load_shortcuts_file(db: Database, shortcuts_file: Path):
     db.collection('shortcuts').import_bulk(docs)
 
 
-def load_fallen_leaves_files(db: Database, fallen_leaves_file_dir: Path):
+def load_fallen_leaves(fallen_leaves_dir: Path) -> None:
     fallen_leaves = []
-    for fallen_leaves_file in fallen_leaves_file_dir.glob('*.json'):
+    for fallen_leaves_file in fallen_leaves_dir.glob('*.json'):
         leaves: Dict[str, dict] = json_load(fallen_leaves_file)
         docs = [{'uid': key, 'fallen_leaves': value, } for key, value in leaves.items()]
         fallen_leaves.extend(docs)
-    db['fallen_leaves'].truncate()
-    db.collection('fallen_leaves').import_bulk(fallen_leaves)
+    Collection('fallen_leaves').recreate(fallen_leaves)
 
 
 def update_text_extra_info():
@@ -709,7 +709,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     load_shortcuts_file(db, structure_dir / 'shortcuts.json')
 
     printer.print_stage('Loading fallen-leaves files')
-    load_fallen_leaves_files(db, structure_dir / 'fallen-leaves')
+    load_fallen_leaves(structure_dir / 'fallen-leaves')
 
     printer.print_stage("Building and loading navigation from structure_dir")
     navigation.add_navigation_docs_and_edges(change_tracker, db, structure_dir, sc_bilara_data_dir)

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -1,10 +1,14 @@
+import json
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
 from common.arangodb import get_db, delete_db
+from common.collections import Collection, database
 from common.utils import current_app
 from data_loader import arangoload
+from data_loader.arangoload import load_fallen_leaves_files
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -45,3 +49,76 @@ def test_do_entire_run(data_load_app):
         printer = arangoload.run(no_pull=False)
         assert len(printer.stages) == 51
         save_as_csv(printer.stages, "load-data-run.csv")
+
+
+class TestLoadFallenLeaves:
+    @pytest.fixture
+    def empty_collection(self) -> Generator[Collection, None, None]:
+        coll = Collection('fallen_leaves')
+        coll.clear()
+        yield coll
+        coll.clear()
+
+    @pytest.fixture
+    def with_existing_document(self, empty_collection):
+        empty_collection.recreate(
+            [
+                {
+                    "uid": "abc123",
+                    "fallen_leaves": [
+                        {
+                            "toplevel": [
+                                "sublevel-1",
+                                "sublevel-2",
+                            ]
+                        },
+                    ]
+                },
+            ]
+        )
+        return empty_collection
+
+    @pytest.fixture
+    def fallen_leaves_dir(self, tmp_path) -> Path:
+        return tmp_path
+
+    @pytest.fixture
+    def with_file_one(self, fallen_leaves_dir):
+        data = {
+            'pli-tv-bi-vb': [
+                {
+                    'pli-tv-bi-vb-pj': [
+                        'pli-tv-bi-vb-pj1',
+                        'pli-tv-bi-vb-pj2',
+                    ]
+                },
+            ]
+        }
+        file_location = fallen_leaves_dir / 'first-fallen-leaves.json'
+        with file_location.open("w") as f:
+            json.dump(data, f)
+
+    @pytest.fixture
+    def with_file_two(self, fallen_leaves_dir):
+        data = {
+            'pli-tv-bu-vb': [
+                {
+                    'pli-tv-bu-vb-as': [
+                        'pli-tv-bu-vb-as1',
+                        'pli-tv-bu-vb-as2',
+                    ]
+                },
+            ]
+        }
+        file_location = fallen_leaves_dir / 'second-fallen-leaves.json'
+        with file_location.open("w") as f:
+            json.dump(data, f)
+
+    def test_populates_empty_collection(self, empty_collection, with_file_one, with_file_two, fallen_leaves_dir):
+        load_fallen_leaves_files(database(), fallen_leaves_dir)
+        assert sorted([doc['uid'] for doc in Collection('fallen_leaves').documents()]) == ['pli-tv-bi-vb', 'pli-tv-bu-vb']
+
+    def test_recreates_collection(self, with_existing_document, with_file_one, with_file_two, fallen_leaves_dir):
+        assert sorted([doc['uid'] for doc in Collection('fallen_leaves').documents()]) == ['abc123']
+        load_fallen_leaves_files(database(), fallen_leaves_dir)
+        assert sorted([doc['uid'] for doc in Collection('fallen_leaves').documents()]) == ['pli-tv-bi-vb', 'pli-tv-bu-vb']

--- a/server/tests/data_loader/test_arangoload.py
+++ b/server/tests/data_loader/test_arangoload.py
@@ -8,7 +8,7 @@ from common.arangodb import get_db, delete_db
 from common.collections import Collection, database
 from common.utils import current_app
 from data_loader import arangoload
-from data_loader.arangoload import load_fallen_leaves_files
+from data_loader.arangoload import load_fallen_leaves
 from data_loader.observability import save_as_csv
 from migrations.runner import run_migrations
 
@@ -115,10 +115,10 @@ class TestLoadFallenLeaves:
             json.dump(data, f)
 
     def test_populates_empty_collection(self, empty_collection, with_file_one, with_file_two, fallen_leaves_dir):
-        load_fallen_leaves_files(database(), fallen_leaves_dir)
+        load_fallen_leaves(fallen_leaves_dir)
         assert sorted([doc['uid'] for doc in Collection('fallen_leaves').documents()]) == ['pli-tv-bi-vb', 'pli-tv-bu-vb']
 
     def test_recreates_collection(self, with_existing_document, with_file_one, with_file_two, fallen_leaves_dir):
         assert sorted([doc['uid'] for doc in Collection('fallen_leaves').documents()]) == ['abc123']
-        load_fallen_leaves_files(database(), fallen_leaves_dir)
+        load_fallen_leaves(fallen_leaves_dir)
         assert sorted([doc['uid'] for doc in Collection('fallen_leaves').documents()]) == ['pli-tv-bi-vb', 'pli-tv-bu-vb']


### PR DESCRIPTION
Added tests and refactored as part of issue https://github.com/suttacentral/suttacentral/issues/3618.

Changed behavior: this function originally used the stock import_bulk()
