### PR TITLE
ci: configure Python linting with `ruff`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ lint: lint-server
 
 .PHONY: lint-server
 lint-server: lint-server-deps
+	@docker exec -t sc-flask uv run ruff check
 
 # check for a synced lockfile and no unused or undeclared deps
 .PHONY: lint-server-deps

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ lint: lint-server
 lint-server: lint-server-deps
 	@docker exec -t sc-flask uv run ruff check
 
+.PHONY: lint-server-fix
+lint-server-fix:
+	@docker exec -t sc-flask uv run ruff check --fix
+
 # check for a synced lockfile and no unused or undeclared deps
 .PHONY: lint-server-deps
 lint-server-deps:

--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ class InitialMigration(Migration):
 2. `uv run python -m sc_flask.manage list_routes` - Lists all available routes/URLs.
 
 ### 1.10 Style guidelines
-* Follow [PEP8](https://www.python.org/dev/peps/pep-0008/) for Python code.
+
+* `make lint-server`
 
 * Try to keep line width under 120 characters.
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -54,5 +54,12 @@ ignore_unused = [
     "uwsgi", # used as CLI in `Makefile`, `entrypoint.sh`
 ]
 
+[tool.ruff.lint]
+# add to the default lint rules
+extend-select = [
+    "A", # no shadowing built-ins
+    "T100", # no debugger statements
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pytest>=7.2.0,<8",
     "pytest-flask>=1.2.0,<2",
     "pytest-sugar>=0.9.6,<0.10",
+    "ruff>=0.15.13,<0.16.0",
 ]
 
 [build-system]
@@ -49,6 +50,7 @@ ignore_unused = [
     "fawltydeps", # used as CLI in `Makefile`
     "pytest-flask", # used within `@pytest.fixture`, such as in `conftest.py`
     "pytest-sugar", # modifies pytest output automatically
+    "ruff", # used as CLI in `Makefile`
     "uwsgi", # used as CLI in `Makefile`, `entrypoint.sh`
 ]
 

--- a/server/src/api/views/__init__.py
+++ b/server/src/api/views/__init__.py
@@ -1,3 +1,4 @@
+# ruff: noqa F401 -- allow unused imports here as they are re-exports
 from .dictionary import (
     DictionaryFull,
     LookupDictionaries,

--- a/server/src/api/views/views.py
+++ b/server/src/api/views/views.py
@@ -115,7 +115,7 @@ class Languages(Resource):
         if include_all:
             response = languages
         else:
-            response = [l for l in languages if not l['is_root']]
+            response = [lang for lang in languages if not lang['is_root']]
 
         return response, 200
 
@@ -1912,7 +1912,7 @@ class GitHubDirectoryListing(Resource):
 
             path_parts = parsed.path.strip('/').split('/')
             return (path_parts[0], path_parts[1]) if len(path_parts) >= 2 else None
-        except:
+        except: # noqa E722 -- we don't care about the error here
             return None
 
     def _get_directory_contents(self, owner, repo, path, branch, file_extensions):

--- a/server/src/common/models.py
+++ b/server/src/common/models.py
@@ -266,7 +266,6 @@ class Difficulty(Model):
         Returns:
             Generated object.
         """
-        fake = Faker()
         difficulty = randint(1, 3)
         uid = generate_uid()
         return cls(difficulty, uid)

--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -829,5 +829,5 @@ def run(no_pull: bool = False) -> StagePrinter:
 
 def hyphenate_pali_and_san():
     db = arangodb.get_db()
-    print(f'\nHyphenate Pali and Sanskrit texts:')
+    print('\nHyphenate Pali and Sanskrit texts:')
     hyphenation.hyphenate_texts(db)

--- a/server/src/data_loader/languages.py
+++ b/server/src/data_loader/languages.py
@@ -1,4 +1,3 @@
-import logging
 from collections import Counter
 from pathlib import Path
 from typing import Dict, List

--- a/server/src/data_loader/navigation.py
+++ b/server/src/data_loader/navigation.py
@@ -114,7 +114,7 @@ def _parse_tree_recursive(element: Dict[str, list]) -> List[Dict[str, str]]:
     edges = []
     for name, content in reversed(element.items()):
         for item in reversed(content):
-            if type(item) == dict:
+            if type(item) is dict:
                 edges.extend(
                     [{'_from': name, '_to': subgroup_name} for subgroup_name in item.keys()]
                 )

--- a/server/src/data_loader/observability.py
+++ b/server/src/data_loader/observability.py
@@ -1,6 +1,5 @@
 import csv
 import time
-from collections.abc import Iterator
 from dataclasses import dataclass
 from itertools import count
 from typing import Callable

--- a/server/src/data_loader/sc_bilara_data.py
+++ b/server/src/data_loader/sc_bilara_data.py
@@ -1,12 +1,11 @@
 import re
 from pathlib import Path
-from typing import Dict, Set, List
+from typing import Dict, List
 
 from arango.database import Database
 
 from data_loader.languages import process_languages
 from data_loader.util import json_load
-import shutil
 
 
 def load_publications(db: Database, sc_bilara_data_dir: Path) -> None:
@@ -146,7 +145,7 @@ def load_texts(db: Database, sc_bilara_data_dir: Path) -> None:
     lang_folder_idx = len(sc_bilara_data_dir.parts) + 1
 
     folders: List[Path] = {folder for folder in sc_bilara_data_dir.glob('*') 
-                           if not folder.name.startswith(('_', '.')) and not folder.name in {'name', 'blurb'}}
+                           if not folder.name.startswith(('_', '.')) and folder.name not in {'name', 'blurb'}}
 
     files: List[Path] = []
     for folder in folders:

--- a/server/src/data_loader/sc_html.py
+++ b/server/src/data_loader/sc_html.py
@@ -15,7 +15,6 @@ may change again so don't write comments like this.
 import itertools
 
 import lxml.html as _html
-import regex
 from lxml.html import defs
 
 defs.html5_tags = frozenset({'section', 'article', 'header'})

--- a/server/src/migrations/migrations/add_bilara_author_edition_039.py
+++ b/server/src/migrations/migrations/add_bilara_author_edition_039.py
@@ -8,4 +8,4 @@ class SecondMigration(Migration):
 
     def create_collections(self):
         db = get_db()
-        bilara_author_edition = db.create_collection('bilara_author_edition', edge=False)
+        db.create_collection('bilara_author_edition', edge=False)

--- a/server/src/sc_flask/manage.py
+++ b/server/src/sc_flask/manage.py
@@ -37,7 +37,6 @@ def list_routes():
 
     output = []
     for rule in app.url_map.iter_rules():
-        options = {arg: "[{0}]".format(arg) for arg in rule.arguments}
         methods = ','.join(rule.methods)
         line = urllib.parse.unquote("{:50s} {:20s} {}".format(rule.endpoint, methods, rule))
         output.append(line)

--- a/server/src/search/__init__.py
+++ b/server/src/search/__init__.py
@@ -1,5 +1,3 @@
-import logging
-import os
 from pathlib import Path
 
 

--- a/server/src/search/algolia_texts.py
+++ b/server/src/search/algolia_texts.py
@@ -7,15 +7,15 @@ from tqdm import tqdm
 
 from algoliasearch.search_client import SearchClient
 
-# algolia_client = SearchClient.create('B3DSEV09M1', '')
-algolia_client = SearchClient.create('6P1QMGK4ZX', '')
-algolia_index = algolia_client.init_index('sc_text_contents')
-
 from common.arangodb import get_db
 from common.queries import (
     TEXTS_BY_LANG_FOR_SEARCH,
     BILARA_TEXT_BY_LANG_FOR_SEARCH,
 )
+
+# algolia_client = SearchClient.create('B3DSEV09M1', '')
+algolia_client = SearchClient.create('6P1QMGK4ZX', '')
+algolia_index = algolia_client.init_index('sc_text_contents')
 
 EBS_NAMES = '''
 FOR d IN ebs_names

--- a/server/src/search/algolia_texts.py
+++ b/server/src/search/algolia_texts.py
@@ -1,10 +1,8 @@
-import os
 import logging
 import json
 import time
 import lxml.html
 import regex
-import sys
 from tqdm import tqdm
 
 from algoliasearch.search_client import SearchClient

--- a/server/src/search/texts.py
+++ b/server/src/search/texts.py
@@ -340,16 +340,6 @@ def import_texts_to_arangodb():
     )
     languages = list(db.aql.execute(query))
 
-    order = [
-        "en", "pli", "lzh", "san", "pra", "xct", "pgd", "de", "zh", "af",
-        "ar", "bn", "ca", "cs", "es", "fa", "fi", "fr", "gu",
-        "haw", "he", "hi", "hr", "hu", "id", "it", "jpn", "kan", "kho",
-        "ko", "la", "lt", "mr", "my", "nl", "no", "pl", "pt",
-        "ro", "ru", "si", "sk", "sl", "sld", "sr", "sv", "ta", "th",
-        "uig", "vi", "xto"
-    ]
-    # languages = sorted(languages, key=lambda x: order.index(x["uid"]))
-
     for lang in tqdm(languages):
         loader = TextLoader(lang)
         loader.import_all_text_to_db()

--- a/server/src/search/texts.py
+++ b/server/src/search/texts.py
@@ -7,8 +7,6 @@ from tqdm import tqdm
 
 from common.arangodb import get_db
 from common.queries import (
-    CURRENT_MTIMES,
-    CURRENT_BILARA_MTIMES,
     TEXTS_BY_LANG_FOR_SEARCH,
     BILARA_TEXT_BY_LANG_FOR_SEARCH,
     TEXT_REFERENCES

--- a/server/src/search/view.py
+++ b/server/src/search/view.py
@@ -1,4 +1,4 @@
-from flask import request, current_app
+from flask import request
 from flask_restful import Resource
 
 from common.extensions import cache, make_cache_key

--- a/server/src/search/view.py
+++ b/server/src/search/view.py
@@ -1,5 +1,6 @@
 from flask import request
 from flask_restful import Resource
+import logging
 
 from common.extensions import cache, make_cache_key
 from search.instant_search import instant_search_query

--- a/server/tests/api/test_endpoints.py
+++ b/server/tests/api/test_endpoints.py
@@ -562,7 +562,7 @@ class TestParagraphs:
             assert 'description' in item
 
 
-class TestParagraphs:
+class TestEpigraphs:
     @pytest.fixture
     def client(self):
         app.config['TESTING'] = True
@@ -570,7 +570,7 @@ class TestParagraphs:
             with app.app_context():
                 yield client
 
-    def test_basic_paragraphs(self, client):
+    def test_basic_epigraphs(self, client):
         url = "/epigraphs"
         response = client.get(url)
 

--- a/server/tests/common/test_ebook_download_link.py
+++ b/server/tests/common/test_ebook_download_link.py
@@ -1,4 +1,3 @@
-import requests
 
 download_links_of_collections = [
   'https://github.com/suttacentral/editions/raw/main/en/sujato/dn/epub/Long-Discourses-sujato-2024-05-13.epub',

--- a/server/tests/common/test_uid_matcher.py
+++ b/server/tests/common/test_uid_matcher.py
@@ -31,7 +31,7 @@ decompose_test_data = [
 
 all_uids = list(
     itertools.chain(
-        (f'dn', 'an', 'sa', 'sa-2'),
+        ('dn', 'an', 'sa', 'sa-2'),
         (f'dn{i}' for i in range(1, 35)),
         (f'an{i}' for i in range(1, 12)),
         (f'an1.{i * 10 + 1}-{i * 10 + 10}' for i in range(0, 10)),

--- a/server/tests/data_loader/test_observability.py
+++ b/server/tests/data_loader/test_observability.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterator
 
-import pytest
 
 from data_loader.observability import StagePrinter, RunTime
 

--- a/server/tests/data_loader/test_unsegmented.py
+++ b/server/tests/data_loader/test_unsegmented.py
@@ -532,25 +532,25 @@ class TestCreateDocument:
         assert document.author.short_name == 'Bodhi'
 
     def test_sets_author_uid(self, sutta_path):
-        html = f"<html><head><meta author='Bhikkhu Bodhi'></head></html>"
+        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
         add_html_file(sutta_path, html)
         document = create_document('en', sutta_path, FakeAuthors())
         assert document.author.uid == 'bodhi'
 
     def test_sets_missing_author_uid_to_none(self, sutta_path):
-        html = f"<html><head><meta author='Bhikkhu Nobody'></head></html>"
+        html = "<html><head><meta author='Bhikkhu Nobody'></head></html>"
         add_html_file(sutta_path, html)
         document = create_document('en', sutta_path, FakeAuthors())
         assert document.author.uid is None
 
     def test_generates_path_with_author(self, sutta_path):
-        html = f"<html><head><meta author='Bhikkhu Bodhi'></head></html>"
+        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
         add_html_file(sutta_path, html)
         document = create_document('en', sutta_path, FakeAuthors())
         assert document.path == 'en/mn1/bodhi'
 
     def test_generates_path_with_missing_author(self, sutta_path):
-        html = f"<html><head><meta author='Bhikkhu Nobody'></head></html>"
+        html = "<html><head><meta author='Bhikkhu Nobody'></head></html>"
         add_html_file(sutta_path, html)
         document = create_document('en', sutta_path, FakeAuthors())
         assert document.path == 'en/mn1'
@@ -568,13 +568,13 @@ class TestCreateDocument:
         assert document.file.last_modified == sutta_path.stat().st_mtime
 
     def test_sets_key_with_author(self, sutta_path):
-        html = f"<html><head><meta author='Bhikkhu Bodhi'></head></html>"
+        html = "<html><head><meta author='Bhikkhu Bodhi'></head></html>"
         add_html_file(sutta_path, html)
         document = create_document('en', sutta_path, FakeAuthors())
         assert document.key == 'en_mn1_bodhi'
 
     def test_sets_key_with_missing_author(self, sutta_path):
-        html = f"<html><head><meta author='Bhikkhu Nobody'></head></html>"
+        html = "<html><head><meta author='Bhikkhu Nobody'></head></html>"
         add_html_file(sutta_path, html)
         document = create_document('en', sutta_path, FakeAuthors())
         assert document.key == 'en_mn1'

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -638,6 +638,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
+]
+
+[[package]]
 name = "sc-flask"
 version = "0.1.0"
 source = { editable = "." }
@@ -673,6 +698,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-flask" },
     { name = "pytest-sugar" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -708,6 +734,7 @@ dev = [
     { name = "pytest", specifier = ">=7.2.0,<8" },
     { name = "pytest-flask", specifier = ">=1.2.0,<2" },
     { name = "pytest-sugar", specifier = ">=0.9.6,<0.10" },
+    { name = "ruff", specifier = ">=0.15.13,<0.16.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add `ruff` as a dev dep to lint ~and format~ Python code
  - chose `ruff` as it's backed by [the same org as `uv`](https://github.com/astral-sh/ruff/blob/f2fb134161ed5842388b46e65de4435117601880/README.md?plain=1#L60) and is very performant
    - literally had results instantly on a fresh run

## Details

- use a bit more than default config for now
- add a lint check in the `Makefile` for now

**ci: auto-fix Python code via `ruff`**
- run `uv run ruff check --fix` and commit the changes
  - mostly unused imports and unused `f`-strings (were just plain strings)
- add a `lint-server-fix` target to the `Makefile`

**ci: manually fix remaining Python lint errors**
- mostly unused imports and dead code
  - plus a missing import, an accidentally duplicated class/test name, etc

**ci: configure additional lint rules for ruff**
- add a structure for adding more rules
- add two simple rules for now that the codebase is already compliant with:
  - check for stray [debugger statements](https://docs.astral.sh/ruff/rules/debugger/)
  - check for shadowed built-ins ([example](https://docs.astral.sh/ruff/rules/builtin-variable-shadowing/))

## Verification

- CI passes; `uv run ruff check` exits 0 with no errors

## Future Work

- [ ] add [more lint rules](https://docs.astral.sh/ruff/rules)
  - partly done [in a separate branch](https://github.com/agilgur5/suttacentral/commit/63e35eafe4735df510a6fa2d658645b7c171d108) as there's a lot to check and fix
    - those all require changes to the source code, so will be better as individual PRs 
- [ ] add [formatting](https://docs.astral.sh/ruff/formatter/)
  - partly done [in a separate branch](https://github.com/agilgur5/suttacentral/commit/eb7e97dd3251bd484c1b3849ad88081725ba63c5) as there are a lot of automated changes