### PR TITLE
fix(ci): configure `base_dir` for `fawltydeps`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ lint-server: lint-server-deps
 .PHONY: lint-server-deps
 lint-server-deps:
 	@docker exec -t sc-flask uv lock --check
-	@docker exec -t sc-flask uv run fawltydeps --exclude scripts/
+	@docker exec -t sc-flask uv run fawltydeps
 
 migrate:
 	@docker exec -t sc-flask bash -c "uv run python -m sc_flask.manage migrate"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -43,9 +43,7 @@ requires = ["uv_build>=0.10.4,<0.11.0"]
 build-backend = "uv_build"
 
 [tool.fawltydeps]
-ignore_undeclared = [
-    "sc_flask" # ignore self-reference, name of our package
-]
+base_dir = "src/"
 # ignore deps that are not directly imported
 ignore_unused = [
     "fawltydeps", # used as CLI in `Makefile`


### PR DESCRIPTION
## Summary

Add `base_dir` config for `fawltydeps`
- Fixes #3657 

## Details

- apparently the reason that the `scripts/` dir had to be (temporarily) excluded and why `sc_flask` needed to be ignored was because we needed to [set a `base_dir`](https://github.com/tweag/FawltyDeps/blob/3bd8baed78c01d03a39077860c4f37dfe450faa0/docs/usage.md#correctly-identifying-1st--vs-3rd-party-imports)
  - set to `src/` to match `uv`'s package structure (c.f. https://github.com/suttacentral/suttacentral/issues/3583#issuecomment-4108969587)
  
## Verification

- CI passes; `uv run fawltydeps` exits 0 with no errors