### PR TITLE
refactor(deps): use SemVer ranges in `pyproject.toml`

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -3,43 +3,43 @@ name = "sc-flask"
 version = "0.1.0"
 description = "The backend python implementation for SuttaCentral.net"
 readme = "README.md"
-requires-python = "==3.11.3"
+requires-python = "~=3.11.3"
 dependencies = [
-    "aksharamukha==2.3",
-    "algoliasearch==3.0.0",
-    "beautifulsoup4==4.11.1",
-    "click==8.1.3",
-    "decorator==5.1.1",
-    "faker==15.3.4",
-    "flasgger==0.9.5",
-    "flask==2.2.5",
-    "flask-caching==2.0.1",
-    "flask-cors==3.0.10",
-    "flask-restful==0.3.9",
-    "fonttools==4.38.0",
-    "jinja2==3.1.2",
-    "lxml[cssselect]==4.9.1",
-    "python-arango==7.5.3",
+    "aksharamukha>=2.3,<3",
+    "algoliasearch>=3.0.0,<4",
+    "beautifulsoup4>=4.11.1,<5",
+    "click>=8.1.3,<9",
+    "decorator>=5.1.1,<6",
+    "faker>=15.3.4,<16",
+    "flasgger>=0.9.5,<0.10",
+    "flask>=2.2.5,<3",
+    "flask-caching>=2.0.1,<3",
+    "flask-cors>=3.0.10,<4",
+    "flask-restful>=0.3.9,<0.4",
+    "fonttools>=4.38.0,<5",
+    "jinja2>=3.1.2,<4",
+    "lxml[cssselect]>=4.9.1,<5",
+    "python-arango>=7.5.3,<8",
     "regex==2022.10.31",
-    "requests==2.31.0",
-    "sortedcontainers==2.4.0",
-    "stripe==6.4.0",
-    "tqdm==4.64.1",
-    "unidecode==1.3.7",
-    "uwsgi==2.0.21",
-    "zhconv==1.4.3",
+    "requests>=2.31.0,<3",
+    "sortedcontainers>=2.4.0,<3",
+    "stripe>=6.4.0,<7",
+    "tqdm>=4.64.1,<5",
+    "unidecode>=1.3.7,<2",
+    "uwsgi>=2.0.21,<3",
+    "zhconv>=1.4.3,<2",
 ]
 
 [dependency-groups]
 dev = [
-    "fawltydeps>=0.20.0,<0.21.0",
-    "pytest==7.2.0",
-    "pytest-flask==1.2.0",
-    "pytest-sugar==0.9.6",
+    "fawltydeps>=0.20.0,<0.21",
+    "pytest>=7.2.0,<8",
+    "pytest-flask>=1.2.0,<2",
+    "pytest-sugar>=0.9.6,<0.10",
 ]
 
 [build-system]
-requires = ["uv_build>=0.10.4,<0.11.0"]
+requires = ["uv_build>=0.10.4,<0.11"]
 build-backend = "uv_build"
 
 [tool.fawltydeps]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = "==3.11.3"
+requires-python = ">=3.11.3, <3.12"
 
 [[package]]
 name = "aksharamukha"
@@ -677,37 +677,37 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aksharamukha", specifier = "==2.3" },
-    { name = "algoliasearch", specifier = "==3.0.0" },
-    { name = "beautifulsoup4", specifier = "==4.11.1" },
-    { name = "click", specifier = "==8.1.3" },
-    { name = "decorator", specifier = "==5.1.1" },
-    { name = "faker", specifier = "==15.3.4" },
-    { name = "flasgger", specifier = "==0.9.5" },
-    { name = "flask", specifier = "==2.2.5" },
-    { name = "flask-caching", specifier = "==2.0.1" },
-    { name = "flask-cors", specifier = "==3.0.10" },
-    { name = "flask-restful", specifier = "==0.3.9" },
-    { name = "fonttools", specifier = "==4.38.0" },
-    { name = "jinja2", specifier = "==3.1.2" },
-    { name = "lxml", extras = ["cssselect"], specifier = "==4.9.1" },
-    { name = "python-arango", specifier = "==7.5.3" },
+    { name = "aksharamukha", specifier = ">=2.3,<3" },
+    { name = "algoliasearch", specifier = ">=3.0.0,<4" },
+    { name = "beautifulsoup4", specifier = ">=4.11.1,<5" },
+    { name = "click", specifier = ">=8.1.3,<9" },
+    { name = "decorator", specifier = ">=5.1.1,<6" },
+    { name = "faker", specifier = ">=15.3.4,<16" },
+    { name = "flasgger", specifier = ">=0.9.5,<0.10" },
+    { name = "flask", specifier = ">=2.2.5,<3" },
+    { name = "flask-caching", specifier = ">=2.0.1,<3" },
+    { name = "flask-cors", specifier = ">=3.0.10,<4" },
+    { name = "flask-restful", specifier = ">=0.3.9,<0.4" },
+    { name = "fonttools", specifier = ">=4.38.0,<5" },
+    { name = "jinja2", specifier = ">=3.1.2,<4" },
+    { name = "lxml", extras = ["cssselect"], specifier = ">=4.9.1,<5" },
+    { name = "python-arango", specifier = ">=7.5.3,<8" },
     { name = "regex", specifier = "==2022.10.31" },
-    { name = "requests", specifier = "==2.31.0" },
-    { name = "sortedcontainers", specifier = "==2.4.0" },
-    { name = "stripe", specifier = "==6.4.0" },
-    { name = "tqdm", specifier = "==4.64.1" },
-    { name = "unidecode", specifier = "==1.3.7" },
-    { name = "uwsgi", specifier = "==2.0.21" },
-    { name = "zhconv", specifier = "==1.4.3" },
+    { name = "requests", specifier = ">=2.31.0,<3" },
+    { name = "sortedcontainers", specifier = ">=2.4.0,<3" },
+    { name = "stripe", specifier = ">=6.4.0,<7" },
+    { name = "tqdm", specifier = ">=4.64.1,<5" },
+    { name = "unidecode", specifier = ">=1.3.7,<2" },
+    { name = "uwsgi", specifier = ">=2.0.21,<3" },
+    { name = "zhconv", specifier = ">=1.4.3,<2" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "fawltydeps", specifier = ">=0.20.0,<0.21.0" },
-    { name = "pytest", specifier = "==7.2.0" },
-    { name = "pytest-flask", specifier = "==1.2.0" },
-    { name = "pytest-sugar", specifier = "==0.9.6" },
+    { name = "fawltydeps", specifier = ">=0.20.0,<0.21" },
+    { name = "pytest", specifier = ">=7.2.0,<8" },
+    { name = "pytest-flask", specifier = ">=1.2.0,<2" },
+    { name = "pytest-sugar", specifier = ">=0.9.6,<0.10" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Use SemVer ranges for all Python deps where possible

This is a follow-up to https://github.com/suttacentral/suttacentral/pull/3557#discussion_r2839214522

## Details

- updating a dependency to a SemVer patch or minor version _should_ be non-breaking, so we don't have to pin to a specific patch version
  - now that we have a lockfile (`uv.lock`), all versions are _still_ pinned to a patch
  - this just changes the "allowable" versions of deps and makes it easier to auto-update within the range. for example:
    - if there's a CVE in a dep, we can auto-update the patch seamlessly now
    - if we need to bump a dep due to another dep requirement, it can be automatically bumped in the lockfile if it is within range, without changing the main manifest
      - `uv add` etc will do that automatically, whereas before it would error, since it had to match the version _exactly_, not just be SemVer-compatible
    - etc
    
## Notes to Reviewers

- `regex` cannot use a SemVer range as it uses CalVer, not SemVer, and so doesn't have a notion of compatibility between versions
- Python itself shouldn't use any minor version because, per [PEP 387](https://peps.python.org/pep-0387/), it doesn't strictly follow SemVer and can have breaking changes within a minor version after a deprecation cycle

## Verification

Double-checked that these ranges would be compatible by hand for some cases with https://nok.github.io/pip-dev/ / https://github.com/nok/pip-dev (an interactive version specifier visualization)