### PR TITLE
Refactor relationships loading algorithm

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -52,5 +52,9 @@ ignore_unused = [
     "uwsgi", # used as CLI in `Makefile`, `entrypoint.sh`
 ]
 
+ignore_undeclared = [
+    "fakes" # is declared outside a package in data_loader tests
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/server/scripts/dump_relationships.py
+++ b/server/scripts/dump_relationships.py
@@ -1,0 +1,32 @@
+import csv
+import sys
+from pathlib import Path
+
+from arango import ArangoClient
+
+file_name = sys.argv[1]
+
+client = ArangoClient()
+db = client.db('suttacentral', username='root', password='test')
+cursor = db.aql.execute(
+    """
+    FOR doc IN relationship
+    SORT doc._from, doc._to, doc.from, doc.to, doc.number, doc.remark, doc.resembling, doc.type
+    RETURN UNSET(doc, "_key", "_id", "_rev")
+    """)
+
+with Path(file_name).open('w', newline='') as file:
+    writer = csv.writer(file)
+    for doc in cursor:
+        writer.writerow(
+            [
+                doc['_from'],
+                doc['_to'],
+                doc['from'],
+                doc['to'],
+                doc['number'],
+                doc['remark'],
+                doc['resembling'],
+                doc['type'],
+            ]
+        )

--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -42,7 +42,7 @@ from . import (
 from .change_tracker import ChangeTracker
 from .generate_sitemap import generate_sitemap
 from .observability import StagePrinter
-from .relationships import generate_relationship_edges
+from .relationships import load_relationships
 from .util import json_load
 import re
 
@@ -592,7 +592,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     sc_bilara_data.load_bilara_author_edition(db, sc_bilara_data_dir)
 
     printer.print_stage("Generating and loading relationships")
-    generate_relationship_edges(
+    load_relationships(
         change_tracker, relationship_dir, additional_info_dir, db
     )
 

--- a/server/src/data_loader/arangoload.py
+++ b/server/src/data_loader/arangoload.py
@@ -1,13 +1,9 @@
 import json
-import logging
 import pathlib
-from collections import defaultdict
-from itertools import product
 from pathlib import Path
 from typing import Dict
 import subprocess
 
-import regex
 from arango.database import Database
 from flask import current_app
 from tqdm import tqdm
@@ -29,8 +25,6 @@ from common.queries import (
     INSERT_EBS_NAMES,
     RANGE_UIDS
 )
-from common.uid_matcher import UidMatcher
-from common.utils import chunks
 from . import (
     biblio,
     currencies,
@@ -48,6 +42,7 @@ from . import (
 from .change_tracker import ChangeTracker
 from .generate_sitemap import generate_sitemap
 from .observability import StagePrinter
+from .relationships import generate_relationship_edges
 from .util import json_load
 import re
 
@@ -69,7 +64,6 @@ def collect_data(repo_dir: Path, repo_addr: str):
         subprocess.run(['git', 'pull'], cwd=repo_dir)
 
 
-
 def load_child_range(db: Database, structure_dir: Path) -> None:
     """
     Load child range data from structure_dir/child_range.json file
@@ -86,157 +80,6 @@ def load_child_range(db: Database, structure_dir: Path) -> None:
         'range': nav_range
     } for uid, nav_range in child_range_content.items()]
     db['child_range'].import_bulk(data, overwrite=True)
-
-
-def get_uid_matcher(db):
-    all_uids = set(
-        db.aql.execute(
-            '''
-            FOR doc IN super_nav_details
-                RETURN doc.uid
-            '''
-        )
-    )
-
-    return UidMatcher(all_uids)
-
-
-def generate_relationship_edges(
-        change_tracker, relationship_dir, additional_info_dir, db
-):
-    relationship_files = [relationship_dir / Path('parallels.json')]
-
-    if not change_tracker.is_any_file_new_or_changed(relationship_files):
-        return
-
-    print('Generating Parallels')
-    relationship_data = []
-    for relationship_file in relationship_files:
-        relationship_data.extend(json_load(relationship_file))
-
-    uid_matcher = get_uid_matcher(db)
-
-    remarks_data = json_load(additional_info_dir / 'notes.json')
-
-    remarks = defaultdict(dict)
-
-    for remark in remarks_data:
-        uids = remark['relations']
-        remark_text = remark['remark']
-        remarks[frozenset(uids)] = remark_text
-
-    ll_edges = []
-    for entry in tqdm(relationship_data):
-        entry.pop('remarks', None)
-        for r_type, uids in entry.items():
-            if r_type == 'retells':
-                r_type = 'retelling'
-            elif r_type == 'mentions':
-                r_type = 'mention'
-            elif r_type == 'parallels':
-                r_type = 'full'
-
-            if r_type == 'full':
-                full = [uid for uid in uids if not uid.startswith('~')]
-                partial = [uid for uid in uids if uid.startswith('~')]
-                for from_uid in full:
-                    m = regex.search('[0-9]+$', from_uid)
-                    if m:
-                        from_nr = int(m[0])
-                    else:
-                        from_nr = 0
-                    true_from_uids = uid_matcher.get_matching_uids(from_uid)
-                    if not true_from_uids and ' ' not in from_uid:
-                        logging.error(
-                            f'Relationship from uid could not be matched: {from_uid} (dropped)'
-                        )
-                        continue
-
-                    for to_uids, is_resembling in ((full, False), (partial, True)):
-                        for to_uid in to_uids:
-                            if to_uid == from_uid:
-                                continue
-                            true_to_uids = uid_matcher.get_matching_uids(to_uid)
-                            if not true_to_uids:
-                                logging.info(
-                                    f'Relationship to uid could not be matched: {to_uid} (appears as orphan)'
-                                )
-                                true_to_uids = ['orphan']
-
-                            for true_from_uid in true_from_uids:
-                                for true_to_uid in true_to_uids:
-                                    remark = remarks.get(
-                                        frozenset([true_from_uid, true_to_uid]), None
-                                    )
-                                    ll_edges.append(
-                                        {
-                                            '_from': true_from_uid,
-                                            '_to': true_to_uid,
-                                            'from': from_uid,
-                                            'number': from_nr,
-                                            'to': to_uid.lstrip('~').split('-')[0],
-                                            'type': r_type,
-                                            'resembling': is_resembling,
-                                            'remark': remark,
-                                        }
-                                    )
-            else:
-                first_uid = uids[0]
-                m = regex.search('[0-9]+$', first_uid)
-                if m:
-                    from_nr = int(m[0])
-                else:
-                    from_nr = 0
-                true_first_uids = uid_matcher.get_matching_uids(first_uid)
-                for true_first_uid, to_uid in product(true_first_uids, uids[1:]):
-                    true_from_uids = uid_matcher.get_matching_uids(to_uid)
-                    if not true_from_uids and ' ' not in from_uid:
-                        logging.error(
-                            f'Relationship from uid could not be matched: {from_uid} (dropped)'
-                        )
-                        continue
-                    for true_from_uid in true_from_uids:
-                        remark = remarks.get(
-                            frozenset([true_from_uid, true_first_uid]), None
-                        )
-                        ll_edges.append(
-                            {
-                                '_from': true_first_uid,
-                                '_to': true_from_uid,
-                                'from': first_uid.lstrip('~'),
-                                'to': to_uid,
-                                'number': from_nr,
-                                'type': r_type,
-                                'resembling': any(
-                                    x.startswith('~') for x in [first_uid, from_uid]
-                                ),
-                                'remark': remark,
-                            }
-                        )
-                        m = regex.search('[0-9]+$', to_uid)
-                        if m:
-                            to_nr = int(m[0])
-                        else:
-                            to_nr = 0
-                        ll_edges.append(
-                            {
-                                '_from': true_from_uid,
-                                '_to': true_first_uid,
-                                'from': to_uid,
-                                'to': first_uid.lstrip('~'),
-                                'number': to_nr,
-                                'type': r_type,
-                                'resembling': any(
-                                    x.startswith('~') for x in [first_uid, from_uid]
-                                ),
-                                'remark': remark,
-                            }
-                        )
-
-    # Because there are many edges (nearly 400k at last count) chunk the import
-    db['relationship'].truncate()
-    for chunk in chunks(ll_edges, 10000):
-        db['relationship'].import_bulk_logged(chunk, from_prefix='super_nav_details', to_prefix='super_nav_details')
 
 
 def load_author_edition(change_tracker, additional_info_dir, db):
@@ -343,10 +186,12 @@ def load_pali_reference_edition_file(db: Database, pali_reference_edition_file: 
     db['pali_reference_edition'].truncate()
     db.collection('pali_reference_edition').import_bulk(pali_reference_content)
 
+
 def load_lzh_reference_edition_file(db: Database, lzh_reference_edition_file: Path):
     lzh_reference_content = json_load(lzh_reference_edition_file)
     db['lzh_reference_edition'].truncate()
     db.collection('lzh_reference_edition').import_bulk(lzh_reference_content)
+
 
 def load_root_edition_file(db: Database, root_edition_file: Path):
     root_edition_content = json_load(root_edition_file)
@@ -826,6 +671,7 @@ def run(no_pull: bool = False) -> StagePrinter:
     printer.print_stage('All done')
 
     return printer
+
 
 def hyphenate_pali_and_san():
     db = arangodb.get_db()

--- a/server/src/data_loader/ports.py
+++ b/server/src/data_loader/ports.py
@@ -1,0 +1,16 @@
+"""
+Ports for a ports-and-adapters approach
+"""
+from pathlib import Path
+from typing import Protocol, Iterable, Iterator
+
+
+class FileChangeTracker(Protocol):
+    def is_file_new_or_changed(self, path: Path, check_calling_function: bool = True) -> bool:
+        ...
+
+    def is_any_file_new_or_changed(self, files: list[Path], check_calling_function: bool = True) -> bool:
+        ...
+
+    def changed_files(self, paths: Iterable[Path]) -> Iterator[Path]:
+        ...

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -1,0 +1,164 @@
+import logging
+from collections import defaultdict
+from itertools import product
+from pathlib import Path
+
+import regex
+from arango.database import StandardDatabase
+from tqdm import tqdm
+
+from common.uid_matcher import UidMatcher
+from common.utils import chunks
+from data_loader.ports import FileChangeTracker
+from data_loader.util import json_load
+
+
+def get_uid_matcher(db: StandardDatabase) -> UidMatcher:
+    all_uids = set(
+        db.aql.execute(
+            '''
+            FOR doc IN super_nav_details
+                RETURN doc.uid
+            '''
+        )
+    )
+
+    return UidMatcher(all_uids)
+
+
+def generate_relationship_edges(
+        change_tracker: FileChangeTracker, relationship_dir: Path, additional_info_dir: Path, db: StandardDatabase
+) -> None:
+    relationship_files = [relationship_dir / Path('parallels.json')]
+
+    if not change_tracker.is_any_file_new_or_changed(relationship_files):
+        return
+
+    print('Generating Parallels')
+    relationship_data = []
+    for relationship_file in relationship_files:
+        relationship_data.extend(json_load(relationship_file))
+
+    uid_matcher = get_uid_matcher(db)
+
+    remarks_data = json_load(additional_info_dir / 'notes.json')
+
+    remarks = defaultdict(dict)
+
+    for remark in remarks_data:
+        uids = remark['relations']
+        remark_text = remark['remark']
+        remarks[frozenset(uids)] = remark_text
+
+    ll_edges = []
+    for entry in tqdm(relationship_data):
+        entry.pop('remarks', None)
+        for r_type, uids in entry.items():
+            if r_type == 'retells':
+                r_type = 'retelling'
+            elif r_type == 'mentions':
+                r_type = 'mention'
+            elif r_type == 'parallels':
+                r_type = 'full'
+
+            if r_type == 'full':
+                full = [uid for uid in uids if not uid.startswith('~')]
+                partial = [uid for uid in uids if uid.startswith('~')]
+                for from_uid in full:
+                    m = regex.search('[0-9]+$', from_uid)
+                    if m:
+                        from_nr = int(m[0])
+                    else:
+                        from_nr = 0
+                    true_from_uids = uid_matcher.get_matching_uids(from_uid)
+                    if not true_from_uids and ' ' not in from_uid:
+                        logging.error(
+                            f'Relationship from uid could not be matched: {from_uid} (dropped)'
+                        )
+                        continue
+
+                    for to_uids, is_resembling in ((full, False), (partial, True)):
+                        for to_uid in to_uids:
+                            if to_uid == from_uid:
+                                continue
+                            true_to_uids = uid_matcher.get_matching_uids(to_uid)
+                            if not true_to_uids:
+                                logging.info(
+                                    f'Relationship to uid could not be matched: {to_uid} (appears as orphan)'
+                                )
+                                true_to_uids = ['orphan']
+
+                            for true_from_uid in true_from_uids:
+                                for true_to_uid in true_to_uids:
+                                    remark = remarks.get(
+                                        frozenset([true_from_uid, true_to_uid]), None
+                                    )
+                                    ll_edges.append(
+                                        {
+                                            '_from': true_from_uid,
+                                            '_to': true_to_uid,
+                                            'from': from_uid,
+                                            'number': from_nr,
+                                            'to': to_uid.lstrip('~').split('-')[0],
+                                            'type': r_type,
+                                            'resembling': is_resembling,
+                                            'remark': remark,
+                                        }
+                                    )
+            else:
+                first_uid = uids[0]
+                m = regex.search('[0-9]+$', first_uid)
+                if m:
+                    from_nr = int(m[0])
+                else:
+                    from_nr = 0
+                true_first_uids = uid_matcher.get_matching_uids(first_uid)
+                for true_first_uid, to_uid in product(true_first_uids, uids[1:]):
+                    true_from_uids = uid_matcher.get_matching_uids(to_uid)
+                    if not true_from_uids and ' ' not in from_uid:
+                        logging.error(
+                            f'Relationship from uid could not be matched: {from_uid} (dropped)'
+                        )
+                        continue
+                    for true_from_uid in true_from_uids:
+                        remark = remarks.get(
+                            frozenset([true_from_uid, true_first_uid]), None
+                        )
+                        ll_edges.append(
+                            {
+                                '_from': true_first_uid,
+                                '_to': true_from_uid,
+                                'from': first_uid.lstrip('~'),
+                                'to': to_uid,
+                                'number': from_nr,
+                                'type': r_type,
+                                'resembling': any(
+                                    x.startswith('~') for x in [first_uid, from_uid]
+                                ),
+                                'remark': remark,
+                            }
+                        )
+                        m = regex.search('[0-9]+$', to_uid)
+                        if m:
+                            to_nr = int(m[0])
+                        else:
+                            to_nr = 0
+                        ll_edges.append(
+                            {
+                                '_from': true_from_uid,
+                                '_to': true_first_uid,
+                                'from': to_uid,
+                                'to': first_uid.lstrip('~'),
+                                'number': to_nr,
+                                'type': r_type,
+                                'resembling': any(
+                                    x.startswith('~') for x in [first_uid, from_uid]
+                                ),
+                                'remark': remark,
+                            }
+                        )
+
+    # Because there are many edges (nearly 400k at last count) chunk the import
+    db['relationship'].truncate()
+    for chunk in chunks(ll_edges, 10000):
+        db['relationship'].import_bulk_logged(chunk, from_prefix='super_nav_details', to_prefix='super_nav_details')

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -147,12 +147,10 @@ def handle_other_parallels(from_uid, ll_edges: list[Any], r_type: str | Any, rem
                     '_from': true_first_uid,
                     '_to': true_from_uid,
                     'from': first_uid.lstrip('~'),
-                    'to': to_uid,
+                    'to': to_uid.lstrip('~'),
                     'number': from_nr,
                     'type': r_type,
-                    'resembling': any(
-                        x.startswith('~') for x in [first_uid, from_uid]
-                    ),
+                    'resembling': any(x.startswith('~') for x in [first_uid, to_uid]),
                     'remark': remark,
                 }
             )
@@ -161,13 +159,11 @@ def handle_other_parallels(from_uid, ll_edges: list[Any], r_type: str | Any, rem
                 {
                     '_from': true_from_uid,
                     '_to': true_first_uid,
-                    'from': to_uid,
+                    'from': to_uid.lstrip('~'),
                     'to': first_uid.lstrip('~'),
                     'number': to_nr,
                     'type': r_type,
-                    'resembling': any(
-                        x.startswith('~') for x in [first_uid, from_uid]
-                    ),
+                    'resembling': any(x.startswith('~') for x in [first_uid, to_uid]),
                     'remark': remark,
                 }
             )

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -331,24 +331,27 @@ def load_relationships(change_tracker: FileChangeTracker, relationship_dir: Path
     Edge.load_remarks(notes_data)
 
     unmatched = Unmatched()
-    entries = all_entries(relationship_data)
+    raw = raw_entries(relationship_data)
+    entries = all_entries(raw)
     import_entries(db, entries, unmatched)
     unmatched.log()
 
 
-def import_entries(db: StandardDatabase, entries: list[Entry], unmatched: Unmatched) -> None:
+def import_entries(db: StandardDatabase, entries: Iterator[Entry], unmatched: Unmatched) -> None:
     db['relationship'].truncate()
-    edges = entries_to_edges(tqdm(entries), unmatched)
+    edges = entries_to_edges(entries, unmatched)
     for chunk in edge_chunks(edges):
         write_chunk(db, chunk)
 
 
-def all_entries(relationship_data: list[dict]) -> list[Entry]:
-    return [
-        Entry(entry_type, encodings)
-        for entry_data in relationship_data
-        for entry_type, encodings in entry_data.items()
-    ]
+def raw_entries(relationship_data: list[dict]) -> Iterator[tuple[str, list[str]]]:
+    for entry in tqdm(relationship_data):
+        for entry_type, encodings in entry.items():
+            yield entry_type, encodings
+
+
+def all_entries(entries: Iterable[tuple[str, list[str]]]) -> Iterator[Entry]:
+    return (Entry(entry[0], entry[1]) for entry in entries)
 
 
 def entries_to_edges(entries: Iterable[Entry], unmatched: Unmatched) -> Iterator[Edge]:

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -25,6 +25,7 @@ class Encoding:
 
     def __init__(self, encoding: str):
         self._encoding = encoding
+        self._matching_uids = self._matcher.get_matching_uids(self._encoding)
 
     def __str__(self) -> str:
         return self._encoding
@@ -36,7 +37,7 @@ class Encoding:
         return hash(self._encoding)
 
     def matching_uids(self) -> list[str]:
-        return self._matcher.get_matching_uids(self._encoding)
+        return self._matching_uids
 
     def is_resembling(self) -> bool:
         return self._encoding.startswith('~')

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -32,6 +32,9 @@ class Encoding:
     def __eq__(self, other: Self) -> bool:
         return self._encoding == other._encoding
 
+    def __hash__(self) -> int:
+        return hash(self._encoding)
+
     def matching_uids(self) -> list[str]:
         return self._matcher.get_matching_uids(self._encoding)
 
@@ -183,22 +186,22 @@ class Edge:
 
 class Unmatched:
     def __init__(self):
-        self._dropped: list[Encoding] = []
-        self._orphans: list[Encoding] = []
+        self._dropped: set[Encoding] = set()
+        self._orphans: set[Encoding] = set()
 
     @property
-    def dropped(self) -> list[Encoding]:
+    def dropped(self) -> set[Encoding]:
         return self._dropped
 
     @property
-    def orphans(self) -> list[Encoding]:
+    def orphans(self) -> set[Encoding]:
         return self._orphans
 
     def add_dropped(self, encoding: Encoding) -> None:
-        self._dropped.append(encoding)
+        self._dropped.add(encoding)
 
     def add_orphan(self, encoding: Encoding) -> None:
-        self._orphans.append(encoding)
+        self._orphans.add(encoding)
 
     def log(self) -> None:
         for encoding in self._dropped:

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -210,55 +210,34 @@ class Unmatched:
 
 class ParallelsEdges(Iterable):
     def __init__(self, entry: Entry, unmatched: Unmatched):
-        self._entry = entry
+        self._edge_type = entry.edge_type
+        self._full_encodings = [encoding for encoding in entry.encodings if not encoding.is_resembling()]
+        self._resembling_encodings = [encoding for encoding in entry.encodings if encoding.is_resembling()]
         self._unmatched = unmatched
 
     def __iter__(self) -> Iterator[Edge]:
-        return self._all_edges()
+        return (
+            Edge(self._edge_type, edge_encodings, edge_uids)
+            for edge_encodings in drop_unmatched_from(self._edge_encodings(), self._unmatched)
+            for edge_uids in self._uids(edge_encodings)
+        )
 
-    def _all_edges(self) -> Iterator[Edge]:
-        filtered = self._drop_unmatched(self._all_edge_encodings())
-        for edge_encodings in filtered:
-            for edge_uids in self._uids(edge_encodings):
-                yield Edge(self._entry.edge_type, edge_encodings, edge_uids)
-
-    def _drop_unmatched(self, edge_encodings: Iterable[EdgeEncodings]) -> Iterator[EdgeEncodings]:
-        for encodings in edge_encodings:
-            if encodings.from_.has_matching_uid():
-                yield encodings
-            else:
-                self._unmatched.add_dropped(encodings.from_)
-
-    def _all_edge_encodings(self) -> Iterator[EdgeEncodings]:
+    def _edge_encodings(self) -> Iterator[EdgeEncodings]:
         yield from self._full_to_full()
         yield from self._full_to_full_reversed()
         yield from self._full_to_resembling()
 
     def _full_to_full(self) -> Iterator[EdgeEncodings]:
-        return (
-            EdgeEncodings(from_, to)
-            for from_, to in combinations(self._full_encodings(), 2)
-        )
+        return (EdgeEncodings(from_, to) for from_, to in combinations(self._full_encodings, 2))
 
     def _full_to_full_reversed(self) -> Iterator[EdgeEncodings]:
-        for edge_encodings in self._full_to_full():
-            yield edge_encodings.reversed()
+        return (edge_encodings.reversed() for edge_encodings in self._full_to_full())
 
     def _full_to_resembling(self) -> Iterator[EdgeEncodings]:
-        for from_ in self._full_encodings():
-            for to in self._resembling_encodings():
-                yield EdgeEncodings(from_, to)
-
-    def _full_encodings(self) -> Iterator[Encoding]:
         return (
-            encoding for encoding in self._entry.encodings
-            if not encoding.is_resembling()
-        )
-
-    def _resembling_encodings(self) -> Iterator[Encoding]:
-        return (
-            encoding for encoding in self._entry.encodings
-            if encoding.is_resembling()
+            EdgeEncodings(from_, to)
+            for from_ in self._full_encodings
+            for to in self._resembling_encodings
         )
 
     def _uids(self, encodings: EdgeEncodings) -> Iterator[EdgeUids]:
@@ -270,6 +249,14 @@ class ParallelsEdges(Iterable):
             to_uids = ['orphan']
 
         return (EdgeUids(*uids) for uids in product(from_uids, to_uids))
+
+
+def drop_unmatched_from(edge_encodings: Iterable[EdgeEncodings], unmatched: Unmatched) -> Iterator[EdgeEncodings]:
+    for encodings in edge_encodings:
+        if encodings.from_.has_matching_uid():
+            yield encodings
+        else:
+            unmatched.add_dropped(encodings.from_)
 
 
 class OtherEdges(Iterable):

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Iterator, Iterable
 from dataclasses import dataclass
 from enum import StrEnum
-from itertools import product
+from itertools import product, combinations
 from pathlib import Path
 from typing import Self
 
@@ -214,25 +214,40 @@ class ParallelsEdges(Iterable):
         self._unmatched = unmatched
 
     def __iter__(self) -> Iterator[Edge]:
-        return (
-            Edge(self._entry.edge_type, encodings, uids)
-            for encodings in self._encodings()
-            for uids in self._uids(encodings)
-        )
+        return self._all_edges()
 
-    def _encodings(self) -> Iterator[EdgeEncodings]:
-        return (
-            EdgeEncodings(from_encoding, to_encoding)
-            for from_encoding in self._from_encodings()
-            for to_encoding in self._to_encodings(from_encoding)
-        )
+    def _all_edges(self) -> Iterator[Edge]:
+        filtered = self._drop_unmatched(self._all_edge_encodings())
+        for edge_encodings in filtered:
+            for edge_uids in self._uids(edge_encodings):
+                yield Edge(self._entry.edge_type, edge_encodings, edge_uids)
 
-    def _from_encodings(self) -> Iterator[Encoding]:
-        for encoding in self._full_encodings():
-            if encoding.has_matching_uid():
-                yield encoding
+    def _drop_unmatched(self, edge_encodings: Iterable[EdgeEncodings]) -> Iterator[EdgeEncodings]:
+        for encodings in edge_encodings:
+            if encodings.from_.has_matching_uid():
+                yield encodings
             else:
-                self._unmatched.add_dropped(encoding)
+                self._unmatched.add_dropped(encodings.from_)
+
+    def _all_edge_encodings(self) -> Iterator[EdgeEncodings]:
+        yield from self._full_to_full()
+        yield from self._full_to_full_reversed()
+        yield from self._full_to_resembling()
+
+    def _full_to_full(self) -> Iterator[EdgeEncodings]:
+        return (
+            EdgeEncodings(from_, to)
+            for from_, to in combinations(self._full_encodings(), 2)
+        )
+
+    def _full_to_full_reversed(self) -> Iterator[EdgeEncodings]:
+        for edge_encodings in self._full_to_full():
+            yield edge_encodings.reversed()
+
+    def _full_to_resembling(self) -> Iterator[EdgeEncodings]:
+        for from_ in self._full_encodings():
+            for to in self._resembling_encodings():
+                yield EdgeEncodings(from_, to)
 
     def _full_encodings(self) -> Iterator[Encoding]:
         return (
@@ -240,10 +255,10 @@ class ParallelsEdges(Iterable):
             if not encoding.is_resembling()
         )
 
-    def _to_encodings(self, from_encoding: Encoding) -> Iterator[Encoding]:
+    def _resembling_encodings(self) -> Iterator[Encoding]:
         return (
             encoding for encoding in self._entry.encodings
-            if encoding != from_encoding
+            if encoding.is_resembling()
         )
 
     def _uids(self, encodings: EdgeEncodings) -> Iterator[EdgeUids]:

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -330,24 +330,12 @@ def load_relationships(change_tracker: FileChangeTracker, relationship_dir: Path
 
 def import_entries(db: StandardDatabase, entries: list[Entry], unmatched: Unmatched) -> None:
     db['relationship'].truncate()
-    for entry in tqdm(entries):
-        edges = edges_for_entry(entry, unmatched)
-        for chunk in edge_chunks(edges):
-            write_chunk(db, chunk)
+    edges = entries_to_edges(tqdm(entries), unmatched)
+    for chunk in edge_chunks(edges):
+        write_chunk(db, chunk)
 
 
-def all_uids(db: StandardDatabase) -> set[str]:
-    return set(
-        db.aql.execute(
-            '''
-            FOR doc IN super_nav_details
-                RETURN doc.uid
-            '''
-        )
-    )
-
-
-def all_entries(relationship_data) -> list[Entry]:
+def all_entries(relationship_data: list[dict]) -> list[Entry]:
     return [
         Entry(entry_type, encodings)
         for entry_data in relationship_data
@@ -355,7 +343,12 @@ def all_entries(relationship_data) -> list[Entry]:
     ]
 
 
-def edges_for_entry(entry, unmatched):
+def entries_to_edges(entries: Iterable[Entry], unmatched: Unmatched) -> Iterator[Edge]:
+    for entry in entries:
+        yield from edges_for_entry(entry, unmatched)
+
+
+def edges_for_entry(entry: Entry, unmatched: Unmatched) -> Iterator[Edge]:
     if entry.entry_type == EntryType.PARALLELS:
         yield from ParallelsEdges(entry, unmatched)
     else:
@@ -373,4 +366,15 @@ def write_chunk(db: StandardDatabase, chunk: list[dict]):
         chunk,
         from_prefix='super_nav_details',
         to_prefix='super_nav_details'
+    )
+
+
+def all_uids(db: StandardDatabase) -> set[str]:
+    return set(
+        db.aql.execute(
+            '''
+            FOR doc IN super_nav_details
+                RETURN doc.uid
+            '''
+        )
     )

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -66,32 +66,30 @@ class Encoding:
         return self._encoding.lstrip('~').split('-')[0]
 
 
-class EntryType(StrEnum):
-    PARALLELS = 'parallels'
-    MENTIONS = 'mentions'
-    RETELLS = 'retells'
-
-
 class EdgeType(StrEnum):
     FULL = 'full'
     MENTION = 'mention'
     RETELLING = 'retelling'
 
 
-def to_edge_type(entry_type: EntryType) -> EdgeType:
-    edge_types = {
-        EntryType.PARALLELS: EdgeType.FULL,
-        EntryType.MENTIONS: EdgeType.MENTION,
-        EntryType.RETELLS: EdgeType.RETELLING,
-    }
+class EntryType(StrEnum):
+    PARALLELS = 'parallels'
+    MENTIONS = 'mentions'
+    RETELLS = 'retells'
 
-    return edge_types[entry_type]
+    def to_edge_type(self) -> EdgeType:
+        edge_types = {
+            EntryType.PARALLELS: EdgeType.FULL,
+            EntryType.MENTIONS: EdgeType.MENTION,
+            EntryType.RETELLS: EdgeType.RETELLING,
+        }
+
+        return edge_types[self]
 
 
 class Entry:
     def __init__(self, entry_type: str, encodings: list[str]):
         self._entry_type = EntryType(entry_type)
-        self._edge_type = to_edge_type(self._entry_type)
         self._encodings = [Encoding(encoding) for encoding in encodings]
 
     @property
@@ -100,7 +98,7 @@ class Entry:
 
     @property
     def edge_type(self) -> EdgeType:
-        return self._edge_type
+        return self.entry_type.to_edge_type()
 
     @property
     def encodings(self) -> list[Encoding]:

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -1,7 +1,7 @@
 import logging
-from collections import defaultdict
 from collections.abc import Iterator, Iterable
 from dataclasses import dataclass
+from enum import StrEnum
 from itertools import product
 from pathlib import Path
 from typing import Self
@@ -17,7 +17,11 @@ from data_loader.util import json_load
 
 
 class Encoding:
-    matcher: UidMatcher = UidMatcher(set())
+    _matcher: UidMatcher = UidMatcher(set())
+
+    @classmethod
+    def load_uids(cls, uids: Iterable[str]) -> None:
+        Encoding._matcher = UidMatcher(uids)
 
     def __init__(self, encoding: str):
         self._encoding = encoding
@@ -29,7 +33,7 @@ class Encoding:
         return self._encoding == other._encoding
 
     def matching_uids(self) -> list[str]:
-        return self.matcher.get_matching_uids(self._encoding)
+        return self._matcher.get_matching_uids(self._encoding)
 
     def is_resembling(self) -> bool:
         return self._encoding.startswith('~')
@@ -70,145 +74,180 @@ def all_uids(db: StandardDatabase) -> set[str]:
     )
 
 
-@dataclass
-class Entry:
-    entry_type: str
-    relationship_type: str
-    encodings: list[Encoding]
+class EntryType(StrEnum):
+    PARALLELS = 'parallels'
+    MENTIONS = 'mentions'
+    RETELLS = 'retells'
 
 
-def entries(relationship_file: Path) -> Iterator[Entry]:
-    relationship_data = json_load(relationship_file)
+class EdgeType(StrEnum):
+    FULL = 'full'
+    MENTION = 'mention'
+    RETELLING = 'retelling'
 
-    relationship_types = {
-        'retells': 'retelling',
-        'mentions': 'mention',
-        'parallels': 'full',
+
+def to_edge_type(entry_type: EntryType) -> EdgeType:
+    edge_types = {
+        EntryType.PARALLELS: EdgeType.FULL,
+        EntryType.MENTIONS: EdgeType.MENTION,
+        EntryType.RETELLS: EdgeType.RETELLING,
     }
 
+    return edge_types[entry_type]
+
+
+class Entry:
+    def __init__(self, entry_type: str, encodings: list[str]):
+        self._entry_type = EntryType(entry_type)
+        self._edge_type = to_edge_type(self._entry_type)
+        self._encodings = [Encoding(encoding) for encoding in encodings]
+
+    @property
+    def entry_type(self) -> EntryType:
+        return self._entry_type
+
+    @property
+    def edge_type(self) -> EdgeType:
+        return self._edge_type
+
+    @property
+    def encodings(self) -> list[Encoding]:
+        return self._encodings
+
+
+def entries(relationship_data: dict) -> Iterator[Entry]:
     for entry_data in relationship_data:
-        entry_data.pop('remarks', None)
         for entry_type, encodings in entry_data.items():
-            yield Entry(
-                entry_type=entry_type,
-                relationship_type=relationship_types[entry_type],
-                encodings=[Encoding(encoding) for encoding in encodings]
-            )
+            yield Entry(entry_type, encodings)
 
 
 class Remarks:
-    _remarks = defaultdict(dict)
+    def __init__(self, data: list[dict]):
+        self._remarks = {
+            self._relation_key(remark['relations']): remark['remark']
+            for remark in data
+        }
 
-    @classmethod
-    def load(cls, notes_file: Path):
-        cls._remarks = defaultdict(dict)
-        data = json_load(notes_file)
-        for remark in data:
-            uids = remark['relations']
-            remark_text = remark['remark']
-            cls._remarks[frozenset(uids)] = remark_text
+    def lookup(self, uids: Iterable[str]) -> str | None:
+        return self._remarks.get(self._relation_key(uids), None)
 
-    @classmethod
-    def lookup(cls, from_uid: str, to_uid: str) -> str | None:
-        return cls._remarks.get(frozenset([from_uid, to_uid]), None)
+    def _relation_key(self, uids: Iterable[str]) -> frozenset[str]:
+        return frozenset(uids)
 
 
 def load_relationships(change_tracker: FileChangeTracker, relationship_dir: Path, additional_info_dir: Path,
                        db: StandardDatabase) -> None:
     relationship_file = relationship_dir / Path('parallels.json')
-    if not change_tracker.is_file_new_or_changed(relationship_file):
+    notes_file = additional_info_dir / Path('notes.json')
+
+    if not change_tracker.is_any_file_new_or_changed([relationship_file, notes_file]):
         return
 
-    Encoding.matcher = UidMatcher(all_uids(db))
-    Remarks.load(additional_info_dir / Path('notes.json'))
+    relationship_data = json_load(relationship_file)
+    notes_data = json_load(notes_file)
+    uids = all_uids(db)
 
-    ll_edges = []
-    for entry in tqdm(entries(relationship_file)):
-        if entry.entry_type == 'parallels':
-            ll_edges.extend(parallels_edges(entry))
-        else:
-            ll_edges.extend(other_edges(entry))
+    Encoding.load_uids(uids)
+
+    edges = list(all_edges(relationship_data, notes_data))
 
     # Because there are many edges (nearly 400k at last count) chunk the import
     db['relationship'].truncate()
-    for chunk in chunks(ll_edges, 10000):
+    for chunk in chunks(edges, 10000):
         db['relationship'].import_bulk_logged(chunk, from_prefix='super_nav_details', to_prefix='super_nav_details')
 
 
-@dataclass
-class ParallelsEdgeData:
-    to_encoding: Encoding
-    from_encoding: Encoding
-    relationship_type: str
+def all_edges(relationship_data, notes_data) -> Iterator[dict]:
+    remarks = Remarks(notes_data)
+    for entry in tqdm(entries(relationship_data)):
+        if entry.entry_type == EntryType.PARALLELS:
+            yield from ParallelsEdges(entry, remarks)
+        else:
+            yield from OtherEdges(entry, remarks)
 
 
-def parallels_edges(entry: Entry, ) -> Iterator[dict]:
-    full_encodings = [encoding for encoding in entry.encodings if not encoding.is_resembling()]
+class ParallelsEdges(Iterable):
+    def __init__(self, entry: Entry, remarks: Remarks):
+        self._entry = entry
+        self._remarks = remarks
 
-    for from_encoding in drop_when_no_match(full_encodings):
-        to_encodings = [encoding for encoding in entry.encodings if encoding != from_encoding]
+    def __iter__(self) -> Iterator[dict]:
+        return iter(self.edges())
 
-        for to_encoding in to_encodings:
-            edge_data = ParallelsEdgeData(
-                to_encoding=to_encoding,
-                from_encoding=from_encoding,
-                relationship_type=entry.relationship_type
-            )
-            yield from create_parallel_edges(edge_data)
+    def edges(self) -> Iterator[dict]:
+        full_encodings = [encoding for encoding in self._entry.encodings if not encoding.is_resembling()]
+
+        for from_encoding in drop_when_no_match(full_encodings):
+            to_encodings = [encoding for encoding in self._entry.encodings if encoding != from_encoding]
+
+            for to_encoding in to_encodings:
+                yield from self.create_edges(to_encoding, from_encoding)
+
+    def create_edges(self, to_encoding: Encoding, from_encoding: Encoding) -> Iterator[dict]:
+        from_uids = from_encoding.matching_uids()
+        to_uids = to_encoding.matching_uids()
+
+        if not to_uids:
+            to_uids = ['orphan']
+            logging.info(f'Relationship to encoding could not be matched: {to_encoding} (appears as orphan)')
+
+        for from_uid, to_uid in product(from_uids, to_uids):
+            yield {
+                '_from': from_uid,
+                '_to': to_uid,
+                'from': str(from_encoding),
+                'number': from_encoding.number(),
+                'to': to_encoding.first_part(),
+                'type': str(self._entry.edge_type),
+                'resembling': to_encoding.is_resembling(),
+                'remark': self._remarks.lookup((from_uid, to_uid)),
+            }
 
 
-def create_parallel_edges(edge_data: ParallelsEdgeData) -> Iterator[dict]:
-    from_uids = edge_data.from_encoding.matching_uids()
-    to_uids = edge_data.to_encoding.matching_uids()
+class OtherEdges(Iterable):
+    def __init__(self, entry: Entry, remarks: Remarks):
+        self._entry = entry
+        self._remarks = remarks
 
-    if not to_uids:
-        to_uids = ['orphan']
-        logging.info(f'Relationship to encoding could not be matched: {edge_data.to_encoding} (appears as orphan)')
+    def __iter__(self) -> Iterator[dict]:
+        return iter(self.edges())
 
-    for from_uid, to_uid in product(from_uids, to_uids):
-        yield {
-            '_from': from_uid,
-            '_to': to_uid,
-            'from': str(edge_data.from_encoding),
-            'number': edge_data.from_encoding.number(),
-            'to': edge_data.to_encoding.first_part(),
-            'type': edge_data.relationship_type,
-            'resembling': edge_data.to_encoding.is_resembling(),
-            'remark': Remarks.lookup(from_uid, to_uid),
+    def edges(self) -> Iterator[dict]:
+        first_encoding = self._entry.encodings[0]
+        second_encodings = drop_when_no_match(self._entry.encodings[1:])
+
+        for first_uid in first_encoding.matching_uids():
+            for second_encoding in second_encodings:
+                for second_uid in second_encoding.matching_uids():
+                    yield from self.create_edges(first_encoding, second_encoding, first_uid, second_uid,)
+
+    def create_edges(self, first_encoding: Encoding, second_encoding: Encoding, first_uid: str, second_uid: str):
+        is_resembling = first_encoding.is_resembling() or second_encoding.is_resembling()
+        remark = self._remarks.lookup((second_uid, first_uid))
+
+        first_edge = {
+            '_from': first_uid,
+            '_to': second_uid,
+            'from': first_encoding.strip_resembling(),
+            'to': second_encoding.strip_resembling(),
+            'number': first_encoding.number(),
+            'type': str(self._entry.edge_type),
+            'resembling': is_resembling,
+            'remark': remark,
         }
 
+        second_edge = {
+            '_from': second_uid,
+            '_to': first_uid,
+            'from': second_encoding.strip_resembling(),
+            'to': first_encoding.strip_resembling(),
+            'number': second_encoding.number(),
+            'type': str(self._entry.edge_type),
+            'resembling': is_resembling,
+            'remark': remark,
+        }
 
-@dataclass
-class OtherEdgeData:
-    first_encoding: Encoding
-    second_encoding: Encoding
-    first_uid: str
-    second_uid: str
-    relationship_type: str
-    remark: str
-
-    @property
-    def is_resembling(self) -> bool:
-        return self.first_encoding.is_resembling() or self.second_encoding.is_resembling()
-
-
-def other_edges(entry: Entry) -> Iterator[dict]:
-    first_encoding = entry.encodings[0]
-    second_encodings = drop_when_no_match(entry.encodings[1:])
-
-    for first_uid in first_encoding.matching_uids():
-        for second_encoding in second_encodings:
-            for second_uid in second_encoding.matching_uids():
-                yield from create_other_edges(
-                    OtherEdgeData(
-                        first_encoding=first_encoding,
-                        second_encoding=second_encoding,
-                        first_uid=first_uid,
-                        second_uid=second_uid,
-                        relationship_type=entry.relationship_type,
-                        remark=Remarks.lookup(second_uid, first_uid)
-                    )
-                )
+        return first_edge, second_edge
 
 
 def drop_when_no_match(encodings: Iterable[Encoding]) -> Iterator[Encoding]:
@@ -217,29 +256,3 @@ def drop_when_no_match(encodings: Iterable[Encoding]) -> Iterator[Encoding]:
             yield encoding
         else:
             logging.error(f'Relationship encoding has no matching uids: {encoding} (dropped)')
-
-
-def create_other_edges(edge_data: OtherEdgeData):
-    first_edge = {
-        '_from': edge_data.first_uid,
-        '_to': edge_data.second_uid,
-        'from': edge_data.first_encoding.strip_resembling(),
-        'to': edge_data.second_encoding.strip_resembling(),
-        'number': edge_data.first_encoding.number(),
-        'type': edge_data.relationship_type,
-        'resembling': edge_data.is_resembling,
-        'remark': edge_data.remark,
-    }
-
-    second_edge = {
-        '_from': edge_data.second_uid,
-        '_to': edge_data.first_uid,
-        'from': edge_data.second_encoding.strip_resembling(),
-        'to': edge_data.first_encoding.strip_resembling(),
-        'number': edge_data.second_encoding.number(),
-        'type': edge_data.relationship_type,
-        'resembling': edge_data.is_resembling,
-        'remark': edge_data.remark,
-    }
-
-    return first_edge, second_edge

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -214,7 +214,7 @@ class OtherEdges(Iterable):
 
     def edges(self) -> Iterator[dict]:
         first_encoding = self._entry.encodings[0]
-        second_encodings = drop_when_no_match(self._entry.encodings[1:])
+        second_encodings = list(drop_when_no_match(self._entry.encodings[1:]))
 
         for first_uid in first_encoding.matching_uids():
             for second_encoding in second_encodings:

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from itertools import product
 from pathlib import Path
+from typing import Any, Literal
 
 import regex
 from arango.database import StandardDatabase
@@ -40,7 +41,36 @@ def generate_relationship_edges(
         relationship_data.extend(json_load(relationship_file))
 
     uid_matcher = get_uid_matcher(db)
+    remarks = get_remarks(additional_info_dir)
 
+    ll_edges = []
+    for entry in tqdm(relationship_data):
+        entry.pop('remarks', None)
+        for entry_type, uids in entry.items():
+            r_type = relationship_type(entry_type)
+
+            if r_type == 'full':
+                from_uid = handle_full_parallels(ll_edges, r_type, remarks, uid_matcher, uids)
+            else:
+                handle_other_parallels(from_uid, ll_edges, r_type, remarks, uid_matcher, uids)
+
+    # Because there are many edges (nearly 400k at last count) chunk the import
+    db['relationship'].truncate()
+    for chunk in chunks(ll_edges, 10000):
+        db['relationship'].import_bulk_logged(chunk, from_prefix='super_nav_details', to_prefix='super_nav_details')
+
+
+def relationship_type(entry_type: str) -> str:
+    if entry_type == 'retells':
+        return 'retelling'
+    elif entry_type == 'mentions':
+        return 'mention'
+    elif entry_type == 'parallels':
+        return 'full'
+    raise ValueError(f'Invalid relationship type "{entry_type}"')
+
+
+def get_remarks(additional_info_dir: Path) -> defaultdict[Any, dict]:
     remarks_data = json_load(additional_info_dir / 'notes.json')
 
     remarks = defaultdict(dict)
@@ -49,116 +79,104 @@ def generate_relationship_edges(
         uids = remark['relations']
         remark_text = remark['remark']
         remarks[frozenset(uids)] = remark_text
+    return remarks
 
-    ll_edges = []
-    for entry in tqdm(relationship_data):
-        entry.pop('remarks', None)
-        for r_type, uids in entry.items():
-            if r_type == 'retells':
-                r_type = 'retelling'
-            elif r_type == 'mentions':
-                r_type = 'mention'
-            elif r_type == 'parallels':
-                r_type = 'full'
 
-            if r_type == 'full':
-                full = [uid for uid in uids if not uid.startswith('~')]
-                partial = [uid for uid in uids if uid.startswith('~')]
-                for from_uid in full:
-                    m = regex.search('[0-9]+$', from_uid)
-                    if m:
-                        from_nr = int(m[0])
-                    else:
-                        from_nr = 0
-                    true_from_uids = uid_matcher.get_matching_uids(from_uid)
-                    if not true_from_uids and ' ' not in from_uid:
-                        logging.error(
-                            f'Relationship from uid could not be matched: {from_uid} (dropped)'
-                        )
-                        continue
+def handle_full_parallels(ll_edges: list[Any], r_type: Literal['full'], remarks: defaultdict[Any, dict],
+                          uid_matcher: UidMatcher, uids) -> Any:
+    full = [uid for uid in uids if not uid.startswith('~')]
+    partial = [uid for uid in uids if uid.startswith('~')]
+    for from_uid in full:
+        from_nr = uid_number(from_uid)
+        true_from_uids = uid_matcher.get_matching_uids(from_uid)
+        if not true_from_uids and ' ' not in from_uid:
+            logging.error(
+                f'Relationship from uid could not be matched: {from_uid} (dropped)'
+            )
+            continue
 
-                    for to_uids, is_resembling in ((full, False), (partial, True)):
-                        for to_uid in to_uids:
-                            if to_uid == from_uid:
-                                continue
-                            true_to_uids = uid_matcher.get_matching_uids(to_uid)
-                            if not true_to_uids:
-                                logging.info(
-                                    f'Relationship to uid could not be matched: {to_uid} (appears as orphan)'
-                                )
-                                true_to_uids = ['orphan']
+        for to_uids, is_resembling in ((full, False), (partial, True)):
+            for to_uid in to_uids:
+                if to_uid == from_uid:
+                    continue
+                true_to_uids = uid_matcher.get_matching_uids(to_uid)
+                if not true_to_uids:
+                    logging.info(
+                        f'Relationship to uid could not be matched: {to_uid} (appears as orphan)'
+                    )
+                    true_to_uids = ['orphan']
 
-                            for true_from_uid in true_from_uids:
-                                for true_to_uid in true_to_uids:
-                                    remark = remarks.get(
-                                        frozenset([true_from_uid, true_to_uid]), None
-                                    )
-                                    ll_edges.append(
-                                        {
-                                            '_from': true_from_uid,
-                                            '_to': true_to_uid,
-                                            'from': from_uid,
-                                            'number': from_nr,
-                                            'to': to_uid.lstrip('~').split('-')[0],
-                                            'type': r_type,
-                                            'resembling': is_resembling,
-                                            'remark': remark,
-                                        }
-                                    )
-            else:
-                first_uid = uids[0]
-                m = regex.search('[0-9]+$', first_uid)
-                if m:
-                    from_nr = int(m[0])
-                else:
-                    from_nr = 0
-                true_first_uids = uid_matcher.get_matching_uids(first_uid)
-                for true_first_uid, to_uid in product(true_first_uids, uids[1:]):
-                    true_from_uids = uid_matcher.get_matching_uids(to_uid)
-                    if not true_from_uids and ' ' not in from_uid:
-                        logging.error(
-                            f'Relationship from uid could not be matched: {from_uid} (dropped)'
-                        )
-                        continue
-                    for true_from_uid in true_from_uids:
+                for true_from_uid in true_from_uids:
+                    for true_to_uid in true_to_uids:
                         remark = remarks.get(
-                            frozenset([true_from_uid, true_first_uid]), None
+                            frozenset([true_from_uid, true_to_uid]), None
                         )
-                        ll_edges.append(
-                            {
-                                '_from': true_first_uid,
-                                '_to': true_from_uid,
-                                'from': first_uid.lstrip('~'),
-                                'to': to_uid,
-                                'number': from_nr,
-                                'type': r_type,
-                                'resembling': any(
-                                    x.startswith('~') for x in [first_uid, from_uid]
-                                ),
-                                'remark': remark,
-                            }
-                        )
-                        m = regex.search('[0-9]+$', to_uid)
-                        if m:
-                            to_nr = int(m[0])
-                        else:
-                            to_nr = 0
                         ll_edges.append(
                             {
                                 '_from': true_from_uid,
-                                '_to': true_first_uid,
-                                'from': to_uid,
-                                'to': first_uid.lstrip('~'),
-                                'number': to_nr,
+                                '_to': true_to_uid,
+                                'from': from_uid,
+                                'number': from_nr,
+                                'to': to_uid.lstrip('~').split('-')[0],
                                 'type': r_type,
-                                'resembling': any(
-                                    x.startswith('~') for x in [first_uid, from_uid]
-                                ),
+                                'resembling': is_resembling,
                                 'remark': remark,
                             }
                         )
+    return from_uid
 
-    # Because there are many edges (nearly 400k at last count) chunk the import
-    db['relationship'].truncate()
-    for chunk in chunks(ll_edges, 10000):
-        db['relationship'].import_bulk_logged(chunk, from_prefix='super_nav_details', to_prefix='super_nav_details')
+
+def handle_other_parallels(from_uid, ll_edges: list[Any], r_type: str | Any, remarks: defaultdict[Any, dict],
+                           uid_matcher: UidMatcher, uids):
+    first_uid = uids[0]
+    from_nr = uid_number(first_uid)
+    true_first_uids = uid_matcher.get_matching_uids(first_uid)
+    for true_first_uid, to_uid in product(true_first_uids, uids[1:]):
+        true_from_uids = uid_matcher.get_matching_uids(to_uid)
+        if not true_from_uids and ' ' not in from_uid:
+            logging.error(
+                f'Relationship from uid could not be matched: {from_uid} (dropped)'
+            )
+            continue
+        for true_from_uid in true_from_uids:
+            remark = remarks.get(
+                frozenset([true_from_uid, true_first_uid]), None
+            )
+            ll_edges.append(
+                {
+                    '_from': true_first_uid,
+                    '_to': true_from_uid,
+                    'from': first_uid.lstrip('~'),
+                    'to': to_uid,
+                    'number': from_nr,
+                    'type': r_type,
+                    'resembling': any(
+                        x.startswith('~') for x in [first_uid, from_uid]
+                    ),
+                    'remark': remark,
+                }
+            )
+            to_nr = uid_number(to_uid)
+            ll_edges.append(
+                {
+                    '_from': true_from_uid,
+                    '_to': true_first_uid,
+                    'from': to_uid,
+                    'to': first_uid.lstrip('~'),
+                    'number': to_nr,
+                    'type': r_type,
+                    'resembling': any(
+                        x.startswith('~') for x in [first_uid, from_uid]
+                    ),
+                    'remark': remark,
+                }
+            )
+
+
+def uid_number(first_uid) -> int:
+    m = regex.search('[0-9]+$', first_uid)
+    if m:
+        from_nr = int(m[0])
+    else:
+        from_nr = 0
+    return from_nr

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -50,9 +50,9 @@ def generate_relationship_edges(
             r_type = relationship_type(entry_type)
 
             if r_type == 'full':
-                from_uid = handle_full_parallels(ll_edges, r_type, remarks, uid_matcher, uids)
+                handle_full_parallels(ll_edges, r_type, remarks, uid_matcher, uids)
             else:
-                handle_other_parallels(from_uid, ll_edges, r_type, remarks, uid_matcher, uids)
+                handle_other_parallels(ll_edges, r_type, remarks, uid_matcher, uids)
 
     # Because there are many edges (nearly 400k at last count) chunk the import
     db['relationship'].truncate()
@@ -83,7 +83,7 @@ def get_remarks(additional_info_dir: Path) -> defaultdict[Any, dict]:
 
 
 def handle_full_parallels(ll_edges: list[Any], r_type: Literal['full'], remarks: defaultdict[Any, dict],
-                          uid_matcher: UidMatcher, uids) -> Any:
+                          uid_matcher: UidMatcher, uids) -> None:
     full = [uid for uid in uids if not uid.startswith('~')]
     partial = [uid for uid in uids if uid.startswith('~')]
     for from_uid in full:
@@ -123,19 +123,19 @@ def handle_full_parallels(ll_edges: list[Any], r_type: Literal['full'], remarks:
                                 'remark': remark,
                             }
                         )
-    return from_uid
 
 
-def handle_other_parallels(from_uid, ll_edges: list[Any], r_type: str | Any, remarks: defaultdict[Any, dict],
-                           uid_matcher: UidMatcher, uids):
+def handle_other_parallels(ll_edges: list[Any], r_type: str | Any, remarks: defaultdict[Any, dict],
+                           uid_matcher: UidMatcher, uids) -> None:
     first_uid = uids[0]
     from_nr = uid_number(first_uid)
     true_first_uids = uid_matcher.get_matching_uids(first_uid)
     for true_first_uid, to_uid in product(true_first_uids, uids[1:]):
+        # Legacy code mystery: Why does true_from_ids come from to_uid?
         true_from_uids = uid_matcher.get_matching_uids(to_uid)
-        if not true_from_uids and ' ' not in from_uid:
+        if not true_from_uids and ' ' not in to_uid:
             logging.error(
-                f'Relationship from uid could not be matched: {from_uid} (dropped)'
+                f'Relationship from uid could not be matched: {to_uid} (dropped)'
             )
             continue
         for true_from_uid in true_from_uids:

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -1,8 +1,10 @@
 import logging
 from collections import defaultdict
+from collections.abc import Iterator, Iterable
+from dataclasses import dataclass
 from itertools import product
 from pathlib import Path
-from typing import Any, Literal
+from typing import Self
 
 import regex
 from arango.database import StandardDatabase
@@ -14,8 +16,52 @@ from data_loader.ports import FileChangeTracker
 from data_loader.util import json_load
 
 
-def get_uid_matcher(db: StandardDatabase) -> UidMatcher:
-    all_uids = set(
+class Encoding:
+    all_uids: set[str] = set()
+
+    def __init__(self, encoding: str):
+        self._matcher = UidMatcher(self.all_uids)
+        self._encoding = encoding
+
+    def __str__(self) -> str:
+        return self._encoding
+
+    def __eq__(self, other: Self) -> bool:
+        return self._encoding == other._encoding
+
+    def matching_uids(self) -> list[str]:
+        return self._matcher.get_matching_uids(self._encoding)
+
+    def is_resembling(self) -> bool:
+        return self._encoding.startswith('~')
+
+    def is_external(self) -> bool:
+        return ' ' in self._encoding
+
+    def has_matching_uid(self) -> bool:
+        if self.is_external():
+            return True
+        if self.matching_uids():
+            return True
+        return False
+
+    def number(self) -> int:
+        m = regex.search('[0-9]+$', self._encoding)
+        if m:
+            from_nr = int(m[0])
+        else:
+            from_nr = 0
+        return from_nr
+
+    def strip_resembling(self) -> str:
+        return self._encoding.lstrip('~')
+
+    def first_part(self) -> str:
+        return self._encoding.lstrip('~').split('-')[0]
+
+
+def all_uids(db: StandardDatabase) -> set[str]:
+    return set(
         db.aql.execute(
             '''
             FOR doc IN super_nav_details
@@ -24,35 +70,65 @@ def get_uid_matcher(db: StandardDatabase) -> UidMatcher:
         )
     )
 
-    return UidMatcher(all_uids)
+
+@dataclass
+class Entry:
+    entry_type: str
+    relationship_type: str
+    encodings: list[Encoding]
 
 
-def generate_relationship_edges(
-        change_tracker: FileChangeTracker, relationship_dir: Path, additional_info_dir: Path, db: StandardDatabase
-) -> None:
-    relationship_files = [relationship_dir / Path('parallels.json')]
+def entries(relationship_file: Path) -> Iterator[Entry]:
+    relationship_data = json_load(relationship_file)
 
-    if not change_tracker.is_any_file_new_or_changed(relationship_files):
+    relationship_types = {
+        'retells': 'retelling',
+        'mentions': 'mention',
+        'parallels': 'full',
+    }
+
+    for entry_data in relationship_data:
+        entry_data.pop('remarks', None)
+        for entry_type, encodings in entry_data.items():
+            yield Entry(
+                entry_type=entry_type,
+                relationship_type=relationship_types[entry_type],
+                encodings=[Encoding(encoding) for encoding in encodings]
+            )
+
+
+class Remarks:
+    _remarks = defaultdict(dict)
+
+    @classmethod
+    def load(cls, notes_file: Path):
+        cls._remarks = defaultdict(dict)
+        data = json_load(notes_file)
+        for remark in data:
+            uids = remark['relations']
+            remark_text = remark['remark']
+            cls._remarks[frozenset(uids)] = remark_text
+
+    @classmethod
+    def lookup(cls, from_uid: str, to_uid: str) -> str | None:
+        return cls._remarks.get(frozenset([from_uid, to_uid]), None)
+
+
+def load_relationships(change_tracker: FileChangeTracker, relationship_dir: Path, additional_info_dir: Path,
+                       db: StandardDatabase) -> None:
+    relationship_file = relationship_dir / Path('parallels.json')
+    if not change_tracker.is_file_new_or_changed(relationship_file):
         return
 
-    print('Generating Parallels')
-    relationship_data = []
-    for relationship_file in relationship_files:
-        relationship_data.extend(json_load(relationship_file))
-
-    uid_matcher = get_uid_matcher(db)
-    remarks = get_remarks(additional_info_dir)
+    Encoding.all_uids = all_uids(db)
+    Remarks.load(additional_info_dir / Path('notes.json'))
 
     ll_edges = []
-    for entry in tqdm(relationship_data):
-        entry.pop('remarks', None)
-        for entry_type, uids in entry.items():
-            r_type = relationship_type(entry_type)
-
-            if r_type == 'full':
-                handle_full_parallels(ll_edges, r_type, remarks, uid_matcher, uids)
-            else:
-                handle_other_parallels(ll_edges, r_type, remarks, uid_matcher, uids)
+    for entry in tqdm(entries(relationship_file)):
+        if entry.entry_type == 'parallels':
+            ll_edges.extend(parallels_edges(entry))
+        else:
+            ll_edges.extend(other_edges(entry))
 
     # Because there are many edges (nearly 400k at last count) chunk the import
     db['relationship'].truncate()
@@ -60,119 +136,111 @@ def generate_relationship_edges(
         db['relationship'].import_bulk_logged(chunk, from_prefix='super_nav_details', to_prefix='super_nav_details')
 
 
-def relationship_type(entry_type: str) -> str:
-    if entry_type == 'retells':
-        return 'retelling'
-    elif entry_type == 'mentions':
-        return 'mention'
-    elif entry_type == 'parallels':
-        return 'full'
-    raise ValueError(f'Invalid relationship type "{entry_type}"')
+@dataclass
+class ParallelsEdgeData:
+    to_encoding: Encoding
+    from_encoding: Encoding
+    relationship_type: str
 
 
-def get_remarks(additional_info_dir: Path) -> defaultdict[Any, dict]:
-    remarks_data = json_load(additional_info_dir / 'notes.json')
+def parallels_edges(entry: Entry, ) -> Iterator[dict]:
+    full_encodings = [encoding for encoding in entry.encodings if not encoding.is_resembling()]
 
-    remarks = defaultdict(dict)
+    for from_encoding in drop_when_no_match(full_encodings):
+        to_encodings = [encoding for encoding in entry.encodings if encoding != from_encoding]
 
-    for remark in remarks_data:
-        uids = remark['relations']
-        remark_text = remark['remark']
-        remarks[frozenset(uids)] = remark_text
-    return remarks
-
-
-def handle_full_parallels(ll_edges: list[Any], r_type: Literal['full'], remarks: defaultdict[Any, dict],
-                          uid_matcher: UidMatcher, uids) -> None:
-    full = [uid for uid in uids if not uid.startswith('~')]
-    partial = [uid for uid in uids if uid.startswith('~')]
-    for from_uid in full:
-        from_nr = uid_number(from_uid)
-        true_from_uids = uid_matcher.get_matching_uids(from_uid)
-        if not true_from_uids and ' ' not in from_uid:
-            logging.error(
-                f'Relationship from uid could not be matched: {from_uid} (dropped)'
+        for to_encoding in to_encodings:
+            edge_data = ParallelsEdgeData(
+                to_encoding=to_encoding,
+                from_encoding=from_encoding,
+                relationship_type=entry.relationship_type
             )
-            continue
+            yield from create_parallel_edges(edge_data)
 
-        for to_uids, is_resembling in ((full, False), (partial, True)):
-            for to_uid in to_uids:
-                if to_uid == from_uid:
-                    continue
-                true_to_uids = uid_matcher.get_matching_uids(to_uid)
-                if not true_to_uids:
-                    logging.info(
-                        f'Relationship to uid could not be matched: {to_uid} (appears as orphan)'
+
+def create_parallel_edges(edge_data: ParallelsEdgeData) -> Iterator[dict]:
+    from_uids = edge_data.from_encoding.matching_uids()
+    to_uids = edge_data.to_encoding.matching_uids()
+
+    if not to_uids:
+        to_uids = ['orphan']
+        logging.info(f'Relationship to encoding could not be matched: {edge_data.to_encoding} (appears as orphan)')
+
+    for from_uid, to_uid in product(from_uids, to_uids):
+        yield {
+            '_from': from_uid,
+            '_to': to_uid,
+            'from': str(edge_data.from_encoding),
+            'number': edge_data.from_encoding.number(),
+            'to': edge_data.to_encoding.first_part(),
+            'type': edge_data.relationship_type,
+            'resembling': edge_data.to_encoding.is_resembling(),
+            'remark': Remarks.lookup(from_uid, to_uid),
+        }
+
+
+@dataclass
+class OtherEdgeData:
+    first_encoding: Encoding
+    second_encoding: Encoding
+    first_uid: str
+    second_uid: str
+    relationship_type: str
+    remark: str
+
+    @property
+    def is_resembling(self) -> bool:
+        return self.first_encoding.is_resembling() or self.second_encoding.is_resembling()
+
+
+def other_edges(entry: Entry) -> Iterator[dict]:
+    first_encoding = entry.encodings[0]
+    second_encodings = drop_when_no_match(entry.encodings[1:])
+
+    for first_uid in first_encoding.matching_uids():
+        for second_encoding in second_encodings:
+            for second_uid in second_encoding.matching_uids():
+                yield from create_other_edges(
+                    OtherEdgeData(
+                        first_encoding=first_encoding,
+                        second_encoding=second_encoding,
+                        first_uid=first_uid,
+                        second_uid=second_uid,
+                        relationship_type=entry.relationship_type,
+                        remark=Remarks.lookup(second_uid, first_uid)
                     )
-                    true_to_uids = ['orphan']
-
-                for true_from_uid in true_from_uids:
-                    for true_to_uid in true_to_uids:
-                        remark = remarks.get(
-                            frozenset([true_from_uid, true_to_uid]), None
-                        )
-                        ll_edges.append(
-                            {
-                                '_from': true_from_uid,
-                                '_to': true_to_uid,
-                                'from': from_uid,
-                                'number': from_nr,
-                                'to': to_uid.lstrip('~').split('-')[0],
-                                'type': r_type,
-                                'resembling': is_resembling,
-                                'remark': remark,
-                            }
-                        )
+                )
 
 
-def handle_other_parallels(ll_edges: list[Any], r_type: str | Any, remarks: defaultdict[Any, dict],
-                           uid_matcher: UidMatcher, uids) -> None:
-    first_uid = uids[0]
-    from_nr = uid_number(first_uid)
-    true_first_uids = uid_matcher.get_matching_uids(first_uid)
-    for true_first_uid, to_uid in product(true_first_uids, uids[1:]):
-        # Legacy code mystery: Why does true_from_ids come from to_uid?
-        true_from_uids = uid_matcher.get_matching_uids(to_uid)
-        if not true_from_uids and ' ' not in to_uid:
-            logging.error(
-                f'Relationship from uid could not be matched: {to_uid} (dropped)'
-            )
-            continue
-        for true_from_uid in true_from_uids:
-            remark = remarks.get(
-                frozenset([true_from_uid, true_first_uid]), None
-            )
-            ll_edges.append(
-                {
-                    '_from': true_first_uid,
-                    '_to': true_from_uid,
-                    'from': first_uid.lstrip('~'),
-                    'to': to_uid.lstrip('~'),
-                    'number': from_nr,
-                    'type': r_type,
-                    'resembling': any(x.startswith('~') for x in [first_uid, to_uid]),
-                    'remark': remark,
-                }
-            )
-            to_nr = uid_number(to_uid)
-            ll_edges.append(
-                {
-                    '_from': true_from_uid,
-                    '_to': true_first_uid,
-                    'from': to_uid.lstrip('~'),
-                    'to': first_uid.lstrip('~'),
-                    'number': to_nr,
-                    'type': r_type,
-                    'resembling': any(x.startswith('~') for x in [first_uid, to_uid]),
-                    'remark': remark,
-                }
-            )
+def drop_when_no_match(encodings: Iterable[Encoding]) -> Iterator[Encoding]:
+    for encoding in encodings:
+        if encoding.has_matching_uid():
+            yield encoding
+        else:
+            logging.error(f'Relationship encoding has no matching uids: {encoding} (dropped)')
 
 
-def uid_number(first_uid) -> int:
-    m = regex.search('[0-9]+$', first_uid)
-    if m:
-        from_nr = int(m[0])
-    else:
-        from_nr = 0
-    return from_nr
+def create_other_edges(edge_data: OtherEdgeData):
+    first_edge = {
+        '_from': edge_data.first_uid,
+        '_to': edge_data.second_uid,
+        'from': edge_data.first_encoding.strip_resembling(),
+        'to': edge_data.second_encoding.strip_resembling(),
+        'number': edge_data.first_encoding.number(),
+        'type': edge_data.relationship_type,
+        'resembling': edge_data.is_resembling,
+        'remark': edge_data.remark,
+    }
+
+    second_edge = {
+        '_from': edge_data.second_uid,
+        '_to': edge_data.first_uid,
+        'from': edge_data.second_encoding.strip_resembling(),
+        'to': edge_data.first_encoding.strip_resembling(),
+        'number': edge_data.second_encoding.number(),
+        'type': edge_data.relationship_type,
+        'resembling': edge_data.is_resembling,
+        'remark': edge_data.remark,
+    }
+
+    return first_edge, second_edge

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -11,7 +11,7 @@ from arango.database import StandardDatabase
 from tqdm import tqdm
 
 from common.uid_matcher import UidMatcher
-from common.utils import chunks
+from common import utils
 from data_loader.ports import FileChangeTracker
 from data_loader.util import json_load
 
@@ -63,17 +63,6 @@ class Encoding:
         return self._encoding.lstrip('~').split('-')[0]
 
 
-def all_uids(db: StandardDatabase) -> set[str]:
-    return set(
-        db.aql.execute(
-            '''
-            FOR doc IN super_nav_details
-                RETURN doc.uid
-            '''
-        )
-    )
-
-
 class EntryType(StrEnum):
     PARALLELS = 'parallels'
     MENTIONS = 'mentions'
@@ -115,12 +104,6 @@ class Entry:
         return self._encodings
 
 
-def entries(relationship_data: dict) -> Iterator[Entry]:
-    for entry_data in relationship_data:
-        for entry_type, encodings in entry_data.items():
-            yield Entry(entry_type, encodings)
-
-
 class Remarks:
     def __init__(self, data: list[dict]):
         self._remarks = {
@@ -133,6 +116,192 @@ class Remarks:
 
     def _relation_key(self, uids: Iterable[str]) -> frozenset[str]:
         return frozenset(uids)
+
+
+@dataclass
+class EdgeEncodings:
+    from_: Encoding
+    to: Encoding
+
+    def reversed(self) -> Self:
+        return EdgeEncodings(self.to, self.from_)
+
+
+@dataclass
+class EdgeUids:
+    from_: str
+    to: str
+
+    def reversed(self) -> Self:
+        return EdgeUids(self.to, self.from_)
+
+
+class Edge:
+    _remarks = Remarks([])
+
+    @classmethod
+    def load_remarks(cls, notes_data) -> None:
+        Edge._remarks = Remarks(notes_data)
+
+    def __init__(self, edge_type: EdgeType, encodings: EdgeEncodings, uids: EdgeUids):
+        self._edge_type = edge_type
+        self._encodings = encodings
+        self._uids = uids
+
+    def _from(self) -> str:
+        return self._encodings.from_.strip_resembling()
+
+    def _to(self) -> str:
+        # Note: Requires further scrutiny. Why is the handling different?
+        if self._edge_type == EdgeType.FULL:
+            return self._encodings.to.first_part()
+        else:
+            return self._encodings.to.strip_resembling()
+
+    def _number(self) -> int:
+        return self._encodings.from_.number()
+
+    def _resembling(self) -> bool:
+        # Note: for parallels entries the first encoding is never resembling.
+        return self._encodings.from_.is_resembling() or self._encodings.to.is_resembling()
+
+    def _remark(self) -> str:
+        return self._remarks.lookup((self._uids.from_, self._uids.to))
+
+    def as_dict(self) -> dict:
+        return {
+            '_from': self._uids.from_,
+            '_to': self._uids.to,
+            'from': self._from(),
+            'to': self._to(),
+            'number': self._number(),
+            'type': str(self._edge_type),
+            'resembling': self._resembling(),
+            'remark': self._remark(),
+        }
+
+
+class Unmatched:
+    def __init__(self):
+        self._dropped: list[Encoding] = []
+        self._orphans: list[Encoding] = []
+
+    @property
+    def dropped(self) -> list[Encoding]:
+        return self._dropped
+
+    @property
+    def orphans(self) -> list[Encoding]:
+        return self._orphans
+
+    def add_dropped(self, encoding: Encoding) -> None:
+        self._dropped.append(encoding)
+
+    def add_orphan(self, encoding: Encoding) -> None:
+        self._orphans.append(encoding)
+
+    def log(self) -> None:
+        for encoding in self._dropped:
+            logging.error(f'Relationship encoding has no matching uids: {encoding} (dropped)')
+
+        for encoding in self._orphans:
+            logging.info(f'Relationship to encoding could not be matched: {encoding} (appears as orphan)')
+
+
+class ParallelsEdges(Iterable):
+    def __init__(self, entry: Entry, unmatched: Unmatched):
+        self._entry = entry
+        self._unmatched = unmatched
+
+    def __iter__(self) -> Iterator[Edge]:
+        return (
+            Edge(self._entry.edge_type, encodings, uids)
+            for encodings in self._encodings()
+            for uids in self._uids(encodings)
+        )
+
+    def _encodings(self) -> Iterator[EdgeEncodings]:
+        return (
+            EdgeEncodings(from_encoding, to_encoding)
+            for from_encoding in self._from_encodings()
+            for to_encoding in self._to_encodings(from_encoding)
+        )
+
+    def _from_encodings(self) -> Iterator[Encoding]:
+        for encoding in self._full_encodings():
+            if encoding.has_matching_uid():
+                yield encoding
+            else:
+                self._unmatched.add_dropped(encoding)
+
+    def _full_encodings(self) -> Iterator[Encoding]:
+        return (
+            encoding for encoding in self._entry.encodings
+            if not encoding.is_resembling()
+        )
+
+    def _to_encodings(self, from_encoding: Encoding) -> Iterator[Encoding]:
+        return (
+            encoding for encoding in self._entry.encodings
+            if encoding != from_encoding
+        )
+
+    def _uids(self, encodings: EdgeEncodings) -> Iterator[EdgeUids]:
+        from_uids = encodings.from_.matching_uids()
+        to_uids = encodings.to.matching_uids()
+
+        if not to_uids:
+            self._unmatched.add_orphan(encodings.to)
+            to_uids = ['orphan']
+
+        return (EdgeUids(*uids) for uids in product(from_uids, to_uids))
+
+
+class OtherEdges(Iterable):
+    def __init__(self, entry: Entry, unmatched: Unmatched):
+        self._edge_type = entry.edge_type
+        self._first = entry.encodings[0]
+        self._others = entry.encodings[1:]
+        self._drop_encodings(unmatched)
+
+    def __iter__(self) -> Iterator[Edge]:
+        return (
+            edge for encodings in self._encodings()
+            for uids in self._uids(encodings)
+            for edge in self._reciprocal_edges(encodings, uids)
+        )
+
+    def _reciprocal_edges(self, encodings: EdgeEncodings, uids: EdgeUids) -> Iterator[Edge]:
+        yield Edge(self._edge_type, encodings, uids)
+        yield Edge(self._edge_type, encodings.reversed(), uids.reversed())
+
+    def _encodings(self) -> Iterator[EdgeEncodings]:
+        return (
+            EdgeEncodings(self._first, second)
+            for second in self._matched_others()
+        )
+
+    def _uids(self, encodings: EdgeEncodings) -> Iterator[EdgeUids]:
+        return (
+            EdgeUids(first_uid, second_uid)
+            for first_uid in encodings.from_.matching_uids()
+            for second_uid in encodings.to.matching_uids()
+        )
+
+    def _matched_others(self) -> Iterator[Encoding]:
+        return (
+            encoding for encoding in self._others
+            if encoding.has_matching_uid()
+        )
+
+    def _drop_encodings(self, unmatched: Unmatched) -> None:
+        to_drop = (
+            encoding for encoding in self._others
+            if not encoding.has_matching_uid()
+        )
+
+        for encoding in to_drop:
+            unmatched.add_dropped(encoding)
 
 
 def load_relationships(change_tracker: FileChangeTracker, relationship_dir: Path, additional_info_dir: Path,
@@ -148,111 +317,57 @@ def load_relationships(change_tracker: FileChangeTracker, relationship_dir: Path
     uids = all_uids(db)
 
     Encoding.load_uids(uids)
+    Edge.load_remarks(notes_data)
 
-    edges = list(all_edges(relationship_data, notes_data))
+    unmatched = Unmatched()
+    entries = all_entries(relationship_data)
+    import_entries(db, entries, unmatched)
+    unmatched.log()
 
-    # Because there are many edges (nearly 400k at last count) chunk the import
+
+def import_entries(db: StandardDatabase, entries: list[Entry], unmatched: Unmatched) -> None:
     db['relationship'].truncate()
-    for chunk in chunks(edges, 10000):
-        db['relationship'].import_bulk_logged(chunk, from_prefix='super_nav_details', to_prefix='super_nav_details')
+    for entry in tqdm(entries):
+        edges = edges_for_entry(entry, unmatched)
+        for chunk in edge_chunks(edges):
+            write_chunk(db, chunk)
 
 
-def all_edges(relationship_data, notes_data) -> Iterator[dict]:
-    remarks = Remarks(notes_data)
-    for entry in tqdm(entries(relationship_data)):
-        if entry.entry_type == EntryType.PARALLELS:
-            yield from ParallelsEdges(entry, remarks)
-        else:
-            yield from OtherEdges(entry, remarks)
+def all_uids(db: StandardDatabase) -> set[str]:
+    return set(
+        db.aql.execute(
+            '''
+            FOR doc IN super_nav_details
+                RETURN doc.uid
+            '''
+        )
+    )
 
 
-class ParallelsEdges(Iterable):
-    def __init__(self, entry: Entry, remarks: Remarks):
-        self._entry = entry
-        self._remarks = remarks
-
-    def __iter__(self) -> Iterator[dict]:
-        return iter(self.edges())
-
-    def edges(self) -> Iterator[dict]:
-        full_encodings = [encoding for encoding in self._entry.encodings if not encoding.is_resembling()]
-
-        for from_encoding in drop_when_no_match(full_encodings):
-            to_encodings = [encoding for encoding in self._entry.encodings if encoding != from_encoding]
-
-            for to_encoding in to_encodings:
-                yield from self.create_edges(to_encoding, from_encoding)
-
-    def create_edges(self, to_encoding: Encoding, from_encoding: Encoding) -> Iterator[dict]:
-        from_uids = from_encoding.matching_uids()
-        to_uids = to_encoding.matching_uids()
-
-        if not to_uids:
-            to_uids = ['orphan']
-            logging.info(f'Relationship to encoding could not be matched: {to_encoding} (appears as orphan)')
-
-        for from_uid, to_uid in product(from_uids, to_uids):
-            yield {
-                '_from': from_uid,
-                '_to': to_uid,
-                'from': str(from_encoding),
-                'number': from_encoding.number(),
-                'to': to_encoding.first_part(),
-                'type': str(self._entry.edge_type),
-                'resembling': to_encoding.is_resembling(),
-                'remark': self._remarks.lookup((from_uid, to_uid)),
-            }
+def all_entries(relationship_data) -> list[Entry]:
+    return [
+        Entry(entry_type, encodings)
+        for entry_data in relationship_data
+        for entry_type, encodings in entry_data.items()
+    ]
 
 
-class OtherEdges(Iterable):
-    def __init__(self, entry: Entry, remarks: Remarks):
-        self._entry = entry
-        self._remarks = remarks
-
-    def __iter__(self) -> Iterator[dict]:
-        return iter(self.edges())
-
-    def edges(self) -> Iterator[dict]:
-        first_encoding = self._entry.encodings[0]
-        second_encodings = list(drop_when_no_match(self._entry.encodings[1:]))
-
-        for first_uid in first_encoding.matching_uids():
-            for second_encoding in second_encodings:
-                for second_uid in second_encoding.matching_uids():
-                    yield from self.create_edges(first_encoding, second_encoding, first_uid, second_uid,)
-
-    def create_edges(self, first_encoding: Encoding, second_encoding: Encoding, first_uid: str, second_uid: str):
-        is_resembling = first_encoding.is_resembling() or second_encoding.is_resembling()
-        remark = self._remarks.lookup((second_uid, first_uid))
-
-        first_edge = {
-            '_from': first_uid,
-            '_to': second_uid,
-            'from': first_encoding.strip_resembling(),
-            'to': second_encoding.strip_resembling(),
-            'number': first_encoding.number(),
-            'type': str(self._entry.edge_type),
-            'resembling': is_resembling,
-            'remark': remark,
-        }
-
-        second_edge = {
-            '_from': second_uid,
-            '_to': first_uid,
-            'from': second_encoding.strip_resembling(),
-            'to': first_encoding.strip_resembling(),
-            'number': second_encoding.number(),
-            'type': str(self._entry.edge_type),
-            'resembling': is_resembling,
-            'remark': remark,
-        }
-
-        return first_edge, second_edge
+def edges_for_entry(entry, unmatched):
+    if entry.entry_type == EntryType.PARALLELS:
+        yield from ParallelsEdges(entry, unmatched)
+    else:
+        yield from OtherEdges(entry, unmatched)
 
 
-def drop_when_no_match(encodings: Iterable[Encoding]) -> Iterator[Encoding]:
-    for encoding in encodings:
-        if encoding.has_matching_uid():
-            yield encoding
-        else:
-            logging.error(f'Relationship encoding has no matching uids: {encoding} (dropped)')
+def edge_chunks(edges: Iterable[Edge], chunk_size=10000) -> Iterator[list[dict]]:
+    edges = (edge.as_dict() for edge in edges)
+    for chunk in utils.chunks(edges, chunk_size):
+        yield chunk
+
+
+def write_chunk(db: StandardDatabase, chunk: list[dict]):
+    db['relationship'].import_bulk_logged(
+        chunk,
+        from_prefix='super_nav_details',
+        to_prefix='super_nav_details'
+    )

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -17,10 +17,9 @@ from data_loader.util import json_load
 
 
 class Encoding:
-    all_uids: set[str] = set()
+    matcher: UidMatcher = UidMatcher(set())
 
     def __init__(self, encoding: str):
-        self._matcher = UidMatcher(self.all_uids)
         self._encoding = encoding
 
     def __str__(self) -> str:
@@ -30,7 +29,7 @@ class Encoding:
         return self._encoding == other._encoding
 
     def matching_uids(self) -> list[str]:
-        return self._matcher.get_matching_uids(self._encoding)
+        return self.matcher.get_matching_uids(self._encoding)
 
     def is_resembling(self) -> bool:
         return self._encoding.startswith('~')
@@ -120,7 +119,7 @@ def load_relationships(change_tracker: FileChangeTracker, relationship_dir: Path
     if not change_tracker.is_file_new_or_changed(relationship_file):
         return
 
-    Encoding.all_uids = all_uids(db)
+    Encoding.matcher = UidMatcher(all_uids(db))
     Remarks.load(additional_info_dir / Path('notes.json'))
 
     ll_edges = []

--- a/server/src/data_loader/relationships.py
+++ b/server/src/data_loader/relationships.py
@@ -25,7 +25,8 @@ class Encoding:
 
     def __init__(self, encoding: str):
         self._encoding = encoding
-        self._matching_uids = self._matcher.get_matching_uids(self._encoding)
+        self._matching_uids = self._load_matching_uids()
+        self._number = self._extract_number()
 
     def __str__(self) -> str:
         return self._encoding
@@ -53,18 +54,24 @@ class Encoding:
         return False
 
     def number(self) -> int:
-        m = regex.search('[0-9]+$', self._encoding)
-        if m:
-            from_nr = int(m[0])
-        else:
-            from_nr = 0
-        return from_nr
+        return self._number
 
     def strip_resembling(self) -> str:
         return self._encoding.lstrip('~')
 
     def first_part(self) -> str:
         return self._encoding.lstrip('~').split('-')[0]
+
+    def _load_matching_uids(self):
+        return self._matcher.get_matching_uids(self._encoding)
+
+    def _extract_number(self) -> int:
+        m = regex.search('[0-9]+$', self._encoding)
+        if m:
+            from_nr = int(m[0])
+        else:
+            from_nr = 0
+        return from_nr
 
 
 class EdgeType(StrEnum):

--- a/server/src/data_loader/util.py
+++ b/server/src/data_loader/util.py
@@ -43,7 +43,7 @@ def humansortkey(string, _split=regex.compile(r'(\d+(?:[.-]\d+)*)').split):
     ]
 
 
-def json_load(path: Path) -> dict:
+def json_load(path: Path) -> dict | list[dict]:
     try:
         with open(path, 'r', encoding='utf8') as f:
             return json.load(f)

--- a/server/tests/data_loader/fakes.py
+++ b/server/tests/data_loader/fakes.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from data_loader.ports import FileChangeTracker
+
+
+class FakeFileChangeTracker(FileChangeTracker):
+    def __init__(self):
+        self._changed_files: list[Path] = []
+
+    def change_file(self, path: Path) -> None:
+        self._changed_files.append(path)
+
+    def is_file_new_or_changed(self, path: Path, check_calling_function: bool = True) -> bool:
+        return path in self._changed_files
+
+    def is_any_file_new_or_changed(self, files: list[Path], check_calling_function: bool = True) -> bool:
+        return any(self.is_file_new_or_changed(file) for file in files)
+
+    def changed_files(self, paths: Iterable[Path]) -> Iterator[Path]:
+        yield from self._changed_files

--- a/server/tests/data_loader/test_fakes.py
+++ b/server/tests/data_loader/test_fakes.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from fakes import FakeFileChangeTracker
+
+
+class TestFakeFileChangeTracker:
+    def test_file_not_changed(self):
+        tracker = FakeFileChangeTracker()
+        path = Path('/foo')
+        assert tracker.is_file_new_or_changed(path) is False
+
+    def test_file_is_changed(self):
+        tracker = FakeFileChangeTracker()
+        path = Path('/foo')
+        tracker.change_file(path)
+        assert tracker.is_file_new_or_changed(path) is True
+
+    def test_any_file_not_changed(self):
+        tracker = FakeFileChangeTracker()
+        paths = [Path('/foo'), Path('/bar')]
+        assert tracker.is_any_file_new_or_changed(paths) is False
+
+    def test_any_file_is_changed(self):
+        tracker = FakeFileChangeTracker()
+        paths = [Path('/foo'), Path('/bar')]
+        tracker.change_file(Path('/foo'))
+        assert tracker.is_any_file_new_or_changed(paths) is True
+
+    def test_yield_changed_files(self):
+        tracker = FakeFileChangeTracker()
+        paths = [Path('/foo'), Path('/bar'), Path('/baz')]
+        tracker.change_file(Path('/foo'))
+        tracker.change_file(Path('/baz'))
+        assert sorted(list(tracker.changed_files(paths))) == [Path('/baz'), Path('/foo')]

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -147,8 +147,8 @@ def test_when_related_remark_exists(file_changed, relationship_dir, additional_i
     assert docs[1]['remark'] == "Remarkable"
 
 
-def test_error_when_retells_first(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                  notes_file, database, super_nav_details, relationship):
+def test_no_error_when_retells_first(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                     notes_file, database, super_nav_details, relationship):
     super_nav_details.insert({'uid': 'parallel123'})
     super_nav_details.insert({'uid': 'parallel321'})
     super_nav_details.insert({'uid': 'retell123'})
@@ -160,8 +160,8 @@ def test_error_when_retells_first(file_changed, relationship_dir, additional_inf
     ])
 
     create_file(notes_file, [])
-    with pytest.raises(UnboundLocalError, match="cannot access local variable 'from_uid'"):
-        generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    # This previously gave an UnboundLocalError
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
 
 
 @pytest.mark.parametrize('in_type,out_type', [('retells', 'retelling'), ('mentions', 'mention')])
@@ -466,3 +466,16 @@ def test_partials(file_changed, relationship_dir, additional_info_dir, parallels
             'type': 'full'
         }
     ]
+
+
+def test_branch_where_true_from_uids_has_no_match(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                                  notes_file, database, super_nav_details, relationship, caplog):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [
+        {'parallels': ['abc123', 'xyz321']},
+        {'retells': ['abc123', 'no_such']},
+    ])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    assert caplog.messages == ['Relationship from uid could not be matched: no_such (dropped)']

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -1,0 +1,344 @@
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+from arango.collection import StandardCollection
+from arango.database import StandardDatabase
+
+from common.arangodb import get_db
+from common.utils import current_app
+from data_loader.ports import FileChangeTracker
+from data_loader.relationships import generate_relationship_edges
+from fakes import FakeFileChangeTracker
+
+
+def create_file(path: Path, data: list[dict]) -> None:
+    with path.open("w") as f:
+        json.dump(data, f)
+
+
+def tidy_relationship_docs(relationship: StandardCollection) -> list[Any]:
+    docs = sorted([doc for doc in relationship.all()], key=lambda doc: doc['_from'])
+    for doc in docs:
+        del doc['_key']
+        del doc['_id']
+        del doc['_rev']
+
+    return docs
+
+
+@pytest.fixture
+def database() -> StandardDatabase:
+    app = current_app()
+    with app.app_context():
+        return get_db()  # type: ignore
+
+
+@pytest.fixture
+def super_nav_details(database) -> StandardCollection:
+    if not database.has_collection('super_nav_details'):
+        database.create_collection('super_nav_details')
+    database['super_nav_details'].truncate()
+    return database['super_nav_details']
+
+
+@pytest.fixture
+def relationship(database) -> StandardCollection:
+    if not database.has_collection('relationship'):
+        database.create_collection('relationship')
+    database['relationship'].truncate()
+    return database['relationship']
+
+
+@pytest.fixture
+def relationship_dir(tmp_path: Path) -> Path:
+    path = tmp_path / 'relationship'
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def additional_info_dir(tmp_path: Path) -> Path:
+    path = tmp_path / 'additional_info'
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def parallels_file(relationship_dir) -> Path:
+    return relationship_dir / 'parallels.json'
+
+
+@pytest.fixture
+def notes_file(additional_info_dir) -> Path:
+    return additional_info_dir / 'notes.json'
+
+
+@pytest.fixture
+def file_changed(parallels_file) -> FileChangeTracker:
+    tracker = FakeFileChangeTracker()
+    tracker.change_file(parallels_file)
+    return tracker
+
+
+def test_when_file_is_unchanged_no_documents_are_added(relationship_dir, additional_info_dir, parallels_file,
+                                                       notes_file, database, super_nav_details, relationship):
+    file_unchanged = FakeFileChangeTracker()
+    generate_relationship_edges(file_unchanged, relationship_dir, additional_info_dir, database)
+    assert len(relationship) == 0
+
+
+def test_create_parallel_between_two_uids(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                          notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
+
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+
+    assert tidy_relationship_docs(relationship) == [
+        {
+            '_from': 'super_nav_details/abc123',
+            '_to': 'super_nav_details/xyz321',
+            'from': 'abc123',
+            'number': 123,
+            'remark': None,
+            'resembling': False,
+            'to': 'xyz321',
+            'type': 'full'
+        },
+        {
+            '_from': 'super_nav_details/xyz321',
+            '_to': 'super_nav_details/abc123',
+            'from': 'xyz321',
+            'number': 321,
+            'remark': None,
+            'resembling': False,
+            'to': 'abc123',
+            'type': 'full'
+        },
+    ]
+
+
+def test_when_unrelated_remark_exists(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                      notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
+    create_file(notes_file, [{'relations': ['abc123', 'def'], 'remark': 'Remarkable.'}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    assert docs[0]['remark'] is None
+    assert docs[1]['remark'] is None
+
+
+def test_when_related_remark_exists(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                    notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
+    create_file(notes_file, [{"relations": ["abc123", "xyz321"], "remark": "Remarkable"}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    assert docs[0]['remark'] == "Remarkable"
+    assert docs[1]['remark'] == "Remarkable"
+
+
+def test_error_when_retells_first(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                  notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [
+        {'retells': ['abc123', 'xyz321']},
+        {'parallels': ['abc123', 'xyz321']},
+    ])
+
+    create_file(notes_file, [])
+    with pytest.raises(UnboundLocalError, match="cannot access local variable 'from_uid'"):
+        generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+
+
+@pytest.mark.parametrize('in_type,out_type', [('retells', 'retelling'), ('mentions', 'mention')])
+def test_add_other_types(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                         notes_file, database, super_nav_details, relationship, in_type, out_type):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [
+        {'parallels': ['abc123', 'xyz321']},
+        {in_type: ['abc123', 'xyz321']},
+    ])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = relationship.find({'type': out_type})
+    from_uids = sorted([doc['from'] for doc in docs])
+    assert from_uids == ['abc123', 'xyz321']
+
+
+def test_number_parallel_zero_when_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                           notes_file, database, super_nav_details, relationship):
+    create_file(notes_file, [])
+    super_nav_details.insert({'uid': 'no_number_from'})
+    super_nav_details.insert({'uid': 'no_number_to'})
+    create_file(parallels_file, [{'parallels': ['no_number_from', 'no_number_to']}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    numbers = [doc['number'] for doc in docs]
+    assert numbers == [0, 0]
+
+
+@pytest.mark.parametrize('in_type,out_type', [('retells', 'retelling'), ('mentions', 'mention')])
+def test_number_other_zero_when_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                        notes_file, database, super_nav_details, relationship, in_type, out_type):
+    create_file(notes_file, [])
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    super_nav_details.insert({'uid': 'no_number_from'})
+    super_nav_details.insert({'uid': 'no_number_to'})
+    create_file(parallels_file, [
+        {'parallels': ['abc123', 'xyz321']},
+        {in_type: ['no_number_from', 'no_number_to']},
+    ])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    numbers = [doc['number'] for doc in docs]
+    assert sorted(numbers) == [0, 0, 123, 321]
+
+
+def test_create_orphan_when_from_missing(file_changed, relationship_dir, additional_info_dir,
+                                         parallels_file,
+                                         notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'parallels': ['no_such', 'xyz321']}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    to = [doc['_to'] for doc in docs]
+    assert to == ['super_nav_details/orphan']
+
+
+def test_create_orphan_when_to_missing(file_changed, relationship_dir, additional_info_dir,
+                                       parallels_file,
+                                       notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'parallels': ['abc123', 'no_such']}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    to = [doc['_to'] for doc in docs]
+    assert to == ['super_nav_details/orphan']
+
+
+def test_logs_orphan(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                     notes_file, database, super_nav_details, relationship, caplog):
+    caplog.set_level(logging.INFO)
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'parallels': ['no_such', 'xyz321']}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    assert caplog.messages == [
+        'Relationship from uid could not be matched: no_such (dropped)',
+        'Relationship to uid could not be matched: no_such (appears as orphan)'
+    ]
+
+
+def test_create_resembling_from(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'parallels': ['~abc123', 'xyz321']}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    assert docs == [
+        {
+            '_from': 'super_nav_details/xyz321',
+            '_to': 'super_nav_details/abc123',
+            'from': 'xyz321',
+            'number': 321,
+            'remark': None,
+            'resembling': True,
+            'to': 'abc123',
+            'type': 'full'
+        }
+    ]
+
+
+def test_create_resembling_to(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                              notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'parallels': ['abc123', '~xyz321']}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    assert docs == [
+        {
+            '_from': 'super_nav_details/abc123',
+            '_to': 'super_nav_details/xyz321',
+            'from': 'abc123',
+            'number': 123,
+            'remark': None,
+            'resembling': True,
+            'to': 'xyz321',
+            'type': 'full'
+        }
+    ]
+
+
+@pytest.mark.parametrize('in_type,out_type', [('retells', 'retelling'), ('mentions', 'mention')])
+def test_create_resembling_other_from(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                      notes_file, database, super_nav_details, relationship, in_type, out_type):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [
+        {'parallels': ['abc123', 'xyz321']},
+        {in_type: ['~abc123', 'xyz321']},
+    ])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    resembling = [doc for doc in docs if doc['resembling']]
+    assert resembling == [
+        {
+            '_from': 'super_nav_details/abc123',
+            '_to': 'super_nav_details/xyz321',
+            'from': 'abc123',
+            'number': 123,
+            'remark': None,
+            'resembling': True,
+            'to': 'xyz321',
+            'type': out_type
+        },
+        {'_from': 'super_nav_details/xyz321',
+         '_to': 'super_nav_details/abc123',
+         'from': 'xyz321',
+         'number': 321,
+         'remark': None,
+         'resembling': True,
+         'to': 'abc123',
+         'type': out_type
+         }
+    ]
+
+
+@pytest.mark.parametrize('in_type,out_type', [('retells', 'retelling'), ('mentions', 'mention')])
+def test_not_resembling_when_other_type_and_partial_to(file_changed, relationship_dir, additional_info_dir,
+                                                       parallels_file,
+                                                       notes_file, database, super_nav_details, relationship, in_type,
+                                                       out_type):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [
+        {'parallels': ['abc123', 'xyz321']},
+        {in_type: ['abc123', '~xyz321']},
+    ])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    resembling = [doc for doc in docs if doc['resembling']]
+    assert len(resembling) == 0

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -98,150 +98,102 @@ def with_remarks():
     Edge.load_remarks([])
 
 
-class TestUnmatched:
-    def test_logs_dropped(self, caplog):
-        unmatched = Unmatched()
-        unmatched.add_dropped(Encoding('abc123'))
-        unmatched.log()
-        assert caplog.messages == ['Relationship encoding has no matching uids: abc123 (dropped)']
+class TestEncoding:
+    @pytest.fixture
+    def with_uids(self):
+        Encoding.load_uids({'abc123'})
 
-    def test_logs_orphans(self, caplog):
-        caplog.set_level(logging.INFO)
-        unmatched = Unmatched()
-        unmatched.add_orphan(Encoding('abc123'))
-        unmatched.log()
-        assert caplog.messages == ['Relationship to encoding could not be matched: abc123 (appears as orphan)']
+    def test_to_string(self, with_uids):
+        assert str(Encoding('~abc123')) == '~abc123'
 
+    def test_has_matching_uids(self, with_uids):
+        encoding = Encoding('abc123')
+        assert encoding.matching_uids() == ['abc123']
 
-class TestLoadRelationships:
-    def test_skip_when_files_unchanged(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
-                                       database, super_nav_details, relationship):
-        tracker = FakeFileChangeTracker()
-        load_relationships(tracker, relationship_dir, additional_info_dir, database)
-        assert len(relationship) == 0
+    @pytest.mark.parametrize('encoding,is_resembling', [('abc123', False), ('~abc123', True)])
+    def test_not_resembling(self, with_uids, encoding, is_resembling):
+        assert Encoding(encoding).is_resembling() == is_resembling
 
-    def test_load_when_parallels_have_changed(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
-                                              database, super_nav_details, relationship):
-        super_nav_details.insert({'uid': 'abc123'})
-        super_nav_details.insert({'uid': 'xyz321'})
-        create_file(notes_file, [])
-        create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
-        tracker = FakeFileChangeTracker()
-        tracker.change_file(parallels_file)
-        load_relationships(tracker, relationship_dir, additional_info_dir, database)
-        assert len(relationship) == 2
+    @pytest.mark.parametrize('encoding,is_external', [('abc123', False), ('Has space', True)])
+    def test_not_resembling(self, with_uids, encoding, is_external):
+        assert Encoding(encoding).is_external() == is_external
 
-    def test_load_when_notes_have_changed(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
-                                          database, super_nav_details, relationship):
-        super_nav_details.insert({'uid': 'abc123'})
-        super_nav_details.insert({'uid': 'xyz321'})
-        create_file(notes_file, [])
-        create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
-        tracker = FakeFileChangeTracker()
-        tracker.change_file(notes_file)
-        load_relationships(tracker, relationship_dir, additional_info_dir, database)
-        assert len(relationship) == 2
+    @pytest.mark.parametrize('encoding,number', [('abc123', 123), ('abc', 0)])
+    def test_number(self, encoding, number):
+        assert Encoding(encoding).number() == number
 
-    @pytest.mark.parametrize('entry_type,edge_type', [
-        ('parallels', 'full'),
-        ('retells', 'retelling'),
-        ('mentions', 'mention'),
-    ])
-    def test_sets_edge_type(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
-                            database, super_nav_details, relationship, entry_type, edge_type):
-        super_nav_details.insert({'uid': 'abc123'})
-        super_nav_details.insert({'uid': 'xyz321'})
-        create_file(notes_file, [])
-        create_file(parallels_file, [{entry_type: ['abc123', 'xyz321']}])
-        tracker = FakeFileChangeTracker()
-        tracker.change_file(parallels_file)
-        load_relationships(tracker, relationship_dir, additional_info_dir, database)
-        assert next(relationship.all())['type'] == edge_type
+    @pytest.mark.parametrize('encoding,stripped', [('abc123', 'abc123'), ('~abc123', 'abc123')])
+    def test_strip_resembling(self, encoding, stripped):
+        assert Encoding(encoding).strip_resembling() == stripped
 
-    @pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
-    def test_expands_uid_range(self, file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
-                               database,
-                               super_nav_details, relationship, entry_type):
-        super_nav_details.insert({'uid': 'an7.75'})
-        super_nav_details.insert({'uid': 'an7.76'})
-        super_nav_details.insert({'uid': 'pli-tv-pvr7'})
-        create_file(notes_file, [])
-
-        create_file(parallels_file, [
-            {entry_type: ['an7.75-76', 'pli-tv-pvr7#97.1-#98.1']},
+    @pytest.mark.parametrize(
+        'encoding,first_part',
+        [
+            ('abc123', 'abc123'),
+            ('~abc123', 'abc123'),
+            ('abc-123', 'abc'),
+            ('~abc-123', 'abc'),
         ])
+    def test_first_part(self, encoding, first_part):
+        assert Encoding(encoding).first_part() == first_part
 
-        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-        docs = tidy_relationship_docs(relationship)
-
-        assert [doc['_from'] for doc in docs] == [
-            'super_nav_details/an7.75',
-            'super_nav_details/an7.76',
-            'super_nav_details/pli-tv-pvr7',
-            'super_nav_details/pli-tv-pvr7'
+    @pytest.mark.parametrize(
+        'encoding,has_matching_uid',
+        [
+            ('abc123', True),
+            ('xyz321', False),
+            ('contains space', True),
         ]
+    )
+    def test_has_matching_uid(self, encoding, has_matching_uid):
+        assert Encoding(encoding).has_matching_uid() is has_matching_uid
 
-    @pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
-    def test_adds_remarks(self, file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
-                          database, super_nav_details, relationship, entry_type):
-        super_nav_details.insert({'uid': 'abc123'})
-        super_nav_details.insert({'uid': 'xyz321'})
-        create_file(notes_file, [{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
-        create_file(parallels_file, [{entry_type: ['abc123', 'xyz321']}])
-        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-        docs = tidy_relationship_docs(relationship)
-        assert [doc['remark'] for doc in docs] == ['Remarkable', 'Remarkable']
 
-    @pytest.mark.parametrize('entry_data', [
-        [{"parallels": ['abc123', 'no_such_uid']}],
-        [{"parallels": ['no_such_uid', 'abc321']}],
+class TestToEdgeType:
+    @pytest.mark.parametrize('entry,relationship', [
+        (EntryType.PARALLELS, EdgeType.FULL),
+        (EntryType.MENTIONS, EdgeType.MENTION),
+        (EntryType.RETELLS, EdgeType.RETELLING),
     ])
-    def test_logs_parallels_unmatched_encodings(self, file_changed, relationship_dir, additional_info_dir,
-                                                parallels_file, notes_file, database, super_nav_details, relationship,
-                                                entry_data, caplog):
-        caplog.set_level(logging.INFO)
-        super_nav_details.insert({'uid': 'abc123'})
-        create_file(notes_file, [])
-        create_file(parallels_file, entry_data)
-        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+    def test_converts_types(self, entry, relationship):
+        assert to_edge_type(entry) == relationship
 
-        # We get two messages because we create two edges. Where the from encoding
-        # has no matching uids we drop it, for the to encoding we create an orphan.
-        assert sorted(caplog.messages) == sorted([
-            'Relationship encoding has no matching uids: no_such_uid (dropped)',
-            'Relationship to encoding could not be matched: no_such_uid (appears as orphan)'
-        ])
 
-    @pytest.mark.parametrize('entry_data', [
-        [{"mentions": ['abc123', 'no_such_uid']}],
-        [{"retells": ['abc123', 'no_such_uid']}],
+class TestEntry:
+    def test_entry_type(self):
+        assert Entry('parallels', ['abc123', 'xyz321']).entry_type == 'parallels'
+
+    def test_edge_type(self):
+        assert Entry('parallels', ['abc123', 'xyz321']).edge_type == 'full'
+
+    def test_encodings(self):
+        assert Entry('parallels', ['abc123', 'xyz321']).encodings == [Encoding('abc123'), Encoding('xyz321')]
+
+    def test_invalid_entry_type(self):
+        with pytest.raises(ValueError, match='extrudes'):
+            _ = Entry('extrudes', ['abc123', 'xyz321'])
+
+
+class TestRemarks:
+    def test_no_remark_when_both_missing(self):
+        remarks = Remarks([])
+        assert remarks.lookup(('abc123', 'xyz321')) is None
+
+    def test_get_remark_for_relation(self):
+        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
+        assert remarks.lookup(('abc123', 'xyz321')) == 'Remarkable'
+
+    def test_reverse_order_of_uid_retrieves_remark(self):
+        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
+        assert remarks.lookup(('xyz321', 'abc123')) == 'Remarkable'
+
+    @pytest.mark.parametrize('data', [
+        [{'relations': ['abc123', 'unrelated'], 'remark': 'Remarkable.'}],
+        [{'relations': ['unrelated', 'xyz123'], 'remark': 'Remarkable.'}],
     ])
-    def test_logs_other_unmatched_encodings(self, file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                            notes_file, database, super_nav_details, relationship, entry_data, caplog):
-        caplog.set_level(logging.INFO)
-        super_nav_details.insert({'uid': 'abc123'})
-        create_file(notes_file, [])
-        create_file(parallels_file, entry_data)
-        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-
-        assert sorted(caplog.messages) == sorted([
-            'Relationship encoding has no matching uids: no_such_uid (dropped)',
-        ])
-
-    def test_empties_collection_before_load(self, file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                            notes_file, database, super_nav_details, relationship):
-        super_nav_details.insert({'uid': 'abc123'})
-        super_nav_details.insert({'uid': 'xyz321'})
-        super_nav_details.insert({'uid': 'pqr777'})
-        super_nav_details.insert({'uid': 'stu888'})
-        create_file(notes_file, [])
-        create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
-        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-        create_file(parallels_file, [{'parallels': ['pqr777', 'stu888']}])
-        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-        docs = tidy_relationship_docs(relationship)
-        from_to = [(doc['from'], doc['to']) for doc in docs]
-        assert from_to == [('pqr777', 'stu888'), ('stu888', 'pqr777')]
+    def test_unrelated_remarks_not_retrieved(self, data):
+        remarks = Remarks(data)
+        assert remarks.lookup(('abc123', 'xyz123')) is None
 
 
 class TestEdge:
@@ -344,6 +296,21 @@ class TestEdge:
         uids = EdgeUids(from_uid, to_uid)
         encodings = EdgeEncodings(Encoding('abc123'), Encoding('xyz321'))
         assert Edge(edge_type, encodings, uids).as_dict()['remark'] == remark
+
+
+class TestUnmatched:
+    def test_logs_dropped(self, caplog):
+        unmatched = Unmatched()
+        unmatched.add_dropped(Encoding('abc123'))
+        unmatched.log()
+        assert caplog.messages == ['Relationship encoding has no matching uids: abc123 (dropped)']
+
+    def test_logs_orphans(self, caplog):
+        caplog.set_level(logging.INFO)
+        unmatched = Unmatched()
+        unmatched.add_orphan(Encoding('abc123'))
+        unmatched.log()
+        assert caplog.messages == ['Relationship to encoding could not be matched: abc123 (appears as orphan)']
 
 
 class TestParallelsEdges:
@@ -698,99 +665,132 @@ class TestOtherEdges:
         assert unmatched.dropped == {Encoding('no_such_uid')}
 
 
-class TestEntry:
-    def test_entry_type(self):
-        assert Entry('parallels', ['abc123', 'xyz321']).entry_type == 'parallels'
+class TestLoadRelationships:
+    def test_skip_when_files_unchanged(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                                       database, super_nav_details, relationship):
+        tracker = FakeFileChangeTracker()
+        load_relationships(tracker, relationship_dir, additional_info_dir, database)
+        assert len(relationship) == 0
 
-    def test_edge_type(self):
-        assert Entry('parallels', ['abc123', 'xyz321']).edge_type == 'full'
+    def test_load_when_parallels_have_changed(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                                              database, super_nav_details, relationship):
+        super_nav_details.insert({'uid': 'abc123'})
+        super_nav_details.insert({'uid': 'xyz321'})
+        create_file(notes_file, [])
+        create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
+        tracker = FakeFileChangeTracker()
+        tracker.change_file(parallels_file)
+        load_relationships(tracker, relationship_dir, additional_info_dir, database)
+        assert len(relationship) == 2
 
-    def test_encodings(self):
-        assert Entry('parallels', ['abc123', 'xyz321']).encodings == [Encoding('abc123'), Encoding('xyz321')]
+    def test_load_when_notes_have_changed(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                                          database, super_nav_details, relationship):
+        super_nav_details.insert({'uid': 'abc123'})
+        super_nav_details.insert({'uid': 'xyz321'})
+        create_file(notes_file, [])
+        create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
+        tracker = FakeFileChangeTracker()
+        tracker.change_file(notes_file)
+        load_relationships(tracker, relationship_dir, additional_info_dir, database)
+        assert len(relationship) == 2
 
-    def test_invalid_entry_type(self):
-        with pytest.raises(ValueError, match='extrudes'):
-            _ = Entry('extrudes', ['abc123', 'xyz321'])
+    @pytest.mark.parametrize('entry_type,edge_type', [
+        ('parallels', 'full'),
+        ('retells', 'retelling'),
+        ('mentions', 'mention'),
+    ])
+    def test_sets_edge_type(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                            database, super_nav_details, relationship, entry_type, edge_type):
+        super_nav_details.insert({'uid': 'abc123'})
+        super_nav_details.insert({'uid': 'xyz321'})
+        create_file(notes_file, [])
+        create_file(parallels_file, [{entry_type: ['abc123', 'xyz321']}])
+        tracker = FakeFileChangeTracker()
+        tracker.change_file(parallels_file)
+        load_relationships(tracker, relationship_dir, additional_info_dir, database)
+        assert next(relationship.all())['type'] == edge_type
 
+    @pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
+    def test_expands_uid_range(self, file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                               database,
+                               super_nav_details, relationship, entry_type):
+        super_nav_details.insert({'uid': 'an7.75'})
+        super_nav_details.insert({'uid': 'an7.76'})
+        super_nav_details.insert({'uid': 'pli-tv-pvr7'})
+        create_file(notes_file, [])
 
-class TestEncoding:
-    @pytest.fixture
-    def with_uids(self):
-        Encoding.load_uids({'abc123'})
-
-    def test_to_string(self, with_uids):
-        assert str(Encoding('~abc123')) == '~abc123'
-
-    def test_has_matching_uids(self, with_uids):
-        encoding = Encoding('abc123')
-        assert encoding.matching_uids() == ['abc123']
-
-    @pytest.mark.parametrize('encoding,is_resembling', [('abc123', False), ('~abc123', True)])
-    def test_not_resembling(self, with_uids, encoding, is_resembling):
-        assert Encoding(encoding).is_resembling() == is_resembling
-
-    @pytest.mark.parametrize('encoding,is_external', [('abc123', False), ('Has space', True)])
-    def test_not_resembling(self, with_uids, encoding, is_external):
-        assert Encoding(encoding).is_external() == is_external
-
-    @pytest.mark.parametrize('encoding,number', [('abc123', 123), ('abc', 0)])
-    def test_number(self, encoding, number):
-        assert Encoding(encoding).number() == number
-
-    @pytest.mark.parametrize('encoding,stripped', [('abc123', 'abc123'), ('~abc123', 'abc123')])
-    def test_strip_resembling(self, encoding, stripped):
-        assert Encoding(encoding).strip_resembling() == stripped
-
-    @pytest.mark.parametrize(
-        'encoding,first_part',
-        [
-            ('abc123', 'abc123'),
-            ('~abc123', 'abc123'),
-            ('abc-123', 'abc'),
-            ('~abc-123', 'abc'),
+        create_file(parallels_file, [
+            {entry_type: ['an7.75-76', 'pli-tv-pvr7#97.1-#98.1']},
         ])
-    def test_first_part(self, encoding, first_part):
-        assert Encoding(encoding).first_part() == first_part
 
-    @pytest.mark.parametrize(
-        'encoding,has_matching_uid',
-        [
-            ('abc123', True),
-            ('xyz321', False),
-            ('contains space', True),
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+        docs = tidy_relationship_docs(relationship)
+
+        assert [doc['_from'] for doc in docs] == [
+            'super_nav_details/an7.75',
+            'super_nav_details/an7.76',
+            'super_nav_details/pli-tv-pvr7',
+            'super_nav_details/pli-tv-pvr7'
         ]
-    )
-    def test_has_matching_uid(self, encoding, has_matching_uid):
-        assert Encoding(encoding).has_matching_uid() is has_matching_uid
 
+    @pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
+    def test_adds_remarks(self, file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                          database, super_nav_details, relationship, entry_type):
+        super_nav_details.insert({'uid': 'abc123'})
+        super_nav_details.insert({'uid': 'xyz321'})
+        create_file(notes_file, [{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
+        create_file(parallels_file, [{entry_type: ['abc123', 'xyz321']}])
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+        docs = tidy_relationship_docs(relationship)
+        assert [doc['remark'] for doc in docs] == ['Remarkable', 'Remarkable']
 
-class TestRemarks:
-    def test_no_remark_when_both_missing(self):
-        remarks = Remarks([])
-        assert remarks.lookup(('abc123', 'xyz321')) is None
-
-    def test_get_remark_for_relation(self):
-        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
-        assert remarks.lookup(('abc123', 'xyz321')) == 'Remarkable'
-
-    def test_reverse_order_of_uid_retrieves_remark(self):
-        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
-        assert remarks.lookup(('xyz321', 'abc123')) == 'Remarkable'
-
-    @pytest.mark.parametrize('data', [
-        [{'relations': ['abc123', 'unrelated'], 'remark': 'Remarkable.'}],
-        [{'relations': ['unrelated', 'xyz123'], 'remark': 'Remarkable.'}],
+    @pytest.mark.parametrize('entry_data', [
+        [{"parallels": ['abc123', 'no_such_uid']}],
+        [{"parallels": ['no_such_uid', 'abc321']}],
     ])
-    def test_unrelated_remarks_not_retrieved(self, data):
-        remarks = Remarks(data)
-        assert remarks.lookup(('abc123', 'xyz123')) is None
+    def test_logs_parallels_unmatched_encodings(self, file_changed, relationship_dir, additional_info_dir,
+                                                parallels_file, notes_file, database, super_nav_details, relationship,
+                                                entry_data, caplog):
+        caplog.set_level(logging.INFO)
+        super_nav_details.insert({'uid': 'abc123'})
+        create_file(notes_file, [])
+        create_file(parallels_file, entry_data)
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
 
+        # We get two messages because we create two edges. Where the from encoding
+        # has no matching uids we drop it, for the to encoding we create an orphan.
+        assert sorted(caplog.messages) == sorted([
+            'Relationship encoding has no matching uids: no_such_uid (dropped)',
+            'Relationship to encoding could not be matched: no_such_uid (appears as orphan)'
+        ])
 
-class TestRelationshipType:
-    @pytest.mark.parametrize('entry,relationship', [
-        (EntryType.PARALLELS, EdgeType.FULL),
-        (EntryType.MENTIONS, EdgeType.MENTION),
-        (EntryType.RETELLS, EdgeType.RETELLING),
+    @pytest.mark.parametrize('entry_data', [
+        [{"mentions": ['abc123', 'no_such_uid']}],
+        [{"retells": ['abc123', 'no_such_uid']}],
     ])
-    def test_converts_types(self, entry, relationship):
-        assert to_edge_type(entry) == relationship
+    def test_logs_other_unmatched_encodings(self, file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                            notes_file, database, super_nav_details, relationship, entry_data, caplog):
+        caplog.set_level(logging.INFO)
+        super_nav_details.insert({'uid': 'abc123'})
+        create_file(notes_file, [])
+        create_file(parallels_file, entry_data)
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+
+        assert sorted(caplog.messages) == sorted([
+            'Relationship encoding has no matching uids: no_such_uid (dropped)',
+        ])
+
+    def test_empties_collection_before_load(self, file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                            notes_file, database, super_nav_details, relationship):
+        super_nav_details.insert({'uid': 'abc123'})
+        super_nav_details.insert({'uid': 'xyz321'})
+        super_nav_details.insert({'uid': 'pqr777'})
+        super_nav_details.insert({'uid': 'stu888'})
+        create_file(notes_file, [])
+        create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+        create_file(parallels_file, [{'parallels': ['pqr777', 'stu888']}])
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+        docs = tidy_relationship_docs(relationship)
+        from_to = [(doc['from'], doc['to']) for doc in docs]
+        assert from_to == [('pqr777', 'stu888'), ('stu888', 'pqr777')]

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -10,7 +10,7 @@ from arango.database import StandardDatabase
 from common.arangodb import get_db
 from common.utils import current_app
 from data_loader.ports import FileChangeTracker
-from data_loader.relationships import generate_relationship_edges
+from data_loader.relationships import load_relationships, Remarks, Encoding
 from fakes import FakeFileChangeTracker
 
 
@@ -86,7 +86,7 @@ def file_changed(parallels_file) -> FileChangeTracker:
 def test_when_file_is_unchanged_no_documents_are_added(relationship_dir, additional_info_dir, parallels_file,
                                                        notes_file, database, super_nav_details, relationship):
     file_unchanged = FakeFileChangeTracker()
-    generate_relationship_edges(file_unchanged, relationship_dir, additional_info_dir, database)
+    load_relationships(file_unchanged, relationship_dir, additional_info_dir, database)
     assert len(relationship) == 0
 
 
@@ -97,7 +97,7 @@ def test_create_parallel_between_two_uids(file_changed, relationship_dir, additi
     create_file(notes_file, [])
     create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
 
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
 
     assert tidy_relationship_docs(relationship) == [
         {
@@ -129,7 +129,7 @@ def test_when_unrelated_remark_exists(file_changed, relationship_dir, additional
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
     create_file(notes_file, [{'relations': ['abc123', 'def'], 'remark': 'Remarkable.'}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     assert docs[0]['remark'] is None
     assert docs[1]['remark'] is None
@@ -141,7 +141,7 @@ def test_when_related_remark_exists(file_changed, relationship_dir, additional_i
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
     create_file(notes_file, [{"relations": ["abc123", "xyz321"], "remark": "Remarkable"}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     assert docs[0]['remark'] == "Remarkable"
     assert docs[1]['remark'] == "Remarkable"
@@ -161,7 +161,7 @@ def test_no_error_when_retells_first(file_changed, relationship_dir, additional_
 
     create_file(notes_file, [])
     # This previously gave an UnboundLocalError
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
 
 
 @pytest.mark.parametrize('in_type,out_type', [('retells', 'retelling'), ('mentions', 'mention')])
@@ -174,7 +174,7 @@ def test_add_other_types(file_changed, relationship_dir, additional_info_dir, pa
         {'parallels': ['abc123', 'xyz321']},
         {in_type: ['abc123', 'xyz321']},
     ])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = relationship.find({'type': out_type})
     from_uids = sorted([doc['from'] for doc in docs])
     assert from_uids == ['abc123', 'xyz321']
@@ -186,7 +186,7 @@ def test_number_parallel_zero_when_missing(file_changed, relationship_dir, addit
     super_nav_details.insert({'uid': 'no_number_from'})
     super_nav_details.insert({'uid': 'no_number_to'})
     create_file(parallels_file, [{'parallels': ['no_number_from', 'no_number_to']}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     numbers = [doc['number'] for doc in docs]
     assert numbers == [0, 0]
@@ -204,7 +204,7 @@ def test_number_other_zero_when_missing(file_changed, relationship_dir, addition
         {'parallels': ['abc123', 'xyz321']},
         {in_type: ['no_number_from', 'no_number_to']},
     ])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     numbers = [doc['number'] for doc in docs]
     assert sorted(numbers) == [0, 0, 123, 321]
@@ -216,7 +216,7 @@ def test_create_orphan_when_from_missing(file_changed, relationship_dir, additio
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(notes_file, [])
     create_file(parallels_file, [{'parallels': ['no_such', 'xyz321']}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     to = [doc['_to'] for doc in docs]
     assert to == ['super_nav_details/orphan']
@@ -228,7 +228,7 @@ def test_create_orphan_when_to_missing(file_changed, relationship_dir, additiona
     super_nav_details.insert({'uid': 'abc123'})
     create_file(notes_file, [])
     create_file(parallels_file, [{'parallels': ['abc123', 'no_such']}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     to = [doc['_to'] for doc in docs]
     assert to == ['super_nav_details/orphan']
@@ -241,10 +241,10 @@ def test_logs_orphan(file_changed, relationship_dir, additional_info_dir, parall
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(notes_file, [])
     create_file(parallels_file, [{'parallels': ['no_such', 'xyz321']}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     assert caplog.messages == [
-        'Relationship from uid could not be matched: no_such (dropped)',
-        'Relationship to uid could not be matched: no_such (appears as orphan)'
+        'Relationship encoding has no matching uids: no_such (dropped)',
+        'Relationship to encoding could not be matched: no_such (appears as orphan)'
     ]
 
 
@@ -254,7 +254,7 @@ def test_create_resembling_from(file_changed, relationship_dir, additional_info_
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(notes_file, [])
     create_file(parallels_file, [{'parallels': ['~abc123', 'xyz321']}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     assert docs == [
         {
@@ -276,7 +276,7 @@ def test_create_resembling_to(file_changed, relationship_dir, additional_info_di
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(notes_file, [])
     create_file(parallels_file, [{'parallels': ['abc123', '~xyz321']}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     assert docs == [
         {
@@ -302,7 +302,7 @@ def test_create_resembling_other_from(file_changed, relationship_dir, additional
         {'parallels': ['abc123', 'xyz321']},
         {in_type: ['~abc123', 'xyz321']},
     ])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     resembling = [doc for doc in docs if doc['resembling']]
     assert resembling == [
@@ -328,8 +328,8 @@ def test_create_resembling_other_from(file_changed, relationship_dir, additional
     ]
 
 
-def test_value_error_when_unknown_type(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                       notes_file, database, super_nav_details, relationship):
+def test_key_error_when_unknown_type(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                     notes_file, database, super_nav_details, relationship):
     super_nav_details.insert({'uid': 'abc123'})
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(notes_file, [])
@@ -338,8 +338,8 @@ def test_value_error_when_unknown_type(file_changed, relationship_dir, additiona
     ])
 
     create_file(notes_file, [])
-    with pytest.raises(ValueError, match='Invalid relationship type "extrudes"'):
-        generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    with pytest.raises(KeyError, match='extrudes'):
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
 
 
 def test_first_retell_uid_is_resembling(file_changed, relationship_dir, additional_info_dir,
@@ -354,7 +354,7 @@ def test_first_retell_uid_is_resembling(file_changed, relationship_dir, addition
         {'parallels': ['abc123', 'xyz321']},
         {'retells': ['~pqrs', 'lmno']},
     ])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     resembling = sorted([(doc['to'], doc['from']) for doc in docs if doc['resembling']])
 
@@ -374,7 +374,7 @@ def test_second_retell_uid_is_resembling(file_changed, relationship_dir, additio
         {'parallels': ['abc123', 'xyz321']},
         {'retells': ['pqrs', '~lmno']},
     ])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     resembling = sorted([(doc['to'], doc['from']) for doc in docs if doc['resembling']])
 
@@ -388,7 +388,7 @@ def test_three_parallels(file_changed, relationship_dir, additional_info_dir, pa
     super_nav_details.insert({'uid': 'hij678'})
     create_file(notes_file, [])
     create_file(parallels_file, [{'parallels': ['abc123', 'xyz321', 'hij678']}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     to_from = sorted([(doc['to'], doc['from']) for doc in docs])
     assert to_from == [
@@ -408,7 +408,7 @@ def test_two_full_one_resembling(file_changed, relationship_dir, additional_info
     super_nav_details.insert({'uid': 'hij678'})
     create_file(notes_file, [])
     create_file(parallels_file, [{'parallels': ['abc123', 'xyz321', '~hij678']}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     to_from = sorted([(doc['to'], doc['from']) for doc in docs])
     assert to_from == [
@@ -426,7 +426,7 @@ def test_two_full_one_resembling_first(file_changed, relationship_dir, additiona
     super_nav_details.insert({'uid': 'hij678'})
     create_file(notes_file, [])
     create_file(parallels_file, [{'parallels': ['~hij678', 'abc123', 'xyz321']}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     to_from = sorted([(doc['to'], doc['from']) for doc in docs])
     assert to_from == [
@@ -443,7 +443,7 @@ def test_partials(file_changed, relationship_dir, additional_info_dir, parallels
     super_nav_details.insert({'uid': 'thag1.97'})
     create_file(notes_file, [])
     create_file(parallels_file, [{'parallels': ['ja539#127', 'thag1.97']}])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     assert docs == [
         {'_from': 'super_nav_details/ja539',
@@ -477,5 +477,122 @@ def test_branch_where_true_from_uids_has_no_match(file_changed, relationship_dir
         {'parallels': ['abc123', 'xyz321']},
         {'retells': ['abc123', 'no_such']},
     ])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
-    assert caplog.messages == ['Relationship from uid could not be matched: no_such (dropped)']
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+    assert caplog.messages == ['Relationship encoding has no matching uids: no_such (dropped)']
+
+
+@pytest.mark.parametrize(
+    'entry,to_from',
+    [
+        ({'parallels': ['abc123', 'has space']}, [('has space', 'abc123')]),
+        ({'retells': ['abc123', 'has space']}, []),
+        ({'mentions': ['abc123', 'has space']}, []),
+    ]
+)
+def test_external_uid(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                      notes_file, database, super_nav_details, relationship, entry, to_from):
+    super_nav_details.insert({'uid': 'abc123'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [entry])
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    assert sorted([(doc['to'], doc['from']) for doc in docs]) == to_from
+
+
+@pytest.mark.parametrize(
+    'entry,to_from',
+    [
+        ({'parallels': ['abc123', 'sa-2']}, [('abc123', 'sa-2'), ('sa', 'abc123')]),
+        ({'retells': ['abc123', 'sa-2']}, [('abc123', 'sa-2'), ('sa-2', 'abc123')]),
+        ({'mentions': ['abc123', 'sa-2']}, [('abc123', 'sa-2'), ('sa-2', 'abc123')]),
+    ]
+)
+def test_encoding_contains_dash(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                notes_file, database, super_nav_details, relationship, entry, to_from):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'sa-2'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [entry])
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    assert sorted([(doc['to'], doc['from']) for doc in docs]) == to_from
+
+
+class TestRemarks:
+    def test_get_remark_for_relation(self, notes_file):
+        data = [
+            {
+                'relations': ['abc123', 'xyz321'],
+                'remark': 'Remarkable'
+            }
+        ]
+        create_file(notes_file, data)
+        Remarks.load(notes_file)
+        remarks = Remarks()
+        assert remarks.lookup('abc123', 'xyz321') == 'Remarkable'
+
+    def test_reverse_order_of_uid_retrieves_remark(self, notes_file):
+        data = [
+            {
+                'relations': ['abc123', 'xyz321'],
+                'remark': 'Remarkable'
+            }
+        ]
+        create_file(notes_file, data)
+        assert Remarks.lookup('xyz321', 'abc123') == 'Remarkable'
+
+    def test_no_remark_for_uids(self, notes_file):
+        create_file(notes_file, [])
+        Remarks.load(notes_file)
+        assert Remarks.lookup('abc123', 'xyz321') is None
+
+
+class TestEncoding:
+    @pytest.fixture
+    def with_uids(self):
+        Encoding.all_uids = {'abc123'}
+
+    def test_to_string(self, with_uids):
+        assert str(Encoding('~abc123')) == '~abc123'
+
+    def test_has_matching_uids(self, with_uids):
+        encoding = Encoding('abc123')
+        assert encoding.matching_uids() == ['abc123']
+
+    @pytest.mark.parametrize('encoding,is_resembling', [('abc123', False), ('~abc123', True)])
+    def test_not_resembling(self, with_uids, encoding, is_resembling):
+        assert Encoding(encoding).is_resembling() == is_resembling
+
+    @pytest.mark.parametrize('encoding,is_external', [('abc123', False), ('Has space', True)])
+    def test_not_resembling(self, with_uids, encoding, is_external):
+        assert Encoding(encoding).is_external() == is_external
+
+    @pytest.mark.parametrize('encoding,number', [('abc123', 123), ('abc', 0)])
+    def test_number(self, encoding, number):
+        assert Encoding(encoding).number() == number
+
+    @pytest.mark.parametrize('encoding,stripped', [('abc123', 'abc123'), ('~abc123', 'abc123')])
+    def test_strip_resembling(self, encoding, stripped):
+        assert Encoding(encoding).strip_resembling() == stripped
+
+    @pytest.mark.parametrize(
+        'encoding,first_part',
+        [
+            ('abc123', 'abc123'),
+            ('~abc123', 'abc123'),
+            ('abc-123', 'abc'),
+            ('~abc-123', 'abc'),
+        ])
+    def test_first_part(self, encoding, first_part):
+        assert Encoding(encoding).first_part() == first_part
+
+    @pytest.mark.parametrize(
+        'encoding,has_matching_uid',
+        [
+            ('abc123', True),
+            ('xyz321', False),
+            ('contains space', True),
+        ]
+    )
+    def test_has_matching_uid(self, encoding, has_matching_uid):
+        assert Encoding(encoding).has_matching_uid() is has_matching_uid

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -10,8 +10,8 @@ from arango.database import StandardDatabase
 from common.arangodb import get_db
 from common.utils import current_app
 from data_loader.ports import FileChangeTracker
-from data_loader.relationships import load_relationships, Encoding, all_edges, ParallelsEdges, Entry, \
-    EntryType, EdgeType, to_edge_type, OtherEdges, Remarks
+from data_loader.relationships import load_relationships, Encoding, Edge, ParallelsEdges, Entry, \
+    EntryType, EdgeType, to_edge_type, OtherEdges, Remarks, EdgeUids, EdgeEncodings, Unmatched
 from fakes import FakeFileChangeTracker
 
 
@@ -84,6 +84,35 @@ def file_changed(parallels_file) -> FileChangeTracker:
     return tracker
 
 
+@pytest.fixture
+def with_uids():
+    Encoding.load_uids({'abc123', 'xyz321', 'pqr777', 'mn1', 'mn2', 'dn1', 'dn2'})
+    yield
+    Encoding.load_uids({})
+
+
+@pytest.fixture
+def with_remarks():
+    Edge.load_remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
+    yield
+    Edge.load_remarks([])
+
+
+class TestUnmatched:
+    def test_logs_dropped(self, caplog):
+        unmatched = Unmatched()
+        unmatched.add_dropped(Encoding('abc123'))
+        unmatched.log()
+        assert caplog.messages == ['Relationship encoding has no matching uids: abc123 (dropped)']
+
+    def test_logs_orphans(self, caplog):
+        caplog.set_level(logging.INFO)
+        unmatched = Unmatched()
+        unmatched.add_orphan(Encoding('abc123'))
+        unmatched.log()
+        assert caplog.messages == ['Relationship to encoding could not be matched: abc123 (appears as orphan)']
+
+
 class TestLoadRelationships:
     def test_skip_when_files_unchanged(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
                                        database, super_nav_details, relationship):
@@ -129,18 +158,16 @@ class TestLoadRelationships:
         load_relationships(tracker, relationship_dir, additional_info_dir, database)
         assert next(relationship.all())['type'] == edge_type
 
-    @pytest.mark.parametrize('entry_type', ['retells', 'mentions'])
-    def test_expands_uid_range(self, file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file, database,
+    @pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
+    def test_expands_uid_range(self, file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                               database,
                                super_nav_details, relationship, entry_type):
-        super_nav_details.insert({'uid': 'abc123'})
-        super_nav_details.insert({'uid': 'xyz321'})
         super_nav_details.insert({'uid': 'an7.75'})
         super_nav_details.insert({'uid': 'an7.76'})
         super_nav_details.insert({'uid': 'pli-tv-pvr7'})
         create_file(notes_file, [])
 
         create_file(parallels_file, [
-            {'parallels': ['abc123', 'xyz321']},
             {entry_type: ['an7.75-76', 'pli-tv-pvr7#97.1-#98.1']},
         ])
 
@@ -148,80 +175,181 @@ class TestLoadRelationships:
         docs = tidy_relationship_docs(relationship)
 
         assert [doc['_from'] for doc in docs] == [
-            'super_nav_details/abc123',
             'super_nav_details/an7.75',
             'super_nav_details/an7.76',
             'super_nav_details/pli-tv-pvr7',
-            'super_nav_details/pli-tv-pvr7',
-            'super_nav_details/xyz321'
+            'super_nav_details/pli-tv-pvr7'
         ]
 
+    @pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
+    def test_adds_remarks(self, file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                          database, super_nav_details, relationship, entry_type):
+        super_nav_details.insert({'uid': 'abc123'})
+        super_nav_details.insert({'uid': 'xyz321'})
+        create_file(notes_file, [{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
+        create_file(parallels_file, [{entry_type: ['abc123', 'xyz321']}])
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+        docs = tidy_relationship_docs(relationship)
+        assert [doc['remark'] for doc in docs] == ['Remarkable', 'Remarkable']
 
-@pytest.mark.parametrize(
-    'entry,to_from',
-    [
-        ({'parallels': ['abc123', 'sa-2']}, [('abc123', 'sa-2'), ('sa', 'abc123')]),
-        ({'retells': ['abc123', 'sa-2']}, [('abc123', 'sa-2'), ('sa-2', 'abc123')]),
-        ({'mentions': ['abc123', 'sa-2']}, [('abc123', 'sa-2'), ('sa-2', 'abc123')]),
-    ]
-)
-def test_encoding_contains_dash(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                notes_file, database, super_nav_details, relationship, entry, to_from):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'sa-2'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [entry])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    assert sorted([(doc['to'], doc['from']) for doc in docs]) == to_from
-
-
-@pytest.fixture
-def with_uids():
-    Encoding.load_uids({'abc123', 'xyz321', 'pqr777'})
-    yield
-    Encoding.load_uids({})
-
-
-class TestAllEdges:
-    def test_creates_edges_for_each_entry_type(self, with_uids):
-        relationships_data = [
-            {'parallels': ['abc123', 'xyz321']},
-            {'mentions': ['abc123', 'xyz321']},
-            {'retells': ['abc123', 'xyz321']},
-        ]
-
-        notes_data = [{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}]
-
-        assert len(list(all_edges(relationships_data, notes_data))) == 6
-
-
-class TestRemarks:
-    def test_no_remark_when_both_missing(self):
-        remarks = Remarks([])
-        assert remarks.lookup(('abc123', 'xyz321')) is None
-
-    def test_get_remark_for_relation(self):
-        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
-        assert remarks.lookup(('abc123', 'xyz321')) == 'Remarkable'
-
-    def test_reverse_order_of_uid_retrieves_remark(self):
-        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
-        assert remarks.lookup(('xyz321', 'abc123')) == 'Remarkable'
-
-    @pytest.mark.parametrize('data', [
-        [{'relations': ['abc123', 'unrelated'], 'remark': 'Remarkable.'}],
-        [{'relations': ['unrelated', 'xyz123'], 'remark': 'Remarkable.'}],
+    @pytest.mark.parametrize('entry_data', [
+        [{"parallels": ['abc123', 'no_such_uid']}],
+        [{"parallels": ['no_such_uid', 'abc321']}],
     ])
-    def test_unrelated_remarks_not_retrieved(self, data):
-        remarks = Remarks(data)
-        assert remarks.lookup(('abc123', 'xyz123')) is None
+    def test_logs_parallels_unmatched_encodings(self, file_changed, relationship_dir, additional_info_dir,
+                                                parallels_file, notes_file, database, super_nav_details, relationship,
+                                                entry_data, caplog):
+        caplog.set_level(logging.INFO)
+        super_nav_details.insert({'uid': 'abc123'})
+        create_file(notes_file, [])
+        create_file(parallels_file, entry_data)
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+
+        # We get two messages because we create two edges. Where the from encoding
+        # has no matching uids we drop it, for the to encoding we create an orphan.
+        assert sorted(caplog.messages) == sorted([
+            'Relationship encoding has no matching uids: no_such_uid (dropped)',
+            'Relationship to encoding could not be matched: no_such_uid (appears as orphan)'
+        ])
+
+    @pytest.mark.parametrize('entry_data', [
+        [{"mentions": ['abc123', 'no_such_uid']}],
+        [{"retells": ['abc123', 'no_such_uid']}],
+    ])
+    def test_logs_other_unmatched_encodings(self, file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                            notes_file, database, super_nav_details, relationship, entry_data, caplog):
+        caplog.set_level(logging.INFO)
+        super_nav_details.insert({'uid': 'abc123'})
+        create_file(notes_file, [])
+        create_file(parallels_file, entry_data)
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+
+        assert sorted(caplog.messages) == sorted([
+            'Relationship encoding has no matching uids: no_such_uid (dropped)',
+        ])
+
+    def test_empties_collection_before_load(self, file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                            notes_file, database, super_nav_details, relationship):
+        super_nav_details.insert({'uid': 'abc123'})
+        super_nav_details.insert({'uid': 'xyz321'})
+        super_nav_details.insert({'uid': 'pqr777'})
+        super_nav_details.insert({'uid': 'stu888'})
+        create_file(notes_file, [])
+        create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+        create_file(parallels_file, [{'parallels': ['pqr777', 'stu888']}])
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+        docs = tidy_relationship_docs(relationship)
+        from_to = [(doc['from'], doc['to']) for doc in docs]
+        assert from_to == [('pqr777', 'stu888'), ('stu888', 'pqr777')]
+
+
+class TestEdge:
+    @pytest.mark.parametrize('edge_type,uids', [
+        (EdgeType.FULL, EdgeUids('abc123', 'xyz321')),
+        (EdgeType.MENTION, EdgeUids('abc123', 'xyz321')),
+        (EdgeType.RETELLING, EdgeUids('abc123', 'xyz321')),
+    ])
+    def test_from_uid(self, edge_type, uids):
+        encodings = EdgeEncodings(Encoding('abc123'), Encoding('xyz321'))
+        assert Edge(edge_type, encodings, uids).as_dict()['_from'] == 'abc123'
+
+    @pytest.mark.parametrize('edge_type,uids', [
+        (EdgeType.FULL, EdgeUids('abc123', 'xyz321')),
+        (EdgeType.MENTION, EdgeUids('abc123', 'xyz321')),
+        (EdgeType.RETELLING, EdgeUids('abc123', 'xyz321')),
+    ])
+    def test_to_uid(self, edge_type, uids):
+        encodings = EdgeEncodings(Encoding('abc123'), Encoding('xyz321'))
+        assert Edge(edge_type, encodings, uids).as_dict()['_to'] == 'xyz321'
+
+    @pytest.mark.parametrize('edge_type,from_encoding,from_', [
+        (EdgeType.FULL, 'abc123', 'abc123'),
+        (EdgeType.MENTION, 'abc123', 'abc123'),
+        (EdgeType.RETELLING, 'abc123', 'abc123'),
+        (EdgeType.FULL, '~abc123', 'abc123'),
+        (EdgeType.MENTION, '~abc123', 'abc123'),
+        (EdgeType.RETELLING, '~abc123', 'abc123'),
+        (EdgeType.FULL, '~abc123-extra', 'abc123-extra'),
+        (EdgeType.MENTION, '~abc123-extra', 'abc123-extra'),
+        (EdgeType.RETELLING, '~abc123-extra', 'abc123-extra'),
+    ])
+    def test_from_encoding(self, edge_type, from_encoding, from_):
+        uids = EdgeUids('abc123', 'xyz321')
+        encodings = EdgeEncodings(Encoding(from_encoding), Encoding('xyz321'))
+        assert Edge(edge_type, encodings, uids).as_dict()['from'] == from_
+
+    @pytest.mark.parametrize('edge_type,to_encoding,to', [
+        (EdgeType.FULL, 'xyz321', 'xyz321'),
+        (EdgeType.MENTION, 'xyz321', 'xyz321'),
+        (EdgeType.RETELLING, 'xyz321', 'xyz321'),
+        (EdgeType.FULL, '~xyz321', 'xyz321'),
+        (EdgeType.MENTION, '~xyz321', 'xyz321'),
+        (EdgeType.RETELLING, '~xyz321', 'xyz321'),
+        (EdgeType.FULL, '~xyz321-extra', 'xyz321'),
+        (EdgeType.MENTION, '~xyz321-extra', 'xyz321-extra'),
+        (EdgeType.RETELLING, '~xyz321-extra', 'xyz321-extra'),
+    ])
+    def test_to_encoding(self, edge_type, to_encoding, to):
+        uids = EdgeUids('abc123', 'xyz321')
+        encodings = EdgeEncodings(Encoding('abc123'), Encoding(to_encoding))
+        assert Edge(edge_type, encodings, uids).as_dict()['to'] == to
+
+    @pytest.mark.parametrize('edge_type,from_encoding,number', [
+        (EdgeType.FULL, 'abc', 0),
+        (EdgeType.MENTION, 'abc', 0),
+        (EdgeType.RETELLING, 'abc', 0),
+        (EdgeType.FULL, 'abc123', 123),
+        (EdgeType.MENTION, 'abc123', 123),
+        (EdgeType.RETELLING, 'abc123', 123),
+    ])
+    def test_number(self, edge_type, from_encoding, number):
+        uids = EdgeUids('abc123', 'xyz321')
+        encodings = EdgeEncodings(Encoding(from_encoding), Encoding('xyz321'))
+        assert Edge(edge_type, encodings, uids).as_dict()['number'] == number
+
+    @pytest.mark.parametrize('edge_type,type_', [
+        (EdgeType.FULL, 'full'),
+        (EdgeType.MENTION, 'mention'),
+        (EdgeType.RETELLING, 'retelling'),
+    ])
+    def test_type(self, edge_type, type_):
+        uids = EdgeUids('abc123', 'xyz321')
+        encodings = EdgeEncodings(Encoding('abc123'), Encoding('xyz321'))
+        assert Edge(edge_type, encodings, uids).as_dict()['type'] == type_
+
+    @pytest.mark.parametrize('edge_type,from_encoding,to_encoding,resembling', [
+        (EdgeType.FULL, 'abc123', 'xyz321', False),
+        (EdgeType.MENTION, 'abc123', 'xyz321', False),
+        (EdgeType.RETELLING, 'abc123', 'xyz321', False),
+        (EdgeType.FULL, 'abc123', '~xyz321', True),
+        (EdgeType.MENTION, 'abc123', '~xyz321', True),
+        (EdgeType.RETELLING, 'abc123', '~xyz321', True),
+        (EdgeType.MENTION, '~abc123', 'xyz321', True),
+        (EdgeType.RETELLING, '~abc123', 'xyz321', True),
+        (EdgeType.RETELLING, '~abc123', '~xyz321', True),
+        (EdgeType.MENTION, '~abc123', '~xyz321', True),
+        (EdgeType.RETELLING, '~abc123', '~xyz321', True),
+    ])
+    def test_resembling(self, edge_type, from_encoding, to_encoding, resembling):
+        uids = EdgeUids('abc123', 'xyz321')
+        encodings = EdgeEncodings(Encoding(from_encoding), Encoding(to_encoding))
+        assert Edge(edge_type, encodings, uids).as_dict()['resembling'] is resembling
+
+    @pytest.mark.parametrize('edge_type,from_uid,to_uid,remark', [
+        (EdgeType.FULL, 'abc123', 'xyz321', 'Remarkable'),
+        (EdgeType.FULL, 'abc123', 'unrelated', None),
+    ])
+    def test_remark(self, with_remarks, edge_type, from_uid, to_uid, remark):
+        uids = EdgeUids(from_uid, to_uid)
+        encodings = EdgeEncodings(Encoding('abc123'), Encoding('xyz321'))
+        assert Edge(edge_type, encodings, uids).as_dict()['remark'] == remark
 
 
 class TestParallelsEdges:
     def test_creates_edges(self, with_uids):
         entry = Entry(EntryType.PARALLELS, ['abc123', 'xyz321'])
-        assert [edge for edge in ParallelsEdges(entry, Remarks([]))] == [
+        assert [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())] == [
             {
                 '_from': 'abc123',
                 '_to': 'xyz321',
@@ -244,10 +372,9 @@ class TestParallelsEdges:
             },
         ]
 
-    def test_adds_remarks(self, with_uids):
+    def test_adds_remarks(self, with_remarks, with_uids):
         entry = Entry(EntryType.PARALLELS, ['abc123', 'xyz321'])
-        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
-        assert [edge['remark'] for edge in ParallelsEdges(entry, remarks)] == ['Remarkable', 'Remarkable']
+        assert [edge.as_dict()['remark'] for edge in ParallelsEdges(entry, Unmatched())] == ['Remarkable', 'Remarkable']
 
     @pytest.mark.parametrize('entry_data,numbers', [
         (Entry(EntryType.PARALLELS, ['abc123', 'xyz321']), [123, 321]),
@@ -255,33 +382,20 @@ class TestParallelsEdges:
     ])
     def test_adds_numbers(self, with_uids, entry_data, numbers):
         Encoding.load_uids({'abc123', 'xyz321', 'abc'})
-        edges = ParallelsEdges(entry_data, Remarks([]))
-        assert [edge['number'] for edge in edges] == numbers
+        edges = ParallelsEdges(entry_data, Unmatched())
+        assert [edge.as_dict()['number'] for edge in edges] == numbers
 
     @pytest.mark.parametrize('entry,_to', [
         (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid']), ['orphan']),
         (Entry(EntryType.PARALLELS, ['no_such_uid', 'abc123']), ['orphan']),
     ])
     def test_adds_orphan(self, with_uids, entry, _to):
-        edges = ParallelsEdges(entry, Remarks([]))
-        assert [edge['_to'] for edge in edges] == _to
-
-    @pytest.mark.parametrize('entry', [
-        (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid'])),
-        (Entry(EntryType.PARALLELS, ['no_such_uid', 'abc123'])),
-    ])
-    def test_parallels_orphan_is_logged_twice(self, with_uids, entry, caplog):
-        caplog.set_level(logging.INFO)
-        _ = list(ParallelsEdges(entry, Remarks([])))
-        # BUG? It isn't dropped, just show second log message.
-        assert sorted(caplog.messages) == sorted([
-            'Relationship encoding has no matching uids: no_such_uid (dropped)',
-            'Relationship to encoding could not be matched: no_such_uid (appears as orphan)'
-        ])
+        edges = ParallelsEdges(entry, Unmatched())
+        assert [edge.as_dict()['_to'] for edge in edges] == _to
 
     def test_no_resembling_encodings(self, with_uids):
         entry = Entry(EntryType.PARALLELS, ['abc123', 'xyz321'])
-        edges = ParallelsEdges(entry, Remarks([]))
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         resembling = [(edge['_to'], edge['_from'], edge['resembling']) for edge in edges]
         assert resembling == [('xyz321', 'abc123', False), ('abc123', 'xyz321', False)]
 
@@ -290,53 +404,100 @@ class TestParallelsEdges:
         (Entry(EntryType.PARALLELS, ['~xyz321', 'abc123']), [('xyz321', 'abc123', True)]),
     ])
     def test_with_resembling_encodings(self, with_uids, entry, to_from_resembling):
-        edges = ParallelsEdges(entry, Remarks([]))
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         assert [(edge['_to'], edge['_from'], edge['resembling']) for edge in edges] == to_from_resembling
 
-    @pytest.mark.parametrize('entry,to_from', [
-        (
-                Entry(EntryType.PARALLELS, ['abc123', 'xyz321', 'pqr777']),
-                [
-                    ('xyz321', 'abc123'), ('pqr777', 'abc123'),
-                    ('abc123', 'xyz321'), ('pqr777', 'xyz321'),
-                    ('abc123', 'pqr777'), ('xyz321', 'pqr777')
-                ]
-        ),
-        (
-                Entry(EntryType.PARALLELS, ['abc123', 'xyz321', '~pqr777']),
-                [
-                    ('xyz321', 'abc123'), ('pqr777', 'abc123'),
-                    ('abc123', 'xyz321'), ('pqr777', 'xyz321'),
-                ]
-        ),
-        (
-                Entry(EntryType.PARALLELS, ['abc123', '~xyz321', '~pqr777']),
-                [('xyz321', 'abc123'), ('pqr777', 'abc123')]
-        ),
+    @pytest.mark.parametrize('entry,from_uids', [
+        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321', 'pqr777']),
+         ['abc123', 'abc123', 'xyz321', 'xyz321', 'pqr777', 'pqr777']),
+        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321', '~pqr777']), ['abc123', 'abc123', 'xyz321', 'xyz321']),
+        (Entry(EntryType.PARALLELS, ['abc123', '~xyz321', '~pqr777']), ['abc123', 'abc123']),
+        (Entry(EntryType.PARALLELS, ['~abc123', '~xyz321', '~pqr777']), []),
     ])
-    def test_combinations(self, with_uids, entry, to_from):
-        edges = ParallelsEdges(entry, Remarks([]))
-        assert [(edge['_to'], edge['_from']) for edge in edges] == to_from
+    def test_encoding_combinations_give_from_uids(self, with_uids, entry, from_uids):
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
+        assert [edge['_from'] for edge in edges] == from_uids
 
-    @pytest.mark.parametrize('entry,_to,_from', [
+    @pytest.mark.parametrize('entry,to_uids', [
+        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321', 'pqr777']),
+         ['xyz321', 'pqr777', 'abc123', 'pqr777', 'abc123', 'xyz321']),
+        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321', '~pqr777']), ['xyz321', 'pqr777', 'abc123', 'pqr777']),
+        (Entry(EntryType.PARALLELS, ['abc123', '~xyz321', '~pqr777']), ['xyz321', 'pqr777']),
+        (Entry(EntryType.PARALLELS, ['~abc123', '~xyz321', '~pqr777']), []),
+    ])
+    def test_encoding_combinations_give_to_uids(self, with_uids, entry, to_uids):
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
+        assert [edge['_to'] for edge in edges] == to_uids
+
+    @pytest.mark.parametrize('entry,to_encoding,from_encoding', [
         (Entry(EntryType.PARALLELS, ['abc123', 'xyz321#654']), 'xyz321#654', 'abc123'),
         (Entry(EntryType.PARALLELS, ['xyz321#654', 'abc123']), 'abc123', 'xyz321#654'),
     ])
-    def test_sectional_uids(self, with_uids, entry, _to, _from):
-        edges = ParallelsEdges(entry, Remarks([]))
+    def test_sectional_uids(self, with_uids, entry, to_encoding, from_encoding):
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         to_from = [(edge['to'], edge['from']) for edge in edges]
-        assert to_from == [(_to, _from), (_from, _to)]
+        assert to_from == [(to_encoding, from_encoding), (from_encoding, to_encoding)]
 
     def test_external_uid(self, with_uids):
         entry = Entry(EntryType.PARALLELS, ['abc123', 'has space'])
-        edges = ParallelsEdges(entry, Remarks([]))
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         assert [(edge['to'], edge['from']) for edge in edges] == [('has space', 'abc123')]
 
-    def test_expands_uid_range(self):
-        Encoding.load_uids({'an7.75', 'an7.76', 'pli-tv-pvr7'})
-        entry = Entry(EntryType.PARALLELS, ['an7.75-76', 'pli-tv-pvr7#97.1-#98.1'])
-        edges = ParallelsEdges(entry, Remarks([]))
-        assert [edge['_from'] for edge in edges] == ['an7.75', 'an7.76', 'pli-tv-pvr7', 'pli-tv-pvr7']
+    @pytest.mark.parametrize('encodings,from_uids', [
+        (['mn1-2', 'dn1'], ['mn1', 'mn2', 'dn1', 'dn1']),
+        (['mn1', 'dn1-2'], ['mn1', 'mn1', 'dn1', 'dn2']),
+        (['mn1-2', 'dn1-2'], ['mn1', 'mn1', 'mn2', 'mn2', 'dn1', 'dn1', 'dn2', 'dn2']),
+    ])
+    def test_expands_uid_range_in_from_uids(self, with_uids, encodings, from_uids):
+        entry = Entry(EntryType.PARALLELS, encodings)
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
+        assert [edge['_from'] for edge in edges] == from_uids
+
+    @pytest.mark.parametrize('encodings,to_uids', [
+        (['mn1-2', 'dn1'], ['dn1', 'dn1', 'mn1', 'mn2']),
+        (['mn1', 'dn1-2'], ['dn1', 'dn2', 'mn1', 'mn1']),
+        (['mn1-2', 'dn1-2'], ['dn1', 'dn2', 'dn1', 'dn2', 'mn1', 'mn2', 'mn1', 'mn2']),
+    ])
+    def test_expands_uid_range_in_to_uids(self, with_uids, encodings, to_uids):
+        entry = Entry(EntryType.PARALLELS, encodings)
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
+        assert [edge['_to'] for edge in edges] == to_uids
+
+    @pytest.mark.parametrize('entry,from_encodings', [
+        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321']), ['abc123', 'xyz321']),
+        (Entry(EntryType.PARALLELS, ['abc123', '~xyz321']), ['abc123']),
+        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321#1.2.3']), ['abc123', 'xyz321#1.2.3']),
+    ])
+    def test_sets_from_encoding(self, with_uids, entry, from_encodings):
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
+        assert [edge['from'] for edge in edges] == from_encodings
+
+    @pytest.mark.parametrize('entry,to_encodings', [
+        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321']), ['xyz321', 'abc123']),
+        (Entry(EntryType.PARALLELS, ['abc123', '~xyz321']), ['xyz321']),
+        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321#1.2.3']), ['xyz321#1.2.3', 'abc123']),
+    ])
+    def test_sets_to_encoding(self, with_uids, entry, to_encodings):
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
+        assert [edge['to'] for edge in edges] == to_encodings
+
+    @pytest.mark.parametrize('entry', [
+        (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid'])),
+        (Entry(EntryType.PARALLELS, ['no_such_uid', 'abc123'])),
+    ])
+    def test_stores_dropped_encodings(self, with_uids, entry):
+        unmatched = Unmatched()
+        _ = list(ParallelsEdges(entry, unmatched))
+        assert unmatched.dropped == [Encoding('no_such_uid')]
+
+    @pytest.mark.parametrize('entry', [
+        (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid'])),
+        (Entry(EntryType.PARALLELS, ['no_such_uid', 'abc123'])),
+    ])
+    def test_stores_orphan_encodings(self, with_uids, entry):
+        unmatched = Unmatched()
+        _ = list(ParallelsEdges(entry, unmatched))
+        assert unmatched.orphans == [Encoding('no_such_uid')]
 
 
 class TestOtherEdges:
@@ -346,7 +507,7 @@ class TestOtherEdges:
     ])
     def test_creates_edges_for_mentions(self, with_uids, entry_type, edge_type):
         entry = Entry(entry_type, ['abc123', 'xyz321'])
-        edges = OtherEdges(entry, Remarks([]))
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [edge for edge in edges] == [
             {
                 '_from': 'abc123',
@@ -370,20 +531,20 @@ class TestOtherEdges:
         ]
 
     @pytest.mark.parametrize('entry_type', [EntryType.MENTIONS, EntryType.RETELLS])
-    def test_adds_remarks(self, with_uids, entry_type):
+    def test_adds_remarks(self, with_remarks, with_uids, entry_type):
         entry = Entry(entry_type, ['abc123', 'xyz321'])
-        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
-        assert [edge['remark'] for edge in OtherEdges(entry, remarks)] == ['Remarkable', 'Remarkable']
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
+        assert [edge['remark'] for edge in edges] == ['Remarkable', 'Remarkable']
 
-    @pytest.mark.parametrize('entry_data,numbers', [
+    @pytest.mark.parametrize('entry,numbers', [
         (Entry(EntryType.MENTIONS, ['abc123', 'xyz321']), [123, 321]),
         (Entry(EntryType.RETELLS, ['abc123', 'xyz321']), [123, 321]),
         (Entry(EntryType.MENTIONS, ['abc', 'xyz321']), [0, 321]),
         (Entry(EntryType.RETELLS, ['abc', 'xyz321']), [0, 321]),
     ])
-    def test_adds_numbers(self, with_uids, entry_data, numbers):
+    def test_adds_numbers(self, with_uids, entry, numbers):
         Encoding.load_uids({'abc123', 'xyz321', 'abc'})
-        edges = OtherEdges(entry_data, Remarks([]))
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [edge['number'] for edge in edges] == numbers
 
     @pytest.mark.parametrize('entry', [
@@ -393,25 +554,8 @@ class TestOtherEdges:
         (Entry(EntryType.MENTIONS, ['no_such_uid', 'abc123'])),
     ])
     def test_does_not_add_orphans(self, with_uids, entry):
-        edges = OtherEdges(entry, Remarks([]))
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [edge['_to'] for edge in edges] == []
-
-    @pytest.mark.parametrize('entry', [
-        (Entry(EntryType.RETELLS, ['abc123', 'no_such_uid'])),
-        (Entry(EntryType.MENTIONS, ['abc123', 'no_such_uid'])),
-    ])
-    def test_others_with_orphans_are_logged_once(self, with_uids, entry, caplog):
-        _ = list(OtherEdges(entry, Remarks([])))
-        assert caplog.messages == ['Relationship encoding has no matching uids: no_such_uid (dropped)']
-
-    @pytest.mark.parametrize('entry', [
-        (Entry(EntryType.RETELLS, ['no_such_uid', 'abc123'])),
-        (Entry(EntryType.MENTIONS, ['no_such_uid', 'abc123'])),
-    ])
-    def test_others_with_orphans_not_logged_when_missing_is_first(self, with_uids, entry, caplog):
-        _ = list(OtherEdges(entry, Remarks([])))
-        # Bug? No message at all.
-        assert caplog.messages == []
 
     @pytest.mark.parametrize('entry,to_from_resembling', [
         (Entry(EntryType.RETELLS, ['abc123', '~xyz321']), [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
@@ -420,67 +564,33 @@ class TestOtherEdges:
         (Entry(EntryType.MENTIONS, ['~abc123', 'xyz321']), [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
     ])
     def test_adds_resembling(self, with_uids, entry, to_from_resembling):
-        edges = OtherEdges(entry, Remarks([]))
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [(edge['_to'], edge['_from'], edge['resembling']) for edge in edges] == to_from_resembling
 
-    @pytest.mark.parametrize('entry,to_from', [
-        (
-            (Entry(EntryType.RETELLS, ['abc123', 'xyz321', 'pqr777'])),
-            [
-                ('xyz321', 'abc123'), ('abc123', 'xyz321'),
-                ('pqr777', 'abc123'), ('abc123', 'pqr777')
-            ]
-        ),
-        (
-            (Entry(EntryType.RETELLS, ['abc123', 'xyz321', '~pqr777'])),
-            [
-                ('xyz321', 'abc123'), ('abc123', 'xyz321'),
-                ('pqr777', 'abc123'), ('abc123', 'pqr777')
-            ]
-        ),
-        (
-            (Entry(EntryType.RETELLS, ['abc123', '~xyz321', '~pqr777'])),
-            [
-                ('xyz321', 'abc123'), ('abc123', 'xyz321'),
-                ('pqr777', 'abc123'), ('abc123', 'pqr777'),
-            ]
-        ),
-        (
-                (Entry(EntryType.MENTIONS, ['abc123', 'xyz321', 'pqr777'])),
-                [
-                    ('xyz321', 'abc123'), ('abc123', 'xyz321'),
-                    ('pqr777', 'abc123'), ('abc123', 'pqr777')
-                ]
-        ),
-        (
-                (Entry(EntryType.MENTIONS, ['abc123', 'xyz321', '~pqr777'])),
-                [
-                    ('xyz321', 'abc123'), ('abc123', 'xyz321'),
-                    ('pqr777', 'abc123'), ('abc123', 'pqr777')
-                ]
-        ),
-        (
-                (Entry(EntryType.MENTIONS, ['abc123', '~xyz321', '~pqr777'])),
-                [
-                    ('xyz321', 'abc123'), ('abc123', 'xyz321'),
-                    ('pqr777', 'abc123'), ('abc123', 'pqr777'),
-                ]
-        ),
+    @pytest.mark.parametrize('entry,from_uids', [
+        (Entry(EntryType.MENTIONS, ['abc123', 'xyz321', 'pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (Entry(EntryType.RETELLS, ['abc123', 'xyz321', 'pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (Entry(EntryType.MENTIONS, ['abc123', 'xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (Entry(EntryType.RETELLS, ['abc123', 'xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (Entry(EntryType.MENTIONS, ['abc123', '~xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (Entry(EntryType.RETELLS, ['abc123', '~xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (Entry(EntryType.MENTIONS, ['~abc123', '~xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (Entry(EntryType.RETELLS, ['~abc123', '~xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
     ])
-    def test_resembling_combinations(self, with_uids, entry, to_from):
-        edges = OtherEdges(entry, Remarks([]))
-        assert [(edge['_to'], edge['_from']) for edge in edges] == to_from
+    def test_encoding_combinations_gives_from_uids(self, with_uids, entry, from_uids):
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
+        assert [edge['_from'] for edge in edges] == from_uids
 
-    @pytest.mark.parametrize('entry,_to,_from', [
+    @pytest.mark.parametrize('entry,to_encoding,from_encoding', [
         (Entry(EntryType.RETELLS, ['abc123', 'xyz321#654']), 'xyz321#654', 'abc123'),
         (Entry(EntryType.MENTIONS, ['abc123', 'xyz321#654']), 'xyz321#654', 'abc123'),
         (Entry(EntryType.RETELLS, ['xyz321#654', 'abc123']), 'abc123', 'xyz321#654'),
         (Entry(EntryType.MENTIONS, ['xyz321#654', 'abc123']), 'abc123', 'xyz321#654'),
     ])
-    def test_sectional_uids(self, with_uids, entry, _to, _from):
-        edges = OtherEdges(entry, Remarks([]))
+    def test_sectional_uids(self, with_uids, entry, to_encoding, from_encoding):
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         to_from = [(edge['to'], edge['from']) for edge in edges]
-        assert to_from == [(_to, _from), (_from, _to)]
+        assert to_from == [(to_encoding, from_encoding), (from_encoding, to_encoding)]
 
     @pytest.mark.parametrize(
         'entry,to_from',
@@ -490,25 +600,59 @@ class TestOtherEdges:
         ]
     )
     def test_external_uid(self, with_uids, entry, to_from):
-        edges = OtherEdges(entry, Remarks([]))
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [(edge['to'], edge['from']) for edge in edges] == to_from
 
-    @pytest.mark.parametrize('entry_type', [EntryType.MENTIONS, EntryType.RETELLS])
-    def test_expands_uid_range(self, entry_type):
-        Encoding.load_uids({'an7.75', 'an7.76', 'pli-tv-pvr7'})
-        entry = Entry(entry_type, ['an7.75-76', 'pli-tv-pvr7#97.1-#98.1'])
-        edges = OtherEdges(entry, Remarks([]))
-        assert [edge['_from'] for edge in edges] == ['an7.75', 'pli-tv-pvr7', 'an7.76', 'pli-tv-pvr7']
-
-
-class TestRelationshipType:
-    @pytest.mark.parametrize('entry,relationship', [
-        (EntryType.PARALLELS, EdgeType.FULL),
-        (EntryType.MENTIONS, EdgeType.MENTION),
-        (EntryType.RETELLS, EdgeType.RETELLING),
+    @pytest.mark.parametrize('entry,from_uids', [
+        (Entry(EntryType.RETELLS, ['mn1-2', 'dn1']), ['mn1', 'dn1', 'mn2', 'dn1']),
+        (Entry(EntryType.MENTIONS, ['mn1-2', 'dn1']), ['mn1', 'dn1', 'mn2', 'dn1']),
+        (Entry(EntryType.RETELLS, ['mn1', 'dn1-2']), ['mn1', 'dn1', 'mn1', 'dn2']),
+        (Entry(EntryType.MENTIONS, ['mn1', 'dn1-2']), ['mn1', 'dn1', 'mn1', 'dn2']),
+        (Entry(EntryType.RETELLS, ['mn1-2', 'dn1-2']), ['mn1', 'dn1', 'mn1', 'dn2', 'mn2', 'dn1', 'mn2', 'dn2']),
+        (Entry(EntryType.MENTIONS, ['mn1-2', 'dn1-2']), ['mn1', 'dn1', 'mn1', 'dn2', 'mn2', 'dn1', 'mn2', 'dn2']),
     ])
-    def test_converts_types(self, entry, relationship):
-        assert to_edge_type(entry) == relationship
+    def test_expands_uid_range_in_from_uids(self, with_uids, entry, from_uids):
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
+        assert [edge['_from'] for edge in edges] == from_uids
+
+    @pytest.mark.parametrize('entry,to_uids', [
+        (Entry(EntryType.RETELLS, ['mn1-2', 'dn1']), ['dn1', 'mn1', 'dn1', 'mn2']),
+        (Entry(EntryType.MENTIONS, ['mn1-2', 'dn1']), ['dn1', 'mn1', 'dn1', 'mn2']),
+        (Entry(EntryType.RETELLS, ['mn1', 'dn1-2']), ['dn1', 'mn1', 'dn2', 'mn1']),
+        (Entry(EntryType.MENTIONS, ['mn1', 'dn1-2']), ['dn1', 'mn1', 'dn2', 'mn1']),
+        (Entry(EntryType.RETELLS, ['mn1-2', 'dn1-2']), ['dn1', 'mn1', 'dn2', 'mn1', 'dn1', 'mn2', 'dn2', 'mn2']),
+        (Entry(EntryType.MENTIONS, ['mn1-2', 'dn1-2']), ['dn1', 'mn1', 'dn2', 'mn1', 'dn1', 'mn2', 'dn2', 'mn2']),
+    ])
+    def test_expands_uid_range_in_to_uids(self, with_uids, entry, to_uids):
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
+        assert [edge['_to'] for edge in edges] == to_uids
+
+    @pytest.mark.parametrize('entry,from_encodings', [
+        (Entry(EntryType.RETELLS, ['abc123', 'xyz321']), ['abc123', 'xyz321']),
+        (Entry(EntryType.RETELLS, ['abc123', '~xyz321']), ['abc123', 'xyz321']),
+        (Entry(EntryType.RETELLS, ['abc123', 'xyz321#1.2.3']), ['abc123', 'xyz321#1.2.3']),
+    ])
+    def test_sets_from_encoding(self, with_uids, entry, from_encodings):
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
+        assert [edge['from'] for edge in edges] == from_encodings
+
+    @pytest.mark.parametrize('entry,to_encodings', [
+        (Entry(EntryType.RETELLS, ['abc123', 'xyz321']), ['xyz321', 'abc123']),
+        (Entry(EntryType.RETELLS, ['abc123', '~xyz321']), ['xyz321', 'abc123']),
+        (Entry(EntryType.RETELLS, ['abc123', 'xyz321#1.2.3']), ['xyz321#1.2.3', 'abc123']),
+    ])
+    def test_sets_to_encoding(self, with_uids, entry, to_encodings):
+        edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
+        assert [edge['to'] for edge in edges] == to_encodings
+
+    @pytest.mark.parametrize('entry', [
+        (Entry(EntryType.RETELLS, ['abc123', 'no_such_uid'])),
+        (Entry(EntryType.MENTIONS, ['abc123', 'no_such_uid'])),
+    ])
+    def test_stores_dropped_encodings(self, with_uids, entry):
+        unmatched = Unmatched()
+        _ = list(OtherEdges(entry, unmatched))
+        assert unmatched.dropped == [Encoding('no_such_uid')]
 
 
 class TestEntry:
@@ -575,3 +719,35 @@ class TestEncoding:
     )
     def test_has_matching_uid(self, encoding, has_matching_uid):
         assert Encoding(encoding).has_matching_uid() is has_matching_uid
+
+
+class TestRemarks:
+    def test_no_remark_when_both_missing(self):
+        remarks = Remarks([])
+        assert remarks.lookup(('abc123', 'xyz321')) is None
+
+    def test_get_remark_for_relation(self):
+        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
+        assert remarks.lookup(('abc123', 'xyz321')) == 'Remarkable'
+
+    def test_reverse_order_of_uid_retrieves_remark(self):
+        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
+        assert remarks.lookup(('xyz321', 'abc123')) == 'Remarkable'
+
+    @pytest.mark.parametrize('data', [
+        [{'relations': ['abc123', 'unrelated'], 'remark': 'Remarkable.'}],
+        [{'relations': ['unrelated', 'xyz123'], 'remark': 'Remarkable.'}],
+    ])
+    def test_unrelated_remarks_not_retrieved(self, data):
+        remarks = Remarks(data)
+        assert remarks.lookup(('abc123', 'xyz123')) is None
+
+
+class TestRelationshipType:
+    @pytest.mark.parametrize('entry,relationship', [
+        (EntryType.PARALLELS, EdgeType.FULL),
+        (EntryType.MENTIONS, EdgeType.MENTION),
+        (EntryType.RETELLS, EdgeType.RETELLING),
+    ])
+    def test_converts_types(self, entry, relationship):
+        assert to_edge_type(entry) == relationship

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -328,24 +328,6 @@ def test_create_resembling_other_from(file_changed, relationship_dir, additional
     ]
 
 
-@pytest.mark.parametrize('in_type,out_type', [('retells', 'retelling'), ('mentions', 'mention')])
-def test_not_resembling_when_other_type_and_partial_to(file_changed, relationship_dir, additional_info_dir,
-                                                       parallels_file,
-                                                       notes_file, database, super_nav_details, relationship, in_type,
-                                                       out_type):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [
-        {'parallels': ['abc123', 'xyz321']},
-        {in_type: ['abc123', '~xyz321']},
-    ])
-    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    resembling = [doc for doc in docs if doc['resembling']]
-    assert len(resembling) == 0
-
-
 def test_value_error_when_unknown_type(file_changed, relationship_dir, additional_info_dir, parallels_file,
                                        notes_file, database, super_nav_details, relationship):
     super_nav_details.insert({'uid': 'abc123'})
@@ -379,9 +361,9 @@ def test_first_retell_uid_is_resembling(file_changed, relationship_dir, addition
     assert resembling == [('lmno', 'pqrs'), ('pqrs', 'lmno')]
 
 
-def test_bad_edges_when_second_retell_uid_is_resembling(file_changed, relationship_dir, additional_info_dir,
-                                                        parallels_file, notes_file, database, super_nav_details,
-                                                        relationship):
+def test_second_retell_uid_is_resembling(file_changed, relationship_dir, additional_info_dir,
+                                         parallels_file, notes_file, database, super_nav_details,
+                                         relationship):
     super_nav_details.insert({'uid': 'abc123'})
     super_nav_details.insert({'uid': 'xyz321'})
     super_nav_details.insert({'uid': 'pqrs'})
@@ -394,29 +376,9 @@ def test_bad_edges_when_second_retell_uid_is_resembling(file_changed, relationsh
     ])
     generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
-    docs = [doc for doc in docs if doc['type'] == 'retelling']
-    assert docs == [
-        {
-            '_from': 'super_nav_details/lmno',
-            '_to': 'super_nav_details/pqrs',
-            'from': '~lmno',
-            'number': 0,
-            'remark': None,
-            'resembling': False,
-            'to': 'pqrs',
-            'type': 'retelling'
-        },
-        {
-            '_from': 'super_nav_details/pqrs',
-            '_to': 'super_nav_details/lmno',
-            'from': 'pqrs',
-            'number': 0,
-            'remark': None,
-            'resembling': False,
-            'to': '~lmno',
-            'type': 'retelling'
-        }
-    ]
+    resembling = sorted([(doc['to'], doc['from']) for doc in docs if doc['resembling']])
+
+    assert resembling == [('lmno', 'pqrs'), ('pqrs', 'lmno')]
 
 
 def test_three_parallels(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file, database,

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -8,10 +8,10 @@ from arango.collection import StandardCollection
 from arango.database import StandardDatabase
 
 from common.arangodb import get_db
-from common.uid_matcher import UidMatcher
 from common.utils import current_app
 from data_loader.ports import FileChangeTracker
-from data_loader.relationships import load_relationships, Remarks, Encoding
+from data_loader.relationships import load_relationships, Encoding, all_edges, ParallelsEdges, Entry, \
+    EntryType, EdgeType, to_edge_type, OtherEdges, Remarks
 from fakes import FakeFileChangeTracker
 
 
@@ -84,331 +84,51 @@ def file_changed(parallels_file) -> FileChangeTracker:
     return tracker
 
 
-def test_when_file_is_unchanged_no_documents_are_added(relationship_dir, additional_info_dir, parallels_file,
-                                                       notes_file, database, super_nav_details, relationship):
-    file_unchanged = FakeFileChangeTracker()
-    load_relationships(file_unchanged, relationship_dir, additional_info_dir, database)
-    assert len(relationship) == 0
-
-
-def test_add_parallels_edges(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                             notes_file, database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
-
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-
-    assert tidy_relationship_docs(relationship) == [
-        {
-            '_from': 'super_nav_details/abc123',
-            '_to': 'super_nav_details/xyz321',
-            'from': 'abc123',
-            'number': 123,
-            'remark': None,
-            'resembling': False,
-            'to': 'xyz321',
-            'type': 'full'
-        },
-        {
-            '_from': 'super_nav_details/xyz321',
-            '_to': 'super_nav_details/abc123',
-            'from': 'xyz321',
-            'number': 321,
-            'remark': None,
-            'resembling': False,
-            'to': 'abc123',
-            'type': 'full'
-        },
-    ]
-
-
-def test_add_retells_edges(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                           notes_file, database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{'retells': ['abc123', 'xyz321']}])
-
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-
-    assert tidy_relationship_docs(relationship) == [
-        {
-            '_from': 'super_nav_details/abc123',
-            '_to': 'super_nav_details/xyz321',
-            'from': 'abc123',
-            'number': 123,
-            'remark': None,
-            'resembling': False,
-            'to': 'xyz321',
-            'type': 'retelling'
-        },
-        {
-            '_from': 'super_nav_details/xyz321',
-            '_to': 'super_nav_details/abc123',
-            'from': 'xyz321',
-            'number': 321,
-            'remark': None,
-            'resembling': False,
-            'to': 'abc123',
-            'type': 'retelling'
-        }
-    ]
-
-
-def test_add_mentions_edges(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                            notes_file, database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{'mentions': ['abc123', 'xyz321']}])
-
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-
-    assert tidy_relationship_docs(relationship) == [
-        {
-            '_from': 'super_nav_details/abc123',
-            '_to': 'super_nav_details/xyz321',
-            'from': 'abc123',
-            'number': 123,
-            'remark': None,
-            'resembling': False,
-            'to': 'xyz321',
-            'type': 'mention'
-        },
-        {
-            '_from': 'super_nav_details/xyz321',
-            '_to': 'super_nav_details/abc123',
-            'from': 'xyz321',
-            'number': 321,
-            'remark': None,
-            'resembling': False,
-            'to': 'abc123',
-            'type': 'mention'
-        }
-    ]
-
-
-def test_when_unrelated_remark_exists(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                      notes_file, database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
-    create_file(notes_file, [{'relations': ['abc123', 'def'], 'remark': 'Remarkable.'}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    remarks = [doc['remark'] for doc in docs]
-    assert remarks == [None, None]
-
-
-def test_when_related_remark_exists(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                    notes_file, database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
-    create_file(notes_file, [{"relations": ["abc123", "xyz321"], "remark": "Remarkable"}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    remarks = [doc['remark'] for doc in docs]
-    assert remarks == ['Remarkable', 'Remarkable']
-
-
-@pytest.mark.parametrize('in_type', ['parallels', 'retells', 'mentions'])
-def test_number_zero_when_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                  notes_file, database, super_nav_details, relationship, in_type):
-    create_file(notes_file, [])
-    super_nav_details.insert({'uid': 'no_number_from'})
-    super_nav_details.insert({'uid': 'no_number_to'})
-    create_file(parallels_file, [{in_type: ['no_number_from', 'no_number_to']}, ])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    numbers = [doc['number'] for doc in docs]
-    assert sorted(numbers) == [0, 0]
-
-
-def test_create_orphan_when_from_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                         notes_file, database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{'parallels': ['no_such', 'xyz321']}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    to = [doc['_to'] for doc in docs]
-    assert to == ['super_nav_details/orphan']
-
-
-def test_create_orphan_when_to_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                       notes_file, database, super_nav_details, relationship, caplog):
-    super_nav_details.insert({'uid': 'abc123'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{'parallels': ['abc123', 'no_such']}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    to = [doc['_to'] for doc in docs]
-    assert to == ['super_nav_details/orphan']
-    assert caplog.messages == ['Relationship encoding has no matching uids: no_such (dropped)']
-
-
-def test_logs_appears_as_orphan_when_from_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                                  notes_file, database, super_nav_details, relationship, caplog):
-    caplog.set_level(logging.INFO)
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{'parallels': ['no_such', 'xyz321']}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    assert caplog.messages == [
-        'Relationship encoding has no matching uids: no_such (dropped)',
-        'Relationship to encoding could not be matched: no_such (appears as orphan)'
-    ]
-
-
-@pytest.mark.parametrize('entry_type', ['retells', 'mentions'])
-def test_no_orphans_for_others(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                               notes_file, database, super_nav_details, relationship, entry_type, caplog):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{entry_type: ['abc123', 'no_such']}, ])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    assert len(relationship) == 0
-    assert caplog.messages == ['Relationship encoding has no matching uids: no_such (dropped)']
-
-
-@pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
-def test_neither_encoding_is_resembling(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                        notes_file, database, super_nav_details, relationship, entry_type):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{entry_type: ['abc123', 'xyz321']}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    resembling = [doc['resembling'] for doc in docs]
-    assert not any(resembling)
-
-
-@pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
-def test_from_encoding_is_resembling(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                     notes_file, database, super_nav_details, relationship, entry_type):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{entry_type: ['~abc123', 'xyz321']}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    resembling = [doc['resembling'] for doc in docs]
-    assert all(resembling)
-
-
-@pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
-def test_to_encoding_is_resembling(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                   notes_file, database, super_nav_details, relationship, entry_type):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{entry_type: ['abc123', '~xyz321']}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    resembling = [doc['resembling'] for doc in docs]
-    assert all(resembling)
-
-
-def test_key_error_when_unknown_type(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                     notes_file, database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{'extrudes': ['abc123', 'xyz321']}, ])
-    with pytest.raises(KeyError, match='extrudes'):
-        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-
-
-def test_three_parallels(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file, database,
-                         super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    super_nav_details.insert({'uid': 'hij678'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{'parallels': ['abc123', 'xyz321', 'hij678']}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    to_from = sorted([(doc['to'], doc['from']) for doc in docs])
-    assert to_from == [
-        ('abc123', 'hij678'),
-        ('abc123', 'xyz321'),
-        ('hij678', 'abc123'),
-        ('hij678', 'xyz321'),
-        ('xyz321', 'abc123'),
-        ('xyz321', 'hij678'),
-    ]
-
-
-def test_two_full_one_resembling_last(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
-                                      database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    super_nav_details.insert({'uid': 'hij678'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{'parallels': ['abc123', 'xyz321', '~hij678']}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    to_from = sorted([(doc['to'], doc['from']) for doc in docs])
-    assert to_from == [
-        ('abc123', 'xyz321'),
-        ('hij678', 'abc123'),
-        ('hij678', 'xyz321'),
-        ('xyz321', 'abc123')
-    ]
-
-
-def test_two_full_one_resembling_first(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
+class TestLoadRelationships:
+    def test_skip_when_files_unchanged(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
                                        database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    super_nav_details.insert({'uid': 'hij678'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{'parallels': ['~hij678', 'abc123', 'xyz321']}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    to_from = sorted([(doc['to'], doc['from']) for doc in docs])
-    assert to_from == [
-        ('abc123', 'xyz321'),
-        ('hij678', 'abc123'),
-        ('hij678', 'xyz321'),
-        ('xyz321', 'abc123')
+        tracker = FakeFileChangeTracker()
+        load_relationships(tracker, relationship_dir, additional_info_dir, database)
+        assert len(relationship) == 0
+
+    def test_load_when_parallels_have_changed(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                                              database, super_nav_details, relationship):
+        super_nav_details.insert({'uid': 'abc123'})
+        super_nav_details.insert({'uid': 'xyz321'})
+        create_file(notes_file, [])
+        create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
+        tracker = FakeFileChangeTracker()
+        tracker.change_file(parallels_file)
+        load_relationships(tracker, relationship_dir, additional_info_dir, database)
+        assert len(relationship) == 2
+
+    def test_load_when_notes_have_changed(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                                          database, super_nav_details, relationship):
+        super_nav_details.insert({'uid': 'abc123'})
+        super_nav_details.insert({'uid': 'xyz321'})
+        create_file(notes_file, [])
+        create_file(parallels_file, [{'parallels': ['abc123', 'xyz321']}])
+        tracker = FakeFileChangeTracker()
+        tracker.change_file(notes_file)
+        load_relationships(tracker, relationship_dir, additional_info_dir, database)
+        assert len(relationship) == 2
+
+    @pytest.mark.parametrize('entry_type,edge_type', [
+        ('parallels', 'full'),
+        ('retells', 'retelling'),
+        ('mentions', 'mention'),
     ]
-
-
-def test_partials(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
-                  database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'ja539'})
-    super_nav_details.insert({'uid': 'thag1.97'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [{'parallels': ['ja539#127', 'thag1.97']}])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    to_from = sorted([(doc['to'], doc['from']) for doc in docs])
-    assert to_from == [('ja539#127', 'thag1.97'), ('thag1.97', 'ja539#127')]
-
-
-@pytest.mark.parametrize(
-    'entry,to_from',
-    [
-        ({'parallels': ['abc123', 'has space']}, [('has space', 'abc123')]),
-        ({'retells': ['abc123', 'has space']}, []),
-        ({'mentions': ['abc123', 'has space']}, []),
-    ]
-)
-def test_external_uid(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                      notes_file, database, super_nav_details, relationship, entry, to_from):
-    super_nav_details.insert({'uid': 'abc123'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [entry])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    assert sorted([(doc['to'], doc['from']) for doc in docs]) == to_from
+    )
+    def test_sets_edge_type(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                            database, super_nav_details, relationship, entry_type, edge_type):
+        super_nav_details.insert({'uid': 'abc123'})
+        super_nav_details.insert({'uid': 'xyz321'})
+        create_file(notes_file, [])
+        create_file(parallels_file, [{entry_type: ['abc123', 'xyz321']}])
+        tracker = FakeFileChangeTracker()
+        tracker.change_file(parallels_file)
+        load_relationships(tracker, relationship_dir, additional_info_dir, database)
+        assert next(relationship.all())['type'] == edge_type
 
 
 @pytest.mark.parametrize(
@@ -430,39 +150,347 @@ def test_encoding_contains_dash(file_changed, relationship_dir, additional_info_
     assert sorted([(doc['to'], doc['from']) for doc in docs]) == to_from
 
 
+@pytest.fixture
+def with_uids():
+    Encoding.load_uids({'abc123', 'xyz321', 'pqr777'})
+    yield
+    Encoding.load_uids({})
+
+
+class TestAllEdges:
+    def test_creates_edges_for_each_entry_type(self, with_uids):
+        relationships_data = [
+            {'parallels': ['abc123', 'xyz321']},
+            {'mentions': ['abc123', 'xyz321']},
+            {'retells': ['abc123', 'xyz321']},
+        ]
+
+        notes_data = [{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}]
+
+        assert len(list(all_edges(relationships_data, notes_data))) == 6
+
+
 class TestRemarks:
-    def test_get_remark_for_relation(self, notes_file):
-        data = [
-            {
-                'relations': ['abc123', 'xyz321'],
-                'remark': 'Remarkable'
-            }
-        ]
-        create_file(notes_file, data)
-        Remarks.load(notes_file)
-        remarks = Remarks()
-        assert remarks.lookup('abc123', 'xyz321') == 'Remarkable'
+    def test_no_remark_when_both_missing(self):
+        remarks = Remarks([])
+        assert remarks.lookup(('abc123', 'xyz321')) is None
 
-    def test_reverse_order_of_uid_retrieves_remark(self, notes_file):
-        data = [
-            {
-                'relations': ['abc123', 'xyz321'],
-                'remark': 'Remarkable'
-            }
-        ]
-        create_file(notes_file, data)
-        assert Remarks.lookup('xyz321', 'abc123') == 'Remarkable'
+    def test_get_remark_for_relation(self):
+        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
+        assert remarks.lookup(('abc123', 'xyz321')) == 'Remarkable'
 
-    def test_no_remark_for_uids(self, notes_file):
-        create_file(notes_file, [])
-        Remarks.load(notes_file)
-        assert Remarks.lookup('abc123', 'xyz321') is None
+    def test_reverse_order_of_uid_retrieves_remark(self):
+        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
+        assert remarks.lookup(('xyz321', 'abc123')) == 'Remarkable'
+
+    @pytest.mark.parametrize('data', [
+        [{'relations': ['abc123', 'unrelated'], 'remark': 'Remarkable.'}],
+        [{'relations': ['unrelated', 'xyz123'], 'remark': 'Remarkable.'}],
+    ])
+    def test_unrelated_remarks_not_retrieved(self, data):
+        remarks = Remarks(data)
+        assert remarks.lookup(('abc123', 'xyz123')) is None
+
+
+class TestParallelsEdges:
+    def test_creates_edges(self, with_uids):
+        entry = Entry(EntryType.PARALLELS, ['abc123', 'xyz321'])
+        assert [edge for edge in ParallelsEdges(entry, Remarks([]))] == [
+            {
+                '_from': 'abc123',
+                '_to': 'xyz321',
+                'from': 'abc123',
+                'number': 123,
+                'remark': None,
+                'resembling': False,
+                'to': 'xyz321',
+                'type': 'full'
+            },
+            {
+                '_from': 'xyz321',
+                '_to': 'abc123',
+                'from': 'xyz321',
+                'number': 321,
+                'remark': None,
+                'resembling': False,
+                'to': 'abc123',
+                'type': 'full'
+            },
+        ]
+
+    def test_adds_remarks(self, with_uids):
+        entry = Entry(EntryType.PARALLELS, ['abc123', 'xyz321'])
+        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
+        assert [edge['remark'] for edge in ParallelsEdges(entry, remarks)] == ['Remarkable', 'Remarkable']
+
+    @pytest.mark.parametrize('entry_data,numbers', [
+        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321']), [123, 321]),
+        (Entry(EntryType.PARALLELS, ['abc', 'xyz321']), [0, 321]),
+    ])
+    def test_adds_numbers(self, with_uids, entry_data, numbers):
+        Encoding.load_uids({'abc123', 'xyz321', 'abc'})
+        edges = ParallelsEdges(entry_data, Remarks([]))
+        assert [edge['number'] for edge in edges] == numbers
+
+    @pytest.mark.parametrize('entry,_to', [
+        (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid']), ['orphan']),
+        (Entry(EntryType.PARALLELS, ['no_such_uid', 'abc123']), ['orphan']),
+    ])
+    def test_adds_orphan(self, with_uids, entry, _to):
+        edges = ParallelsEdges(entry, Remarks([]))
+        assert [edge['_to'] for edge in edges] == _to
+
+    @pytest.mark.parametrize('entry', [
+        (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid'])),
+        (Entry(EntryType.PARALLELS, ['no_such_uid', 'abc123'])),
+    ])
+    def test_parallels_orphan_is_logged_twice(self, with_uids, entry, caplog):
+        caplog.set_level(logging.INFO)
+        _ = list(ParallelsEdges(entry, Remarks([])))
+        # BUG? It isn't dropped, just show second log message.
+        assert sorted(caplog.messages) == sorted([
+            'Relationship encoding has no matching uids: no_such_uid (dropped)',
+            'Relationship to encoding could not be matched: no_such_uid (appears as orphan)'
+        ])
+
+    def test_no_resembling_encodings(self, with_uids):
+        entry = Entry(EntryType.PARALLELS, ['abc123', 'xyz321'])
+        edges = ParallelsEdges(entry, Remarks([]))
+        resembling = [(edge['_to'], edge['_from'], edge['resembling']) for edge in edges]
+        assert resembling == [('xyz321', 'abc123', False), ('abc123', 'xyz321', False)]
+
+    @pytest.mark.parametrize('entry,to_from_resembling', [
+        (Entry(EntryType.PARALLELS, ['abc123', '~xyz321']), [('xyz321', 'abc123', True)]),
+        (Entry(EntryType.PARALLELS, ['~xyz321', 'abc123']), [('xyz321', 'abc123', True)]),
+    ])
+    def test_with_resembling_encodings(self, with_uids, entry, to_from_resembling):
+        edges = ParallelsEdges(entry, Remarks([]))
+        assert [(edge['_to'], edge['_from'], edge['resembling']) for edge in edges] == to_from_resembling
+
+    @pytest.mark.parametrize('entry,to_from', [
+        (
+                Entry(EntryType.PARALLELS, ['abc123', 'xyz321', 'pqr777']),
+                [
+                    ('xyz321', 'abc123'), ('pqr777', 'abc123'),
+                    ('abc123', 'xyz321'), ('pqr777', 'xyz321'),
+                    ('abc123', 'pqr777'), ('xyz321', 'pqr777')
+                ]
+        ),
+        (
+                Entry(EntryType.PARALLELS, ['abc123', 'xyz321', '~pqr777']),
+                [
+                    ('xyz321', 'abc123'), ('pqr777', 'abc123'),
+                    ('abc123', 'xyz321'), ('pqr777', 'xyz321'),
+                ]
+        ),
+        (
+                Entry(EntryType.PARALLELS, ['abc123', '~xyz321', '~pqr777']),
+                [('xyz321', 'abc123'), ('pqr777', 'abc123')]
+        ),
+    ])
+    def test_combinations(self, with_uids, entry, to_from):
+        edges = ParallelsEdges(entry, Remarks([]))
+        assert [(edge['_to'], edge['_from']) for edge in edges] == to_from
+
+    @pytest.mark.parametrize('entry,_to,_from', [
+        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321#654']), 'xyz321#654', 'abc123'),
+        (Entry(EntryType.PARALLELS, ['xyz321#654', 'abc123']), 'abc123', 'xyz321#654'),
+    ])
+    def test_sectional_uids(self, with_uids, entry, _to, _from):
+        edges = ParallelsEdges(entry, Remarks([]))
+        to_from = [(edge['to'], edge['from']) for edge in edges]
+        assert to_from == [(_to, _from), (_from, _to)]
+
+    def test_external_uid(self, with_uids):
+        entry = Entry(EntryType.PARALLELS, ['abc123', 'has space'])
+        edges = ParallelsEdges(entry, Remarks([]))
+        assert [(edge['to'], edge['from']) for edge in edges] == [('has space', 'abc123')]
+
+
+class TestOtherEdges:
+    @pytest.mark.parametrize('entry_type,edge_type', [
+        (EntryType.MENTIONS, EdgeType.MENTION),
+        (EntryType.RETELLS, EdgeType.RETELLING),
+    ])
+    def test_creates_edges_for_mentions(self, with_uids, entry_type, edge_type):
+        entry = Entry(entry_type, ['abc123', 'xyz321'])
+        edges = OtherEdges(entry, Remarks([]))
+        assert [edge for edge in edges] == [
+            {
+                '_from': 'abc123',
+                '_to': 'xyz321',
+                'from': 'abc123',
+                'number': 123,
+                'remark': None,
+                'resembling': False,
+                'to': 'xyz321',
+                'type': str(edge_type)
+            },
+            {'_from': 'xyz321',
+             '_to': 'abc123',
+             'from': 'xyz321',
+             'number': 321,
+             'remark': None,
+             'resembling': False,
+             'to': 'abc123',
+             'type': str(edge_type)
+             }
+        ]
+
+    @pytest.mark.parametrize('entry_type', [EntryType.MENTIONS, EntryType.RETELLS])
+    def test_adds_remarks(self, with_uids, entry_type):
+        entry = Entry(entry_type, ['abc123', 'xyz321'])
+        remarks = Remarks([{'relations': ['abc123', 'xyz321'], 'remark': 'Remarkable'}])
+        assert [edge['remark'] for edge in OtherEdges(entry, remarks)] == ['Remarkable', 'Remarkable']
+
+    @pytest.mark.parametrize('entry_data,numbers', [
+        (Entry(EntryType.MENTIONS, ['abc123', 'xyz321']), [123, 321]),
+        (Entry(EntryType.RETELLS, ['abc123', 'xyz321']), [123, 321]),
+        (Entry(EntryType.MENTIONS, ['abc', 'xyz321']), [0, 321]),
+        (Entry(EntryType.RETELLS, ['abc', 'xyz321']), [0, 321]),
+    ])
+    def test_adds_numbers(self, with_uids, entry_data, numbers):
+        Encoding.load_uids({'abc123', 'xyz321', 'abc'})
+        edges = OtherEdges(entry_data, Remarks([]))
+        assert [edge['number'] for edge in edges] == numbers
+
+    @pytest.mark.parametrize('entry', [
+        (Entry(EntryType.RETELLS, ['abc123', 'no_such_uid'])),
+        (Entry(EntryType.MENTIONS, ['no_such_uid', 'abc123'])),
+        (Entry(EntryType.RETELLS, ['abc123', 'no_such_uid'])),
+        (Entry(EntryType.MENTIONS, ['no_such_uid', 'abc123'])),
+    ])
+    def test_does_not_add_orphans(self, with_uids, entry):
+        edges = OtherEdges(entry, Remarks([]))
+        assert [edge['_to'] for edge in edges] == []
+
+    @pytest.mark.parametrize('entry', [
+        (Entry(EntryType.RETELLS, ['abc123', 'no_such_uid'])),
+        (Entry(EntryType.MENTIONS, ['abc123', 'no_such_uid'])),
+    ])
+    def test_others_with_orphans_are_logged_once(self, with_uids, entry, caplog):
+        _ = list(OtherEdges(entry, Remarks([])))
+        assert caplog.messages == ['Relationship encoding has no matching uids: no_such_uid (dropped)']
+
+    @pytest.mark.parametrize('entry', [
+        (Entry(EntryType.RETELLS, ['no_such_uid', 'abc123'])),
+        (Entry(EntryType.MENTIONS, ['no_such_uid', 'abc123'])),
+    ])
+    def test_others_with_orphans_not_logged_when_missing_is_first(self, with_uids, entry, caplog):
+        _ = list(OtherEdges(entry, Remarks([])))
+        # Bug? No message at all.
+        assert caplog.messages == []
+
+    @pytest.mark.parametrize('entry,to_from_resembling', [
+        (Entry(EntryType.RETELLS, ['abc123', '~xyz321']), [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
+        (Entry(EntryType.MENTIONS, ['abc123', '~xyz321']), [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
+        (Entry(EntryType.RETELLS, ['~abc123', 'xyz321']), [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
+        (Entry(EntryType.MENTIONS, ['~abc123', 'xyz321']), [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
+    ])
+    def test_adds_resembling(self, with_uids, entry, to_from_resembling):
+        edges = OtherEdges(entry, Remarks([]))
+        assert [(edge['_to'], edge['_from'], edge['resembling']) for edge in edges] == to_from_resembling
+
+    @pytest.mark.parametrize('entry,to_from', [
+        (
+            (Entry(EntryType.RETELLS, ['abc123', 'xyz321', 'pqr777'])),
+            [
+                ('xyz321', 'abc123'), ('abc123', 'xyz321'),
+                ('pqr777', 'abc123'), ('abc123', 'pqr777')
+            ]
+        ),
+        (
+            (Entry(EntryType.RETELLS, ['abc123', 'xyz321', '~pqr777'])),
+            [
+                ('xyz321', 'abc123'), ('abc123', 'xyz321'),
+                ('pqr777', 'abc123'), ('abc123', 'pqr777')
+            ]
+        ),
+        (
+            (Entry(EntryType.RETELLS, ['abc123', '~xyz321', '~pqr777'])),
+            [
+                ('xyz321', 'abc123'), ('abc123', 'xyz321'),
+                ('pqr777', 'abc123'), ('abc123', 'pqr777'),
+            ]
+        ),
+        (
+                (Entry(EntryType.MENTIONS, ['abc123', 'xyz321', 'pqr777'])),
+                [
+                    ('xyz321', 'abc123'), ('abc123', 'xyz321'),
+                    ('pqr777', 'abc123'), ('abc123', 'pqr777')
+                ]
+        ),
+        (
+                (Entry(EntryType.MENTIONS, ['abc123', 'xyz321', '~pqr777'])),
+                [
+                    ('xyz321', 'abc123'), ('abc123', 'xyz321'),
+                    ('pqr777', 'abc123'), ('abc123', 'pqr777')
+                ]
+        ),
+        (
+                (Entry(EntryType.MENTIONS, ['abc123', '~xyz321', '~pqr777'])),
+                [
+                    ('xyz321', 'abc123'), ('abc123', 'xyz321'),
+                    ('pqr777', 'abc123'), ('abc123', 'pqr777'),
+                ]
+        ),
+    ])
+    def test_resembling_combinations(self, with_uids, entry, to_from):
+        edges = OtherEdges(entry, Remarks([]))
+        assert [(edge['_to'], edge['_from']) for edge in edges] == to_from
+
+    @pytest.mark.parametrize('entry,_to,_from', [
+        (Entry(EntryType.RETELLS, ['abc123', 'xyz321#654']), 'xyz321#654', 'abc123'),
+        (Entry(EntryType.MENTIONS, ['abc123', 'xyz321#654']), 'xyz321#654', 'abc123'),
+        (Entry(EntryType.RETELLS, ['xyz321#654', 'abc123']), 'abc123', 'xyz321#654'),
+        (Entry(EntryType.MENTIONS, ['xyz321#654', 'abc123']), 'abc123', 'xyz321#654'),
+    ])
+    def test_sectional_uids(self, with_uids, entry, _to, _from):
+        edges = OtherEdges(entry, Remarks([]))
+        to_from = [(edge['to'], edge['from']) for edge in edges]
+        assert to_from == [(_to, _from), (_from, _to)]
+
+    @pytest.mark.parametrize(
+        'entry,to_from',
+        [
+            (Entry(EntryType.RETELLS, ['abc123', 'has space']), []),
+            (Entry(EntryType.MENTIONS, ['abc123', 'has space']), []),
+        ]
+    )
+    def test_external_uid(self, with_uids, entry, to_from):
+        edges = OtherEdges(entry, Remarks([]))
+        assert [(edge['to'], edge['from']) for edge in edges] == to_from
+
+
+class TestRelationshipType:
+    @pytest.mark.parametrize('entry,relationship', [
+        (EntryType.PARALLELS, EdgeType.FULL),
+        (EntryType.MENTIONS, EdgeType.MENTION),
+        (EntryType.RETELLS, EdgeType.RETELLING),
+    ])
+    def test_converts_types(self, entry, relationship):
+        assert to_edge_type(entry) == relationship
+
+
+class TestEntry:
+    def test_entry_type(self):
+        assert Entry('parallels', ['abc123', 'xyz321']).entry_type == 'parallels'
+
+    def test_edge_type(self):
+        assert Entry('parallels', ['abc123', 'xyz321']).edge_type == 'full'
+
+    def test_encodings(self):
+        assert Entry('parallels', ['abc123', 'xyz321']).encodings == [Encoding('abc123'), Encoding('xyz321')]
+
+    def test_invalid_entry_type(self):
+        with pytest.raises(ValueError, match='extrudes'):
+            _ = Entry('extrudes', ['abc123', 'xyz321'])
 
 
 class TestEncoding:
     @pytest.fixture
     def with_uids(self):
-        Encoding.matcher = UidMatcher({'abc123'})
+        Encoding.load_uids({'abc123'})
 
     def test_to_string(self, with_uids):
         assert str(Encoding('~abc123')) == '~abc123'

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -117,8 +117,7 @@ class TestLoadRelationships:
         ('parallels', 'full'),
         ('retells', 'retelling'),
         ('mentions', 'mention'),
-    ]
-    )
+    ])
     def test_sets_edge_type(self, relationship_dir, additional_info_dir, parallels_file, notes_file,
                             database, super_nav_details, relationship, entry_type, edge_type):
         super_nav_details.insert({'uid': 'abc123'})
@@ -129,6 +128,33 @@ class TestLoadRelationships:
         tracker.change_file(parallels_file)
         load_relationships(tracker, relationship_dir, additional_info_dir, database)
         assert next(relationship.all())['type'] == edge_type
+
+    @pytest.mark.parametrize('entry_type', ['retells', 'mentions'])
+    def test_expands_uid_range(self, file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file, database,
+                               super_nav_details, relationship, entry_type):
+        super_nav_details.insert({'uid': 'abc123'})
+        super_nav_details.insert({'uid': 'xyz321'})
+        super_nav_details.insert({'uid': 'an7.75'})
+        super_nav_details.insert({'uid': 'an7.76'})
+        super_nav_details.insert({'uid': 'pli-tv-pvr7'})
+        create_file(notes_file, [])
+
+        create_file(parallels_file, [
+            {'parallels': ['abc123', 'xyz321']},
+            {entry_type: ['an7.75-76', 'pli-tv-pvr7#97.1-#98.1']},
+        ])
+
+        load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+        docs = tidy_relationship_docs(relationship)
+
+        assert [doc['_from'] for doc in docs] == [
+            'super_nav_details/abc123',
+            'super_nav_details/an7.75',
+            'super_nav_details/an7.76',
+            'super_nav_details/pli-tv-pvr7',
+            'super_nav_details/pli-tv-pvr7',
+            'super_nav_details/xyz321'
+        ]
 
 
 @pytest.mark.parametrize(
@@ -306,6 +332,12 @@ class TestParallelsEdges:
         edges = ParallelsEdges(entry, Remarks([]))
         assert [(edge['to'], edge['from']) for edge in edges] == [('has space', 'abc123')]
 
+    def test_expands_uid_range(self):
+        Encoding.load_uids({'an7.75', 'an7.76', 'pli-tv-pvr7'})
+        entry = Entry(EntryType.PARALLELS, ['an7.75-76', 'pli-tv-pvr7#97.1-#98.1'])
+        edges = ParallelsEdges(entry, Remarks([]))
+        assert [edge['_from'] for edge in edges] == ['an7.75', 'an7.76', 'pli-tv-pvr7', 'pli-tv-pvr7']
+
 
 class TestOtherEdges:
     @pytest.mark.parametrize('entry_type,edge_type', [
@@ -460,6 +492,13 @@ class TestOtherEdges:
     def test_external_uid(self, with_uids, entry, to_from):
         edges = OtherEdges(entry, Remarks([]))
         assert [(edge['to'], edge['from']) for edge in edges] == to_from
+
+    @pytest.mark.parametrize('entry_type', [EntryType.MENTIONS, EntryType.RETELLS])
+    def test_expands_uid_range(self, entry_type):
+        Encoding.load_uids({'an7.75', 'an7.76', 'pli-tv-pvr7'})
+        entry = Entry(entry_type, ['an7.75-76', 'pli-tv-pvr7#97.1-#98.1'])
+        edges = OtherEdges(entry, Remarks([]))
+        assert [edge['_from'] for edge in edges] == ['an7.75', 'pli-tv-pvr7', 'an7.76', 'pli-tv-pvr7']
 
 
 class TestRelationshipType:

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -149,12 +149,14 @@ def test_when_related_remark_exists(file_changed, relationship_dir, additional_i
 
 def test_error_when_retells_first(file_changed, relationship_dir, additional_info_dir, parallels_file,
                                   notes_file, database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
+    super_nav_details.insert({'uid': 'parallel123'})
+    super_nav_details.insert({'uid': 'parallel321'})
+    super_nav_details.insert({'uid': 'retell123'})
+    super_nav_details.insert({'uid': 'retell321'})
     create_file(notes_file, [])
     create_file(parallels_file, [
-        {'retells': ['abc123', 'xyz321']},
-        {'parallels': ['abc123', 'xyz321']},
+        {'retells': ['retell123', 'retell321']},
+        {'parallels': ['parallel123', 'parallel321']},
     ])
 
     create_file(notes_file, [])
@@ -342,3 +344,163 @@ def test_not_resembling_when_other_type_and_partial_to(file_changed, relationshi
     docs = tidy_relationship_docs(relationship)
     resembling = [doc for doc in docs if doc['resembling']]
     assert len(resembling) == 0
+
+
+def test_value_error_when_unknown_type(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                       notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [
+        {'extrudes': ['abc123', 'xyz321']},
+    ])
+
+    create_file(notes_file, [])
+    with pytest.raises(ValueError, match='Invalid relationship type "extrudes"'):
+        generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+
+
+def test_first_retell_uid_is_resembling(file_changed, relationship_dir, additional_info_dir,
+                                        parallels_file, notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    super_nav_details.insert({'uid': 'pqrs'})
+    super_nav_details.insert({'uid': 'lmno'})
+
+    create_file(notes_file, [])
+    create_file(parallels_file, [
+        {'parallels': ['abc123', 'xyz321']},
+        {'retells': ['~pqrs', 'lmno']},
+    ])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    resembling = sorted([(doc['to'], doc['from']) for doc in docs if doc['resembling']])
+
+    assert resembling == [('lmno', 'pqrs'), ('pqrs', 'lmno')]
+
+
+def test_bad_edges_when_second_retell_uid_is_resembling(file_changed, relationship_dir, additional_info_dir,
+                                                        parallels_file, notes_file, database, super_nav_details,
+                                                        relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    super_nav_details.insert({'uid': 'pqrs'})
+    super_nav_details.insert({'uid': 'lmno'})
+
+    create_file(notes_file, [])
+    create_file(parallels_file, [
+        {'parallels': ['abc123', 'xyz321']},
+        {'retells': ['pqrs', '~lmno']},
+    ])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    docs = [doc for doc in docs if doc['type'] == 'retelling']
+    assert docs == [
+        {
+            '_from': 'super_nav_details/lmno',
+            '_to': 'super_nav_details/pqrs',
+            'from': '~lmno',
+            'number': 0,
+            'remark': None,
+            'resembling': False,
+            'to': 'pqrs',
+            'type': 'retelling'
+        },
+        {
+            '_from': 'super_nav_details/pqrs',
+            '_to': 'super_nav_details/lmno',
+            'from': 'pqrs',
+            'number': 0,
+            'remark': None,
+            'resembling': False,
+            'to': '~lmno',
+            'type': 'retelling'
+        }
+    ]
+
+
+def test_three_parallels(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file, database,
+                         super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    super_nav_details.insert({'uid': 'hij678'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'parallels': ['abc123', 'xyz321', 'hij678']}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    to_from = sorted([(doc['to'], doc['from']) for doc in docs])
+    assert to_from == [
+        ('abc123', 'hij678'),
+        ('abc123', 'xyz321'),
+        ('hij678', 'abc123'),
+        ('hij678', 'xyz321'),
+        ('xyz321', 'abc123'),
+        ('xyz321', 'hij678'),
+    ]
+
+
+def test_two_full_one_resembling(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                                 database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    super_nav_details.insert({'uid': 'hij678'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'parallels': ['abc123', 'xyz321', '~hij678']}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    to_from = sorted([(doc['to'], doc['from']) for doc in docs])
+    assert to_from == [
+        ('abc123', 'xyz321'),
+        ('hij678', 'abc123'),
+        ('hij678', 'xyz321'),
+        ('xyz321', 'abc123')
+    ]
+
+
+def test_two_full_one_resembling_first(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                                       database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    super_nav_details.insert({'uid': 'hij678'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'parallels': ['~hij678', 'abc123', 'xyz321']}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    to_from = sorted([(doc['to'], doc['from']) for doc in docs])
+    assert to_from == [
+        ('abc123', 'xyz321'),
+        ('hij678', 'abc123'),
+        ('hij678', 'xyz321'),
+        ('xyz321', 'abc123')
+    ]
+
+
+def test_partials(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                  database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'ja539'})
+    super_nav_details.insert({'uid': 'thag1.97'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'parallels': ['ja539#127', 'thag1.97']}])
+    generate_relationship_edges(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    assert docs == [
+        {'_from': 'super_nav_details/ja539',
+         '_to': 'super_nav_details/thag1.97',
+         'from': 'ja539#127',
+         'number': 127,
+         'remark': None,
+         'resembling': False,
+         'to': 'thag1.97',
+         'type': 'full'
+         },
+        {
+            '_from': 'super_nav_details/thag1.97',
+            '_to': 'super_nav_details/ja539',
+            'from': 'thag1.97',
+            'number': 97,
+            'remark': None,
+            'resembling': False,
+            'to': 'ja539#127',
+            'type': 'full'
+        }
+    ]

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from itertools import repeat
 from pathlib import Path
 from typing import Any
 
@@ -11,7 +12,7 @@ from common.arangodb import get_db
 from common.utils import current_app
 from data_loader.ports import FileChangeTracker
 from data_loader.relationships import load_relationships, Encoding, Edge, Entry, \
-    EntryType, EdgeType, OtherEdges, Remarks, EdgeUids, EdgeEncodings, Unmatched, ParallelsEdges
+    EntryType, EdgeType, OtherEdges, Remarks, EdgeUids, EdgeEncodings, Unmatched, ParallelsEdges, entries_to_edges
 from fakes import FakeFileChangeTracker
 
 
@@ -794,3 +795,17 @@ class TestLoadRelationships:
         docs = tidy_relationship_docs(relationship)
         from_to = [(doc['from'], doc['to']) for doc in docs]
         assert from_to == [('pqr777', 'stu888'), ('stu888', 'pqr777')]
+
+
+class TestEntriesToEdges:
+    def test_one_entry(self):
+        entry = Entry(EntryType.PARALLELS, ['abc123', 'xyz321'])
+        edges = [edge.as_dict() for edge in entries_to_edges([entry], Unmatched())]
+        from_to = [(edge['from'], edge['to']) for edge in edges]
+        assert from_to == [('abc123', 'xyz321'), ('xyz321', 'abc123')]
+
+    def test_yields_right_number_of_edges(self):
+        two_edge_entry = Entry(EntryType.PARALLELS, ['abc123', 'xyz321'])
+        entries = repeat(two_edge_entry, 5)
+        edges = list(entries_to_edges(entries, Unmatched()))
+        assert len(edges) == 10

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -8,6 +8,7 @@ from arango.collection import StandardCollection
 from arango.database import StandardDatabase
 
 from common.arangodb import get_db
+from common.uid_matcher import UidMatcher
 from common.utils import current_app
 from data_loader.ports import FileChangeTracker
 from data_loader.relationships import load_relationships, Remarks, Encoding
@@ -461,7 +462,7 @@ class TestRemarks:
 class TestEncoding:
     @pytest.fixture
     def with_uids(self):
-        Encoding.all_uids = {'abc123'}
+        Encoding.matcher = UidMatcher({'abc123'})
 
     def test_to_string(self, with_uids):
         assert str(Encoding('~abc123')) == '~abc123'

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -120,7 +120,8 @@ class TestEncoding:
         assert Encoding(encoding).is_external() == is_external
 
     @pytest.mark.parametrize('encoding,number', [('abc123', 123), ('abc', 0)])
-    def test_number(self, encoding, number):
+    def test_number(self, with_uids, encoding, number):
+        Encoding.load_uids({'abc123', 'abc'})
         assert Encoding(encoding).number() == number
 
     @pytest.mark.parametrize('encoding,stripped', [('abc123', 'abc123'), ('~abc123', 'abc123')])
@@ -344,20 +345,22 @@ class TestParallelsEdges:
         entry = Entry(EntryType.PARALLELS, ['abc123', 'xyz321'])
         assert [edge.as_dict()['remark'] for edge in ParallelsEdges(entry, Unmatched())] == ['Remarkable', 'Remarkable']
 
-    @pytest.mark.parametrize('entry_data,numbers', [
-        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321']), [123, 321]),
-        (Entry(EntryType.PARALLELS, ['abc', 'xyz321']), [0, 321]),
+    @pytest.mark.parametrize('encodings,numbers', [
+        (['abc123', 'xyz321'], [123, 321]),
+        (['abc', 'xyz321'], [0, 321]),
     ])
-    def test_adds_numbers(self, with_uids, entry_data, numbers):
+    def test_adds_numbers(self, encodings, numbers):
         Encoding.load_uids({'abc123', 'xyz321', 'abc'})
-        edges = ParallelsEdges(entry_data, Unmatched())
+        entry = Entry(EntryType.PARALLELS, encodings)
+        edges = ParallelsEdges(entry, Unmatched())
         assert [edge.as_dict()['number'] for edge in edges] == numbers
 
-    @pytest.mark.parametrize('entry,_to', [
-        (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid']), ['orphan']),
-        (Entry(EntryType.PARALLELS, ['no_such_uid', 'abc123']), ['orphan']),
+    @pytest.mark.parametrize('encodings,_to', [
+        (['abc123', 'no_such_uid'], ['orphan']),
+        (['no_such_uid', 'abc123'], ['orphan']),
     ])
-    def test_adds_orphan(self, with_uids, entry, _to):
+    def test_adds_orphan(self, with_uids, encodings, _to):
+        entry = Entry(EntryType.PARALLELS, encodings)
         edges = ParallelsEdges(entry, Unmatched())
         assert [edge.as_dict()['_to'] for edge in edges] == _to
 
@@ -367,41 +370,43 @@ class TestParallelsEdges:
         resembling = [(edge['_to'], edge['_from'], edge['resembling']) for edge in edges]
         assert resembling == [('xyz321', 'abc123', False), ('abc123', 'xyz321', False)]
 
-    @pytest.mark.parametrize('entry,to_from_resembling', [
-        (Entry(EntryType.PARALLELS, ['abc123', '~xyz321']), [('xyz321', 'abc123', True)]),
-        (Entry(EntryType.PARALLELS, ['~xyz321', 'abc123']), [('xyz321', 'abc123', True)]),
+    @pytest.mark.parametrize('encodings,to_from_resembling', [
+        (['abc123', '~xyz321'], [('xyz321', 'abc123', True)]),
+        (['~xyz321', 'abc123'], [('xyz321', 'abc123', True)]),
     ])
-    def test_with_resembling_encodings(self, with_uids, entry, to_from_resembling):
+    def test_with_resembling_encodings(self, with_uids, encodings, to_from_resembling):
+        entry = Entry(EntryType.PARALLELS, encodings)
         edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         assert [(edge['_to'], edge['_from'], edge['resembling']) for edge in edges] == to_from_resembling
 
-    @pytest.mark.parametrize('entry,from_uids', [
-        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321', 'pqr777']),
-         ['abc123', 'abc123', 'xyz321', 'xyz321', 'pqr777', 'pqr777']),
-        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321', '~pqr777']), ['abc123', 'abc123', 'xyz321', 'xyz321']),
-        (Entry(EntryType.PARALLELS, ['abc123', '~xyz321', '~pqr777']), ['abc123', 'abc123']),
-        (Entry(EntryType.PARALLELS, ['~abc123', '~xyz321', '~pqr777']), []),
+    @pytest.mark.parametrize('encodings,from_uids', [
+        (['abc123', 'xyz321', 'pqr777'], ['abc123', 'abc123', 'xyz321', 'xyz321', 'pqr777', 'pqr777']),
+        (['abc123', 'xyz321', '~pqr777'], ['abc123', 'abc123', 'xyz321', 'xyz321']),
+        (['abc123', '~xyz321', '~pqr777'], ['abc123', 'abc123']),
+        (['~abc123', '~xyz321', '~pqr777'], []),
     ])
-    def test_encoding_combinations_give_from_uids(self, with_uids, entry, from_uids):
+    def test_encoding_combinations_give_from_uids(self, with_uids, encodings, from_uids):
+        entry = Entry(EntryType.PARALLELS, encodings)
         edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         assert sorted([edge['_from'] for edge in edges]) == sorted(from_uids)
 
-    @pytest.mark.parametrize('entry,to_uids', [
-        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321', 'pqr777']),
-         ['xyz321', 'pqr777', 'abc123', 'pqr777', 'abc123', 'xyz321']),
-        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321', '~pqr777']), ['xyz321', 'pqr777', 'abc123', 'pqr777']),
-        (Entry(EntryType.PARALLELS, ['abc123', '~xyz321', '~pqr777']), ['xyz321', 'pqr777']),
-        (Entry(EntryType.PARALLELS, ['~abc123', '~xyz321', '~pqr777']), []),
+    @pytest.mark.parametrize('encodings,to_uids', [
+        (['abc123', 'xyz321', 'pqr777'], ['xyz321', 'pqr777', 'abc123', 'pqr777', 'abc123', 'xyz321']),
+        (['abc123', 'xyz321', '~pqr777'], ['xyz321', 'pqr777', 'abc123', 'pqr777']),
+        (['abc123', '~xyz321', '~pqr777'], ['xyz321', 'pqr777']),
+        (['~abc123', '~xyz321', '~pqr777'], []),
     ])
-    def test_encoding_combinations_give_to_uids(self, with_uids, entry, to_uids):
+    def test_encoding_combinations_give_to_uids(self, with_uids, encodings, to_uids):
+        entry = Entry(EntryType.PARALLELS, encodings)
         edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         assert sorted([edge['_to'] for edge in edges]) == sorted(to_uids)
 
-    @pytest.mark.parametrize('entry,to_encoding,from_encoding', [
-        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321#654']), 'xyz321#654', 'abc123'),
-        (Entry(EntryType.PARALLELS, ['xyz321#654', 'abc123']), 'abc123', 'xyz321#654'),
+    @pytest.mark.parametrize('encodings,to_encoding,from_encoding', [
+        (['abc123', 'xyz321#654'], 'xyz321#654', 'abc123'),
+        (['xyz321#654', 'abc123'], 'abc123', 'xyz321#654'),
     ])
-    def test_sectional_uids(self, with_uids, entry, to_encoding, from_encoding):
+    def test_sectional_uids(self, with_uids, encodings, to_encoding, from_encoding):
+        entry = Entry(EntryType.PARALLELS, encodings)
         edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         to_from = [(edge['to'], edge['from']) for edge in edges]
         assert to_from == [(to_encoding, from_encoding), (from_encoding, to_encoding)]
@@ -431,38 +436,42 @@ class TestParallelsEdges:
         edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         assert [edge['_to'] for edge in edges] == to_uids
 
-    @pytest.mark.parametrize('entry,from_encodings', [
-        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321']), ['abc123', 'xyz321']),
-        (Entry(EntryType.PARALLELS, ['abc123', '~xyz321']), ['abc123']),
-        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321#1.2.3']), ['abc123', 'xyz321#1.2.3']),
+    @pytest.mark.parametrize('encodings,from_encodings', [
+        (['abc123', 'xyz321'], ['abc123', 'xyz321']),
+        (['abc123', '~xyz321'], ['abc123']),
+        (['abc123', 'xyz321#1.2.3'], ['abc123', 'xyz321#1.2.3']),
     ])
-    def test_sets_from_encoding(self, with_uids, entry, from_encodings):
+    def test_sets_from_encoding(self, with_uids, encodings, from_encodings):
+        entry = Entry(EntryType.PARALLELS, encodings)
         edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         assert [edge['from'] for edge in edges] == from_encodings
 
-    @pytest.mark.parametrize('entry,to_encodings', [
-        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321']), ['xyz321', 'abc123']),
-        (Entry(EntryType.PARALLELS, ['abc123', '~xyz321']), ['xyz321']),
-        (Entry(EntryType.PARALLELS, ['abc123', 'xyz321#1.2.3']), ['xyz321#1.2.3', 'abc123']),
+    @pytest.mark.parametrize('encodings,to_encodings', [
+        (['abc123', 'xyz321'], ['xyz321', 'abc123']),
+        (['abc123', '~xyz321'], ['xyz321']),
+        (['abc123', 'xyz321#1.2.3'], ['xyz321#1.2.3', 'abc123']),
     ])
-    def test_sets_to_encoding(self, with_uids, entry, to_encodings):
+    def test_sets_to_encoding(self, with_uids, encodings, to_encodings):
+        entry = Entry(EntryType.PARALLELS, encodings)
         edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         assert [edge['to'] for edge in edges] == to_encodings
 
-    @pytest.mark.parametrize('entry', [
-        (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid'])),
-        (Entry(EntryType.PARALLELS, ['no_such_uid', 'abc123'])),
+    @pytest.mark.parametrize('encodings', [
+        (['abc123', 'no_such_uid']),
+        (['no_such_uid', 'abc123']),
     ])
-    def test_stores_dropped_encodings(self, with_uids, entry):
+    def test_stores_dropped_encodings(self, with_uids, encodings):
+        entry = Entry(EntryType.PARALLELS, encodings)
         unmatched = Unmatched()
         _ = list(ParallelsEdges(entry, unmatched))
         assert unmatched.dropped == {Encoding('no_such_uid')}
 
-    @pytest.mark.parametrize('entry', [
-        (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid'])),
-        (Entry(EntryType.PARALLELS, ['no_such_uid', 'abc123'])),
+    @pytest.mark.parametrize('encodings', [
+        (['abc123', 'no_such_uid']),
+        (['no_such_uid', 'abc123']),
     ])
-    def test_stores_orphan_encodings(self, with_uids, entry):
+    def test_stores_orphan_encodings(self, with_uids, encodings):
+        entry = Entry(EntryType.PARALLELS, encodings)
         unmatched = Unmatched()
         _ = list(ParallelsEdges(entry, unmatched))
         assert unmatched.orphans == {Encoding('no_such_uid')}
@@ -502,11 +511,12 @@ class TestParallelsEdges:
         edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         assert sorted([(edge['from'], edge['to']) for edge in edges]) == sorted(from_to)
 
-    @pytest.mark.parametrize('entry, from_to', [
-        (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid']), [('abc123', 'no_such_uid')]),
-        (Entry(EntryType.PARALLELS, ['no_such_uid', 'abc123']), [('abc123', 'no_such_uid')]),
+    @pytest.mark.parametrize('encodings, from_to', [
+        (['abc123', 'no_such_uid'], [('abc123', 'no_such_uid')]),
+        (['no_such_uid', 'abc123'], [('abc123', 'no_such_uid')]),
     ])
-    def test_drops_unmatched_from_encodings(self, with_uids, entry, from_to):
+    def test_drops_unmatched_from_encodings(self, with_uids, encodings, from_to):
+        entry = Entry(EntryType.PARALLELS, encodings)
         edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
         assert sorted([(edge['from'], edge['to']) for edge in edges]) == sorted(from_to)
 
@@ -547,58 +557,63 @@ class TestOtherEdges:
         edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [edge['remark'] for edge in edges] == ['Remarkable', 'Remarkable']
 
-    @pytest.mark.parametrize('entry,numbers', [
-        (Entry(EntryType.MENTIONS, ['abc123', 'xyz321']), [123, 321]),
-        (Entry(EntryType.RETELLS, ['abc123', 'xyz321']), [123, 321]),
-        (Entry(EntryType.MENTIONS, ['abc', 'xyz321']), [0, 321]),
-        (Entry(EntryType.RETELLS, ['abc', 'xyz321']), [0, 321]),
+    @pytest.mark.parametrize('entry_type,encodings,numbers', [
+        (EntryType.MENTIONS, ['abc123', 'xyz321'], [123, 321]),
+        (EntryType.RETELLS, ['abc123', 'xyz321'], [123, 321]),
+        (EntryType.MENTIONS, ['abc', 'xyz321'], [0, 321]),
+        (EntryType.RETELLS, ['abc', 'xyz321'], [0, 321]),
     ])
-    def test_adds_numbers(self, with_uids, entry, numbers):
+    def test_adds_numbers(self, with_uids, entry_type, encodings, numbers):
         Encoding.load_uids({'abc123', 'xyz321', 'abc'})
+        entry = Entry(entry_type, encodings)
         edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [edge['number'] for edge in edges] == numbers
 
-    @pytest.mark.parametrize('entry', [
-        (Entry(EntryType.RETELLS, ['abc123', 'no_such_uid'])),
-        (Entry(EntryType.MENTIONS, ['no_such_uid', 'abc123'])),
-        (Entry(EntryType.RETELLS, ['abc123', 'no_such_uid'])),
-        (Entry(EntryType.MENTIONS, ['no_such_uid', 'abc123'])),
+    @pytest.mark.parametrize('entry_type,encodings', [
+        (EntryType.RETELLS, ['abc123', 'no_such_uid']),
+        (EntryType.MENTIONS, ['no_such_uid', 'abc123']),
+        (EntryType.RETELLS, ['abc123', 'no_such_uid']),
+        (EntryType.MENTIONS, ['no_such_uid', 'abc123']),
     ])
-    def test_does_not_add_orphans(self, with_uids, entry):
+    def test_does_not_add_orphans(self, with_uids, entry_type, encodings):
+        entry = Entry(entry_type, encodings)
         edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [edge['_to'] for edge in edges] == []
 
-    @pytest.mark.parametrize('entry,to_from_resembling', [
-        (Entry(EntryType.RETELLS, ['abc123', '~xyz321']), [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
-        (Entry(EntryType.MENTIONS, ['abc123', '~xyz321']), [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
-        (Entry(EntryType.RETELLS, ['~abc123', 'xyz321']), [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
-        (Entry(EntryType.MENTIONS, ['~abc123', 'xyz321']), [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
+    @pytest.mark.parametrize('entry_type,encodings,to_from_resembling', [
+        (EntryType.RETELLS, ['abc123', '~xyz321'], [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
+        (EntryType.MENTIONS, ['abc123', '~xyz321'], [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
+        (EntryType.RETELLS, ['~abc123', 'xyz321'], [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
+        (EntryType.MENTIONS, ['~abc123', 'xyz321'], [('xyz321', 'abc123', True), ('abc123', 'xyz321', True)]),
     ])
-    def test_adds_resembling(self, with_uids, entry, to_from_resembling):
+    def test_adds_resembling(self, with_uids, entry_type, encodings, to_from_resembling):
+        entry = Entry(entry_type, encodings)
         edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [(edge['_to'], edge['_from'], edge['resembling']) for edge in edges] == to_from_resembling
 
-    @pytest.mark.parametrize('entry,from_uids', [
-        (Entry(EntryType.MENTIONS, ['abc123', 'xyz321', 'pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
-        (Entry(EntryType.RETELLS, ['abc123', 'xyz321', 'pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
-        (Entry(EntryType.MENTIONS, ['abc123', 'xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
-        (Entry(EntryType.RETELLS, ['abc123', 'xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
-        (Entry(EntryType.MENTIONS, ['abc123', '~xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
-        (Entry(EntryType.RETELLS, ['abc123', '~xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
-        (Entry(EntryType.MENTIONS, ['~abc123', '~xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
-        (Entry(EntryType.RETELLS, ['~abc123', '~xyz321', '~pqr777']), ['abc123', 'xyz321', 'abc123', 'pqr777']),
+    @pytest.mark.parametrize('entry_type,encodings,from_uids', [
+        (EntryType.MENTIONS, ['abc123', 'xyz321', 'pqr777'], ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (EntryType.RETELLS, ['abc123', 'xyz321', 'pqr777'], ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (EntryType.MENTIONS, ['abc123', 'xyz321', '~pqr777'], ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (EntryType.RETELLS, ['abc123', 'xyz321', '~pqr777'], ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (EntryType.MENTIONS, ['abc123', '~xyz321', '~pqr777'], ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (EntryType.RETELLS, ['abc123', '~xyz321', '~pqr777'], ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (EntryType.MENTIONS, ['~abc123', '~xyz321', '~pqr777'], ['abc123', 'xyz321', 'abc123', 'pqr777']),
+        (EntryType.RETELLS, ['~abc123', '~xyz321', '~pqr777'], ['abc123', 'xyz321', 'abc123', 'pqr777']),
     ])
-    def test_encoding_combinations_gives_from_uids(self, with_uids, entry, from_uids):
+    def test_encoding_combinations_gives_from_uids(self, with_uids, entry_type, encodings, from_uids):
+        entry = Entry(entry_type, encodings)
         edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [edge['_from'] for edge in edges] == from_uids
 
-    @pytest.mark.parametrize('entry,to_encoding,from_encoding', [
-        (Entry(EntryType.RETELLS, ['abc123', 'xyz321#654']), 'xyz321#654', 'abc123'),
-        (Entry(EntryType.MENTIONS, ['abc123', 'xyz321#654']), 'xyz321#654', 'abc123'),
-        (Entry(EntryType.RETELLS, ['xyz321#654', 'abc123']), 'abc123', 'xyz321#654'),
-        (Entry(EntryType.MENTIONS, ['xyz321#654', 'abc123']), 'abc123', 'xyz321#654'),
+    @pytest.mark.parametrize('entry_type,encodings,to_encoding,from_encoding', [
+        (EntryType.RETELLS, ['abc123', 'xyz321#654'], 'xyz321#654', 'abc123'),
+        (EntryType.MENTIONS, ['abc123', 'xyz321#654'], 'xyz321#654', 'abc123'),
+        (EntryType.RETELLS, ['xyz321#654', 'abc123'], 'abc123', 'xyz321#654'),
+        (EntryType.MENTIONS, ['xyz321#654', 'abc123'], 'abc123', 'xyz321#654'),
     ])
-    def test_sectional_uids(self, with_uids, entry, to_encoding, from_encoding):
+    def test_sectional_uids(self, with_uids, entry_type, encodings, to_encoding, from_encoding):
+        entry = Entry(entry_type, encodings)
         edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         to_from = [(edge['to'], edge['from']) for edge in edges]
         assert to_from == [(to_encoding, from_encoding), (from_encoding, to_encoding)]
@@ -614,45 +629,49 @@ class TestOtherEdges:
         edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [(edge['to'], edge['from']) for edge in edges] == to_from
 
-    @pytest.mark.parametrize('entry,from_uids', [
-        (Entry(EntryType.RETELLS, ['mn1-2', 'dn1']), ['mn1', 'dn1', 'mn2', 'dn1']),
-        (Entry(EntryType.MENTIONS, ['mn1-2', 'dn1']), ['mn1', 'dn1', 'mn2', 'dn1']),
-        (Entry(EntryType.RETELLS, ['mn1', 'dn1-2']), ['mn1', 'dn1', 'mn1', 'dn2']),
-        (Entry(EntryType.MENTIONS, ['mn1', 'dn1-2']), ['mn1', 'dn1', 'mn1', 'dn2']),
-        (Entry(EntryType.RETELLS, ['mn1-2', 'dn1-2']), ['mn1', 'dn1', 'mn1', 'dn2', 'mn2', 'dn1', 'mn2', 'dn2']),
-        (Entry(EntryType.MENTIONS, ['mn1-2', 'dn1-2']), ['mn1', 'dn1', 'mn1', 'dn2', 'mn2', 'dn1', 'mn2', 'dn2']),
+    @pytest.mark.parametrize('entry_type,encodings,from_uids', [
+        (EntryType.RETELLS, ['mn1-2', 'dn1'], ['mn1', 'dn1', 'mn2', 'dn1']),
+        (EntryType.MENTIONS, ['mn1-2', 'dn1'], ['mn1', 'dn1', 'mn2', 'dn1']),
+        (EntryType.RETELLS, ['mn1', 'dn1-2'], ['mn1', 'dn1', 'mn1', 'dn2']),
+        (EntryType.MENTIONS, ['mn1', 'dn1-2'], ['mn1', 'dn1', 'mn1', 'dn2']),
+        (EntryType.RETELLS, ['mn1-2', 'dn1-2'], ['mn1', 'dn1', 'mn1', 'dn2', 'mn2', 'dn1', 'mn2', 'dn2']),
+        (EntryType.MENTIONS, ['mn1-2', 'dn1-2'], ['mn1', 'dn1', 'mn1', 'dn2', 'mn2', 'dn1', 'mn2', 'dn2']),
     ])
-    def test_expands_uid_range_in_from_uids(self, with_uids, entry, from_uids):
+    def test_expands_uid_range_in_from_uids(self, with_uids, entry_type, encodings, from_uids):
+        entry = Entry(entry_type, encodings)
         edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [edge['_from'] for edge in edges] == from_uids
 
-    @pytest.mark.parametrize('entry,to_uids', [
-        (Entry(EntryType.RETELLS, ['mn1-2', 'dn1']), ['dn1', 'mn1', 'dn1', 'mn2']),
-        (Entry(EntryType.MENTIONS, ['mn1-2', 'dn1']), ['dn1', 'mn1', 'dn1', 'mn2']),
-        (Entry(EntryType.RETELLS, ['mn1', 'dn1-2']), ['dn1', 'mn1', 'dn2', 'mn1']),
-        (Entry(EntryType.MENTIONS, ['mn1', 'dn1-2']), ['dn1', 'mn1', 'dn2', 'mn1']),
-        (Entry(EntryType.RETELLS, ['mn1-2', 'dn1-2']), ['dn1', 'mn1', 'dn2', 'mn1', 'dn1', 'mn2', 'dn2', 'mn2']),
-        (Entry(EntryType.MENTIONS, ['mn1-2', 'dn1-2']), ['dn1', 'mn1', 'dn2', 'mn1', 'dn1', 'mn2', 'dn2', 'mn2']),
+    @pytest.mark.parametrize('entry_type,encodings,to_uids', [
+        (EntryType.RETELLS, ['mn1-2', 'dn1'], ['dn1', 'mn1', 'dn1', 'mn2']),
+        (EntryType.MENTIONS, ['mn1-2', 'dn1'], ['dn1', 'mn1', 'dn1', 'mn2']),
+        (EntryType.RETELLS, ['mn1', 'dn1-2'], ['dn1', 'mn1', 'dn2', 'mn1']),
+        (EntryType.MENTIONS, ['mn1', 'dn1-2'], ['dn1', 'mn1', 'dn2', 'mn1']),
+        (EntryType.RETELLS, ['mn1-2', 'dn1-2'], ['dn1', 'mn1', 'dn2', 'mn1', 'dn1', 'mn2', 'dn2', 'mn2']),
+        (EntryType.MENTIONS, ['mn1-2', 'dn1-2'], ['dn1', 'mn1', 'dn2', 'mn1', 'dn1', 'mn2', 'dn2', 'mn2']),
     ])
-    def test_expands_uid_range_in_to_uids(self, with_uids, entry, to_uids):
+    def test_expands_uid_range_in_to_uids(self, with_uids, entry_type, encodings, to_uids):
+        entry = Entry(entry_type, encodings)
         edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [edge['_to'] for edge in edges] == to_uids
 
-    @pytest.mark.parametrize('entry,from_encodings', [
-        (Entry(EntryType.RETELLS, ['abc123', 'xyz321']), ['abc123', 'xyz321']),
-        (Entry(EntryType.RETELLS, ['abc123', '~xyz321']), ['abc123', 'xyz321']),
-        (Entry(EntryType.RETELLS, ['abc123', 'xyz321#1.2.3']), ['abc123', 'xyz321#1.2.3']),
+    @pytest.mark.parametrize('entry_type,encodings,from_encodings', [
+        (EntryType.RETELLS, ['abc123', 'xyz321'], ['abc123', 'xyz321']),
+        (EntryType.RETELLS, ['abc123', '~xyz321'], ['abc123', 'xyz321']),
+        (EntryType.RETELLS, ['abc123', 'xyz321#1.2.3'], ['abc123', 'xyz321#1.2.3']),
     ])
-    def test_sets_from_encoding(self, with_uids, entry, from_encodings):
+    def test_sets_from_encoding(self, with_uids, entry_type, encodings, from_encodings):
+        entry = Entry(entry_type, encodings)
         edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [edge['from'] for edge in edges] == from_encodings
 
-    @pytest.mark.parametrize('entry,to_encodings', [
-        (Entry(EntryType.RETELLS, ['abc123', 'xyz321']), ['xyz321', 'abc123']),
-        (Entry(EntryType.RETELLS, ['abc123', '~xyz321']), ['xyz321', 'abc123']),
-        (Entry(EntryType.RETELLS, ['abc123', 'xyz321#1.2.3']), ['xyz321#1.2.3', 'abc123']),
+    @pytest.mark.parametrize('entry_type,encodings,to_encodings', [
+        (EntryType.RETELLS, ['abc123', 'xyz321'], ['xyz321', 'abc123']),
+        (EntryType.RETELLS, ['abc123', '~xyz321'], ['xyz321', 'abc123']),
+        (EntryType.RETELLS, ['abc123', 'xyz321#1.2.3'], ['xyz321#1.2.3', 'abc123']),
     ])
-    def test_sets_to_encoding(self, with_uids, entry, to_encodings):
+    def test_sets_to_encoding(self, with_uids, entry_type, encodings, to_encodings):
+        entry = Entry(entry_type, encodings)
         edges = [edge.as_dict() for edge in OtherEdges(entry, Unmatched())]
         assert [edge['to'] for edge in edges] == to_encodings
 

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -90,8 +90,8 @@ def test_when_file_is_unchanged_no_documents_are_added(relationship_dir, additio
     assert len(relationship) == 0
 
 
-def test_create_parallel_between_two_uids(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                          notes_file, database, super_nav_details, relationship):
+def test_add_parallels_edges(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                             notes_file, database, super_nav_details, relationship):
     super_nav_details.insert({'uid': 'abc123'})
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(notes_file, [])
@@ -123,6 +123,72 @@ def test_create_parallel_between_two_uids(file_changed, relationship_dir, additi
     ]
 
 
+def test_add_retells_edges(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                           notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'retells': ['abc123', 'xyz321']}])
+
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+
+    assert tidy_relationship_docs(relationship) == [
+        {
+            '_from': 'super_nav_details/abc123',
+            '_to': 'super_nav_details/xyz321',
+            'from': 'abc123',
+            'number': 123,
+            'remark': None,
+            'resembling': False,
+            'to': 'xyz321',
+            'type': 'retelling'
+        },
+        {
+            '_from': 'super_nav_details/xyz321',
+            '_to': 'super_nav_details/abc123',
+            'from': 'xyz321',
+            'number': 321,
+            'remark': None,
+            'resembling': False,
+            'to': 'abc123',
+            'type': 'retelling'
+        }
+    ]
+
+
+def test_add_mentions_edges(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                            notes_file, database, super_nav_details, relationship):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{'mentions': ['abc123', 'xyz321']}])
+
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+
+    assert tidy_relationship_docs(relationship) == [
+        {
+            '_from': 'super_nav_details/abc123',
+            '_to': 'super_nav_details/xyz321',
+            'from': 'abc123',
+            'number': 123,
+            'remark': None,
+            'resembling': False,
+            'to': 'xyz321',
+            'type': 'mention'
+        },
+        {
+            '_from': 'super_nav_details/xyz321',
+            '_to': 'super_nav_details/abc123',
+            'from': 'xyz321',
+            'number': 321,
+            'remark': None,
+            'resembling': False,
+            'to': 'abc123',
+            'type': 'mention'
+        }
+    ]
+
+
 def test_when_unrelated_remark_exists(file_changed, relationship_dir, additional_info_dir, parallels_file,
                                       notes_file, database, super_nav_details, relationship):
     super_nav_details.insert({'uid': 'abc123'})
@@ -131,8 +197,8 @@ def test_when_unrelated_remark_exists(file_changed, relationship_dir, additional
     create_file(notes_file, [{'relations': ['abc123', 'def'], 'remark': 'Remarkable.'}])
     load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
-    assert docs[0]['remark'] is None
-    assert docs[1]['remark'] is None
+    remarks = [doc['remark'] for doc in docs]
+    assert remarks == [None, None]
 
 
 def test_when_related_remark_exists(file_changed, relationship_dir, additional_info_dir, parallels_file,
@@ -143,75 +209,24 @@ def test_when_related_remark_exists(file_changed, relationship_dir, additional_i
     create_file(notes_file, [{"relations": ["abc123", "xyz321"], "remark": "Remarkable"}])
     load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
-    assert docs[0]['remark'] == "Remarkable"
-    assert docs[1]['remark'] == "Remarkable"
+    remarks = [doc['remark'] for doc in docs]
+    assert remarks == ['Remarkable', 'Remarkable']
 
 
-def test_no_error_when_retells_first(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                     notes_file, database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'parallel123'})
-    super_nav_details.insert({'uid': 'parallel321'})
-    super_nav_details.insert({'uid': 'retell123'})
-    super_nav_details.insert({'uid': 'retell321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [
-        {'retells': ['retell123', 'retell321']},
-        {'parallels': ['parallel123', 'parallel321']},
-    ])
-
-    create_file(notes_file, [])
-    # This previously gave an UnboundLocalError
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-
-
-@pytest.mark.parametrize('in_type,out_type', [('retells', 'retelling'), ('mentions', 'mention')])
-def test_add_other_types(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                         notes_file, database, super_nav_details, relationship, in_type, out_type):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [
-        {'parallels': ['abc123', 'xyz321']},
-        {in_type: ['abc123', 'xyz321']},
-    ])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = relationship.find({'type': out_type})
-    from_uids = sorted([doc['from'] for doc in docs])
-    assert from_uids == ['abc123', 'xyz321']
-
-
-def test_number_parallel_zero_when_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                           notes_file, database, super_nav_details, relationship):
+@pytest.mark.parametrize('in_type', ['parallels', 'retells', 'mentions'])
+def test_number_zero_when_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                  notes_file, database, super_nav_details, relationship, in_type):
     create_file(notes_file, [])
     super_nav_details.insert({'uid': 'no_number_from'})
     super_nav_details.insert({'uid': 'no_number_to'})
-    create_file(parallels_file, [{'parallels': ['no_number_from', 'no_number_to']}])
+    create_file(parallels_file, [{in_type: ['no_number_from', 'no_number_to']}, ])
     load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
     numbers = [doc['number'] for doc in docs]
-    assert numbers == [0, 0]
+    assert sorted(numbers) == [0, 0]
 
 
-@pytest.mark.parametrize('in_type,out_type', [('retells', 'retelling'), ('mentions', 'mention')])
-def test_number_other_zero_when_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                        notes_file, database, super_nav_details, relationship, in_type, out_type):
-    create_file(notes_file, [])
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    super_nav_details.insert({'uid': 'no_number_from'})
-    super_nav_details.insert({'uid': 'no_number_to'})
-    create_file(parallels_file, [
-        {'parallels': ['abc123', 'xyz321']},
-        {in_type: ['no_number_from', 'no_number_to']},
-    ])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    numbers = [doc['number'] for doc in docs]
-    assert sorted(numbers) == [0, 0, 123, 321]
-
-
-def test_create_orphan_when_from_missing(file_changed, relationship_dir, additional_info_dir,
-                                         parallels_file,
+def test_create_orphan_when_from_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
                                          notes_file, database, super_nav_details, relationship):
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(notes_file, [])
@@ -222,9 +237,8 @@ def test_create_orphan_when_from_missing(file_changed, relationship_dir, additio
     assert to == ['super_nav_details/orphan']
 
 
-def test_create_orphan_when_to_missing(file_changed, relationship_dir, additional_info_dir,
-                                       parallels_file,
-                                       notes_file, database, super_nav_details, relationship):
+def test_create_orphan_when_to_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                       notes_file, database, super_nav_details, relationship, caplog):
     super_nav_details.insert({'uid': 'abc123'})
     create_file(notes_file, [])
     create_file(parallels_file, [{'parallels': ['abc123', 'no_such']}])
@@ -232,10 +246,11 @@ def test_create_orphan_when_to_missing(file_changed, relationship_dir, additiona
     docs = tidy_relationship_docs(relationship)
     to = [doc['_to'] for doc in docs]
     assert to == ['super_nav_details/orphan']
+    assert caplog.messages == ['Relationship encoding has no matching uids: no_such (dropped)']
 
 
-def test_logs_orphan(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                     notes_file, database, super_nav_details, relationship, caplog):
+def test_logs_appears_as_orphan_when_from_missing(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                                  notes_file, database, super_nav_details, relationship, caplog):
     caplog.set_level(logging.INFO)
     super_nav_details.insert({'uid': 'abc123'})
     super_nav_details.insert({'uid': 'xyz321'})
@@ -248,84 +263,55 @@ def test_logs_orphan(file_changed, relationship_dir, additional_info_dir, parall
     ]
 
 
-def test_create_resembling_from(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                notes_file, database, super_nav_details, relationship):
+@pytest.mark.parametrize('entry_type', ['retells', 'mentions'])
+def test_no_orphans_for_others(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                               notes_file, database, super_nav_details, relationship, entry_type, caplog):
     super_nav_details.insert({'uid': 'abc123'})
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(notes_file, [])
-    create_file(parallels_file, [{'parallels': ['~abc123', 'xyz321']}])
+    create_file(parallels_file, [{entry_type: ['abc123', 'no_such']}, ])
     load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    assert docs == [
-        {
-            '_from': 'super_nav_details/xyz321',
-            '_to': 'super_nav_details/abc123',
-            'from': 'xyz321',
-            'number': 321,
-            'remark': None,
-            'resembling': True,
-            'to': 'abc123',
-            'type': 'full'
-        }
-    ]
+    assert len(relationship) == 0
+    assert caplog.messages == ['Relationship encoding has no matching uids: no_such (dropped)']
 
 
-def test_create_resembling_to(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                              notes_file, database, super_nav_details, relationship):
+@pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
+def test_neither_encoding_is_resembling(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                        notes_file, database, super_nav_details, relationship, entry_type):
     super_nav_details.insert({'uid': 'abc123'})
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(notes_file, [])
-    create_file(parallels_file, [{'parallels': ['abc123', '~xyz321']}])
+    create_file(parallels_file, [{entry_type: ['abc123', 'xyz321']}])
     load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
-    assert docs == [
-        {
-            '_from': 'super_nav_details/abc123',
-            '_to': 'super_nav_details/xyz321',
-            'from': 'abc123',
-            'number': 123,
-            'remark': None,
-            'resembling': True,
-            'to': 'xyz321',
-            'type': 'full'
-        }
-    ]
+    resembling = [doc['resembling'] for doc in docs]
+    assert not any(resembling)
 
 
-@pytest.mark.parametrize('in_type,out_type', [('retells', 'retelling'), ('mentions', 'mention')])
-def test_create_resembling_other_from(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                      notes_file, database, super_nav_details, relationship, in_type, out_type):
+@pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
+def test_from_encoding_is_resembling(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                     notes_file, database, super_nav_details, relationship, entry_type):
     super_nav_details.insert({'uid': 'abc123'})
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(notes_file, [])
-    create_file(parallels_file, [
-        {'parallels': ['abc123', 'xyz321']},
-        {in_type: ['~abc123', 'xyz321']},
-    ])
+    create_file(parallels_file, [{entry_type: ['~abc123', 'xyz321']}])
     load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
-    resembling = [doc for doc in docs if doc['resembling']]
-    assert resembling == [
-        {
-            '_from': 'super_nav_details/abc123',
-            '_to': 'super_nav_details/xyz321',
-            'from': 'abc123',
-            'number': 123,
-            'remark': None,
-            'resembling': True,
-            'to': 'xyz321',
-            'type': out_type
-        },
-        {'_from': 'super_nav_details/xyz321',
-         '_to': 'super_nav_details/abc123',
-         'from': 'xyz321',
-         'number': 321,
-         'remark': None,
-         'resembling': True,
-         'to': 'abc123',
-         'type': out_type
-         }
-    ]
+    resembling = [doc['resembling'] for doc in docs]
+    assert all(resembling)
+
+
+@pytest.mark.parametrize('entry_type', ['parallels', 'retells', 'mentions'])
+def test_to_encoding_is_resembling(file_changed, relationship_dir, additional_info_dir, parallels_file,
+                                   notes_file, database, super_nav_details, relationship, entry_type):
+    super_nav_details.insert({'uid': 'abc123'})
+    super_nav_details.insert({'uid': 'xyz321'})
+    create_file(notes_file, [])
+    create_file(parallels_file, [{entry_type: ['abc123', '~xyz321']}])
+    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
+    docs = tidy_relationship_docs(relationship)
+    resembling = [doc['resembling'] for doc in docs]
+    assert all(resembling)
 
 
 def test_key_error_when_unknown_type(file_changed, relationship_dir, additional_info_dir, parallels_file,
@@ -333,52 +319,9 @@ def test_key_error_when_unknown_type(file_changed, relationship_dir, additional_
     super_nav_details.insert({'uid': 'abc123'})
     super_nav_details.insert({'uid': 'xyz321'})
     create_file(notes_file, [])
-    create_file(parallels_file, [
-        {'extrudes': ['abc123', 'xyz321']},
-    ])
-
-    create_file(notes_file, [])
+    create_file(parallels_file, [{'extrudes': ['abc123', 'xyz321']}, ])
     with pytest.raises(KeyError, match='extrudes'):
         load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-
-
-def test_first_retell_uid_is_resembling(file_changed, relationship_dir, additional_info_dir,
-                                        parallels_file, notes_file, database, super_nav_details, relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    super_nav_details.insert({'uid': 'pqrs'})
-    super_nav_details.insert({'uid': 'lmno'})
-
-    create_file(notes_file, [])
-    create_file(parallels_file, [
-        {'parallels': ['abc123', 'xyz321']},
-        {'retells': ['~pqrs', 'lmno']},
-    ])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    resembling = sorted([(doc['to'], doc['from']) for doc in docs if doc['resembling']])
-
-    assert resembling == [('lmno', 'pqrs'), ('pqrs', 'lmno')]
-
-
-def test_second_retell_uid_is_resembling(file_changed, relationship_dir, additional_info_dir,
-                                         parallels_file, notes_file, database, super_nav_details,
-                                         relationship):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    super_nav_details.insert({'uid': 'pqrs'})
-    super_nav_details.insert({'uid': 'lmno'})
-
-    create_file(notes_file, [])
-    create_file(parallels_file, [
-        {'parallels': ['abc123', 'xyz321']},
-        {'retells': ['pqrs', '~lmno']},
-    ])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    docs = tidy_relationship_docs(relationship)
-    resembling = sorted([(doc['to'], doc['from']) for doc in docs if doc['resembling']])
-
-    assert resembling == [('lmno', 'pqrs'), ('pqrs', 'lmno')]
 
 
 def test_three_parallels(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file, database,
@@ -401,8 +344,8 @@ def test_three_parallels(file_changed, relationship_dir, additional_info_dir, pa
     ]
 
 
-def test_two_full_one_resembling(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
-                                 database, super_nav_details, relationship):
+def test_two_full_one_resembling_last(file_changed, relationship_dir, additional_info_dir, parallels_file, notes_file,
+                                      database, super_nav_details, relationship):
     super_nav_details.insert({'uid': 'abc123'})
     super_nav_details.insert({'uid': 'xyz321'})
     super_nav_details.insert({'uid': 'hij678'})
@@ -445,40 +388,8 @@ def test_partials(file_changed, relationship_dir, additional_info_dir, parallels
     create_file(parallels_file, [{'parallels': ['ja539#127', 'thag1.97']}])
     load_relationships(file_changed, relationship_dir, additional_info_dir, database)
     docs = tidy_relationship_docs(relationship)
-    assert docs == [
-        {'_from': 'super_nav_details/ja539',
-         '_to': 'super_nav_details/thag1.97',
-         'from': 'ja539#127',
-         'number': 127,
-         'remark': None,
-         'resembling': False,
-         'to': 'thag1.97',
-         'type': 'full'
-         },
-        {
-            '_from': 'super_nav_details/thag1.97',
-            '_to': 'super_nav_details/ja539',
-            'from': 'thag1.97',
-            'number': 97,
-            'remark': None,
-            'resembling': False,
-            'to': 'ja539#127',
-            'type': 'full'
-        }
-    ]
-
-
-def test_branch_where_true_from_uids_has_no_match(file_changed, relationship_dir, additional_info_dir, parallels_file,
-                                                  notes_file, database, super_nav_details, relationship, caplog):
-    super_nav_details.insert({'uid': 'abc123'})
-    super_nav_details.insert({'uid': 'xyz321'})
-    create_file(notes_file, [])
-    create_file(parallels_file, [
-        {'parallels': ['abc123', 'xyz321']},
-        {'retells': ['abc123', 'no_such']},
-    ])
-    load_relationships(file_changed, relationship_dir, additional_info_dir, database)
-    assert caplog.messages == ['Relationship encoding has no matching uids: no_such (dropped)']
+    to_from = sorted([(doc['to'], doc['from']) for doc in docs])
+    assert to_from == [('ja539#127', 'thag1.97'), ('thag1.97', 'ja539#127')]
 
 
 @pytest.mark.parametrize(

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -488,7 +488,7 @@ class TestParallelsEdges:
     def test_stores_dropped_encodings(self, with_uids, entry):
         unmatched = Unmatched()
         _ = list(ParallelsEdges(entry, unmatched))
-        assert unmatched.dropped == [Encoding('no_such_uid')]
+        assert unmatched.dropped == {Encoding('no_such_uid')}
 
     @pytest.mark.parametrize('entry', [
         (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid'])),
@@ -497,7 +497,7 @@ class TestParallelsEdges:
     def test_stores_orphan_encodings(self, with_uids, entry):
         unmatched = Unmatched()
         _ = list(ParallelsEdges(entry, unmatched))
-        assert unmatched.orphans == [Encoding('no_such_uid')]
+        assert unmatched.orphans == {Encoding('no_such_uid')}
 
     @pytest.mark.parametrize('encodings,from_to', [
         (
@@ -695,7 +695,7 @@ class TestOtherEdges:
     def test_stores_dropped_encodings(self, with_uids, entry):
         unmatched = Unmatched()
         _ = list(OtherEdges(entry, unmatched))
-        assert unmatched.dropped == [Encoding('no_such_uid')]
+        assert unmatched.dropped == {Encoding('no_such_uid')}
 
 
 class TestEntry:

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -11,7 +11,7 @@ from common.arangodb import get_db
 from common.utils import current_app
 from data_loader.ports import FileChangeTracker
 from data_loader.relationships import load_relationships, Encoding, Edge, Entry, \
-    EntryType, EdgeType, to_edge_type, OtherEdges, Remarks, EdgeUids, EdgeEncodings, Unmatched, ParallelsEdges
+    EntryType, EdgeType, OtherEdges, Remarks, EdgeUids, EdgeEncodings, Unmatched, ParallelsEdges
 from fakes import FakeFileChangeTracker
 
 
@@ -149,14 +149,14 @@ class TestEncoding:
         assert Encoding(encoding).has_matching_uid() is has_matching_uid
 
 
-class TestToEdgeType:
+class TestEntryType:
     @pytest.mark.parametrize('entry,relationship', [
         (EntryType.PARALLELS, EdgeType.FULL),
         (EntryType.MENTIONS, EdgeType.MENTION),
         (EntryType.RETELLS, EdgeType.RETELLING),
     ])
     def test_converts_types(self, entry, relationship):
-        assert to_edge_type(entry) == relationship
+        assert entry.to_edge_type() == relationship
 
 
 class TestEntry:

--- a/server/tests/data_loader/test_relationships.py
+++ b/server/tests/data_loader/test_relationships.py
@@ -10,8 +10,8 @@ from arango.database import StandardDatabase
 from common.arangodb import get_db
 from common.utils import current_app
 from data_loader.ports import FileChangeTracker
-from data_loader.relationships import load_relationships, Encoding, Edge, ParallelsEdges, Entry, \
-    EntryType, EdgeType, to_edge_type, OtherEdges, Remarks, EdgeUids, EdgeEncodings, Unmatched
+from data_loader.relationships import load_relationships, Encoding, Edge, Entry, \
+    EntryType, EdgeType, to_edge_type, OtherEdges, Remarks, EdgeUids, EdgeEncodings, Unmatched, ParallelsEdges
 from fakes import FakeFileChangeTracker
 
 
@@ -416,7 +416,7 @@ class TestParallelsEdges:
     ])
     def test_encoding_combinations_give_from_uids(self, with_uids, entry, from_uids):
         edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
-        assert [edge['_from'] for edge in edges] == from_uids
+        assert sorted([edge['_from'] for edge in edges]) == sorted(from_uids)
 
     @pytest.mark.parametrize('entry,to_uids', [
         (Entry(EntryType.PARALLELS, ['abc123', 'xyz321', 'pqr777']),
@@ -427,7 +427,7 @@ class TestParallelsEdges:
     ])
     def test_encoding_combinations_give_to_uids(self, with_uids, entry, to_uids):
         edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
-        assert [edge['_to'] for edge in edges] == to_uids
+        assert sorted([edge['_to'] for edge in edges]) == sorted(to_uids)
 
     @pytest.mark.parametrize('entry,to_encoding,from_encoding', [
         (Entry(EntryType.PARALLELS, ['abc123', 'xyz321#654']), 'xyz321#654', 'abc123'),
@@ -498,6 +498,49 @@ class TestParallelsEdges:
         unmatched = Unmatched()
         _ = list(ParallelsEdges(entry, unmatched))
         assert unmatched.orphans == [Encoding('no_such_uid')]
+
+    @pytest.mark.parametrize('encodings,from_to', [
+        (
+                ['abc123', 'xyz321'],
+                [
+                    ('abc123', 'xyz321'), ('xyz321', 'abc123')
+                ]
+        ),
+        (
+                ['abc123', 'xyz321', 'pqr777'],
+                [
+                    ('abc123', 'xyz321'), ('abc123', 'pqr777'), ('xyz321', 'abc123'),
+                    ('xyz321', 'pqr777'), ('pqr777', 'abc123'), ('pqr777', 'xyz321'),
+                ]),
+    ])
+    def test_full_to_full_encodings(self, with_uids, encodings, from_to):
+        entry = Entry(EntryType.PARALLELS, encodings)
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
+        assert sorted([(edge['from'], edge['to']) for edge in edges]) == sorted(from_to)
+
+    @pytest.mark.parametrize('encodings,from_to', [
+        (['abc123', '~xyz321'], [('abc123', 'xyz321')]),
+        (
+                ['abc123', 'xyz321', '~pqr777'],
+                [('abc123', 'xyz321'), ('abc123', 'pqr777'), ('xyz321', 'abc123'), ('xyz321', 'pqr777')],
+        ),
+        (
+                ['abc123', '~xyz321', '~pqr777'],
+                [('abc123', 'xyz321'), ('abc123', 'pqr777')],
+        ),
+    ])
+    def test_full_to_resembling_encodings(self, with_uids, encodings, from_to):
+        entry = Entry(EntryType.PARALLELS, encodings)
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
+        assert sorted([(edge['from'], edge['to']) for edge in edges]) == sorted(from_to)
+
+    @pytest.mark.parametrize('entry, from_to', [
+        (Entry(EntryType.PARALLELS, ['abc123', 'no_such_uid']), [('abc123', 'no_such_uid')]),
+        (Entry(EntryType.PARALLELS, ['no_such_uid', 'abc123']), [('abc123', 'no_such_uid')]),
+    ])
+    def test_drops_unmatched_from_encodings(self, with_uids, entry, from_to):
+        edges = [edge.as_dict() for edge in ParallelsEdges(entry, Unmatched())]
+        assert sorted([(edge['from'], edge['to']) for edge in edges]) == sorted(from_to)
 
 
 class TestOtherEdges:


### PR DESCRIPTION
After @ayya-vimala dropped some code into issue #3655, I decided to have a go at refactoring the algorithm that creates the edges in the `relationship` collection. Along the way I found a few bugs, and given how radically the code has changed, there's a chance that I've introduced one or two.

That said, I wrote extensive tests before starting the refactoring, wrote several more along the way, and tidied them up at the end of the refactoring.

It was a lot of fun, and somewhat exhausting.