### PR TITLE
fix(client): `pm-2` is also Patimokkha

### DIFF
--- a/client/elements/navigation/sc-navigation.js
+++ b/client/elements/navigation/sc-navigation.js
@@ -301,7 +301,7 @@ export class SCNavigation extends LitLocalized(LitElement) {
   }
 
   _isPatimokkha(uid) {
-    return uid.endsWith('-pm');
+    return uid.endsWith('-pm') || uid.endsWith('-pm-2');
   }
 
   _computeMenuApiUrl(uid) {

--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -121,11 +121,11 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
   }
 
   isPatimokkha() {
-    return this.categoryId?.endsWith('-pm');
+    return this.categoryId?.endsWith('-pm') || this.categoryId?.endsWith('-pm-2');
   }
 
   isPatimokkhaRuleCategory(uid) {
-    return uid?.includes('-pm-');
+    return uid?.includes('-pm-') && !uid?.endsWith('-pm-2');
   }
 
   shouldExpandAll() {
@@ -554,11 +554,11 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
   _correctAndRedirectRootURL() {
     ['sutta', 'vinaya', 'abhidhamma'].forEach(this._redirectToPitaka.bind(this));
   }
-  
+
   _redirectToPitaka(section) {
     const currentUrl = window.location.href;
     const domain = window.location.origin;
-  
+
     if (currentUrl.includes(`${domain}/${section}`) && !currentUrl.includes(`${domain}/pitaka/${section}`)) {
       const link = currentUrl.replace(`${domain}/${section}`, `${domain}/pitaka/${section}`);
       dispatchCustomEvent(this, 'sc-navigate', { pathname: link });


### PR DESCRIPTION
## Summary

Check for `-pm-2` endings as well in `isPatimokkha` functions
- Fixes https://github.com/suttacentral/sc-data/issues/433
  - See my root cause analysis in https://github.com/suttacentral/sc-data/issues/433#issuecomment-4972719377 et al

## Details

- these functions only checked if the ID ended in `-pm`, but sometimes there are 2, such as with [`lzh-sarv-bu-pm-2.html`](https://github.com/suttacentral/sc-data/blob/254154c7ed0a10ab24307be36dd8a0d3934604fb/html_text/lzh/vinaya/lzh-sarv-bu-pm-2.html)
  - modify them to also check for ending in `-pm-2`

- In https://github.com/suttacentral/sc-data/issues/433, the result of this check was that a suttaplex card was not displaying for `pm-2` despite the data being near identical between `pm` and `pm-2`

## References

- The logic originates from #2013 / #2271

## Verification

This now matches what PM1 looks like, screenshots:
<table>
    <tr>
      <th>Before</th>
      <th>After</th>
   </tr>
   <tr>
      <td><img width="1343" height="669" alt="Screenshot 2026-07-19 at 9 38 01 PM" src="https://github.com/user-attachments/assets/4e238a27-9593-494e-87c7-b65b7b9ed029" /></td>
      <td><img width="1324" height="669" alt="Screenshot 2026-07-19 at 9 03 56 PM" src="https://github.com/user-attachments/assets/5eb46616-d6a7-4810-ac01-9c11b756ab67" /></td>
    </tr>
</table>



