### PR TITLE
refactor(client): use more variables around `search:resultsFor`

### DIFF
--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -1244,13 +1244,11 @@ export class SCPageSearch extends LitLocalized(LitElement) {
   #createMetaData() {
     const description = this.localize('search:metaDescriptionText');
     const searchResultsText = this.localize('search:searchResultsText');
-    const pageTitle = `${this.#calculateResultCount(this.resultCount)} ${this.localize(
-      'search:resultsFor'
-    )} ${this.searchQuery}`;
+    const resultsFor = this.localize('search:resultsFor');
 
-    const toolbarTitle = `${this.#calculateResultCount(this.resultCount)} ${this.localize(
-      'search:resultsFor'
-    )} <strong class="highlightTitle">${this.searchQuery}</strong>`;
+    const countResultsFor = `${this.#calculateResultCount(this.resultCount)} ${resultsFor}`;
+    const pageTitle = `${countResultsFor} ${this.searchQuery}`;
+    const toolbarTitle = `${countResultsFor} <strong class="highlightTitle">${this.searchQuery}</strong>`;
 
     document.dispatchEvent(
       new CustomEvent('metadata', {


### PR DESCRIPTION
## Summary

~The localization key `search:resultsFor` itself was showing up in the search UI momentarily instead of the localized text.~
Refactors some code around `search:resultsFor` to make it easier and less ambiguous to read.

This was a change I made while [attempting to root cause it](https://discourse.suttacentral.net/t/suttacentral-search-bugs/32425/156?u=agilgur5) a bug reported [on the forum](https://discourse.suttacentral.net/t/suttacentral-search-bugs/32425/151?u=agilgur5) by Ven. @delightedbydhamma. This change failed to fix it, but did help root cause I suppose, see the comments below

## Details

- refactor the code a bit around `${this.localize('search:resultsFor')}` to use more variables and avoid awkward/ambiguous formatting of whitespace

## Verification

- Tested locally, search runs the same as before