### PR TITLE
fix: add missing `create-network` command and `localhost` port instruction to initial set-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ run-preview-env-no-search:
 
 run-production-env:
 	@make generate-env-variables
+	@make create-network
 	@make run-prod-no-logs
 	@bash wait_for_flask.sh
 	@make load-data

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Then run the commands for updating, probably including the `make delete-database
 2. Cd into the repo `cd suttacentral`.
 3. run `make prepare-host` in order to make some small adjustment on the host machine.
 4. run `make run-preview-env` - Build images, load data, index-arangosearch and more. This will run the project for the first time.
+5. Open <http://localhost>
 
 ### 1.1 Running the project
 

--- a/env_variables_setup.py
+++ b/env_variables_setup.py
@@ -13,14 +13,14 @@ RANDOM_WORDS_NUMBER = 3
 
 def intro():
     print('''
-Welcome in SuttaCentral environment setup script!
+Welcome to the SuttaCentral environment setup script!
 You are going to be prompted for a bunch of information.
-If you want to set the value to the random one enter 'R'.
-You will be prompted back with the generated value. eg.
+If you want to set the value to a random one enter 'R'.
+You will be prompted back with the generated value, e.g.
 < R
 > Xu@+$;*ed3||,zfuP7kw%e0!c<`e^PLC
-By default
-If you want to leave current value just leave the answer blank.
+
+If you want to leave the current value as-is, just leave the answer blank.
 
     ''')
 


### PR DESCRIPTION
## Summary

Fix some missing instructions and a missing command when running on a fresh env

## Details

- `@make create-network` was missing from `run-production-env` despite being present in all other targets
  - when I tested it during initial set-up, it was indeed required, as the [shared `docker-compose.yml` includes it](https://github.com/suttacentral/suttacentral/blob/ac30f9c7dc07da9bafd2bf67027c5cbd33c5ee81/docker-compose.yml#L85)

- which URL or port to open during development was missing, so add plain <http://localhost> to the docs as NGINX is [available on port 80](https://github.com/suttacentral/suttacentral/blob/ac30f9c7dc07da9bafd2bf67027c5cbd33c5ee81/docker-compose.yml#L46)

- also fix various grammar issues in `env_variables_setup.py`

## Verification

Ran this all myself locally