### PR TITLE
fix(map): "journey" lists should not be alphabetically sorted

### DIFF
--- a/client/elements/static/sc-static-map.js
+++ b/client/elements/static/sc-static-map.js
@@ -123,14 +123,14 @@ export class SCStaticMap extends SCStaticPage {
 
   _featuresList() {
     return this.layerNames.map(layerName => {
-      const listItems = this._sortObjectsByStringKey(
-        this.features.filter(feature => feature.properties.layer === layerName),
-        feature => feature.properties.name
-      ).map(this._featureItem);
+      const filtered = this.features.filter(feature => feature.properties.layer === layerName);
+      const sorted = layerName.includes("journey") // the journeys are already in order
+        ? filtered
+        : this._sortObjectsByStringKey(filtered, feature => feature.properties.name);
       return html`<div class="features-section">
         <h3>${this._getLocalizedTextByLayerName(layerName)}</h3>
         <ul>
-          ${listItems}
+          ${sorted.map(this._featureItem)}
         </ul>
       </div>`;
     });


### PR DESCRIPTION
## Summary

Remove incorrect sorting of the map data's journey lists
- Fixes #3679 


## Details

- the points of the journey are already sorted numerically, no need to re-sort them
  - the prior sort actually put them out-of-order, which was quite confusing in the UI

- refactor the code here a bit for readability

## Verification

Tested locally that journey items are now correctly sorted and that other lists were not affected.
Screenshots:
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="1252" height="522" alt="Screenshot 2026-07-20 at 11 00 48 AM" src="https://github.com/user-attachments/assets/6c7bf526-c4ca-4dbd-9b4b-fa3304d93a05" /></td>
    <td><img width="1250" height="540" alt="Screenshot 2026-07-20 at 10 59 58 AM" src="https://github.com/user-attachments/assets/6e27000e-a01c-4b49-83ea-2476d21f39a4" /></td>
  </tr>
</table>