### PR TITLE
refactor(client): use `compose watch` to sync front-end files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,7 +32,6 @@ services:
           path: ./server/uv.lock
 
 
-
   sc-nginx:
     volumes:
       - ./client/:/opt/sc/static
@@ -50,15 +49,15 @@ services:
 
   sc-frontend:
     command: npm run dev
-    volumes:
-      - ./client/elements:/opt/sc/frontend/elements
-      - ./client/utils:/opt/sc/frontend/utils
-      - ./client/img:/opt/sc/frontend/img
-      - ./client/localization:/opt/sc/frontend/localization
-      - ./client/index.html:/opt/sc/frontend/index.html
-      - ./client/redux-store.js:/opt/sc/frontend/redux-store.js
-      - ./client/webpack.config.js:/opt/sc/frontend/webpack.config.js
-      - ./client/localization/elements:/opt/sc/frontend/localization/elements
     ports:
       - '3000:3000'
-
+    develop:
+      watch:
+        # Sync frontend files with the container
+        - action: sync
+          initial_sync: true
+          path: ./client/
+          target: /opt/sc/frontend/
+        # Rebuild the image if dependencies or scripts change by checking package.json
+        - action: rebuild
+          path: ./client/package.json


### PR DESCRIPTION
## Summary

During development, move from mounted volumes to `compose watch` to efficiently sync front-end files

## Details

- sync pretty much all files (except ones in `.dockerignore` like [`node_modules/`](https://github.com/suttacentral/suttacentral/blob/ac30f9c7dc07da9bafd2bf67027c5cbd33c5ee81/client/.dockerignore#L4)) and only rebuild on `package.json` changes
  - similar to [the example](https://docs.docker.com/compose/how-tos/file-watch/#example-1) in the docs

- I also was having trouble getting FS events propagated to the container when I changed a file during dev when using `volumes` (i.e. could not trigger live reload)
  - using `action: sync` instead entirely avoids that problem
  
## References

This matches prior changes to the back-end in https://github.com/suttacentral/suttacentral/commit/eaa794dbab6ed73219e391133b9ba650a2272433 et al / #3575

## Verification

I've been using this configuration for a bit, including for several of my recent front-end PRs like #3683 and #3675
  