### PR TITLE
fix(pub): word-wrap long URLs in Bibliography page

### DIFF
--- a/client/elements/styles/sc-publication-styles.js
+++ b/client/elements/styles/sc-publication-styles.js
@@ -6,6 +6,10 @@ export const SCPublicationStyles = css`
     margin: 2em auto 4em;
   }
 
+  .bibliography-list {
+    overflow-wrap: anywhere; /* word-wrap long URLs */
+  }
+
   hgroup {
     text-align: center;
   }


### PR DESCRIPTION
## Summary

Add word wrapping to make sure the [Vinaya Editions Bibliography page](https://suttacentral.net/edition/pli-tv-vi/en/brahmali/bibliography) is readable on smaller width devices

## Details

- per [forum bug report](https://discourse.suttacentral.net/t/suttacentral-bug-reports/27763/303?u=agilgur5), the Bibliography page was unreadable on devices with smaller width screens
  - after a [moderately involved root cause analysis](https://discourse.suttacentral.net/t/suttacentral-bug-reports/27763/339?u=agilgur5), it turns out this is because long URLs were not being word wrapped on the page, overflowing beyond the `max-width` CSS
    - add `overflow-wrap: anywhere` to fix this
    
## Verification

Tested locally, screenshots:
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="863" height="530" alt="Screenshot 2026-07-21 at 11 18 30 AM" src="https://github.com/user-attachments/assets/d31d8ccf-3ac8-4daf-9dc7-4815a553481e" />
    </td>
    <td>
<img width="864" height="526" alt="Screenshot 2026-07-21 at 11 18 40 AM" src="https://github.com/user-attachments/assets/c0813db7-52a6-4f77-94ce-4b7f774bd377" />
    </td>
  </tr>
</table>
