### PR TITLE
fix(styles): remove `margin` for empty verses in Bilara translations

### DIFF
--- a/client/elements/styles/sc-layout-bilara-styles.js
+++ b/client/elements/styles/sc-layout-bilara-styles.js
@@ -88,6 +88,10 @@ export const plainStyles = html`
       hyphens: none;
       margin-left: 2em;
     }
+    /* remove the margin when the text is empty (e.g. omitted repetition), so that there isn't a block of empty space when only viewing the translation */
+    .verse-line .translation:has(> .text:empty) {
+      margin-left: 0;
+    }
 
     j {
       display: block;


### PR DESCRIPTION
## Summary

Remove chunks of empty vertical space due to `margin` of omitted verse translation

## Details

- per [forum bug report](https://discourse.suttacentral.net/t/empty-spans-are-taking-up-space-when-there-is-pali-and-no-english/42691?u=agilgur5), empty spans were taking up a massive chunk of vertical space in ~[DN32:12.1](https://suttacentral.net/dn32/en/sujato#12.1)
  - after a [moderately involved root cause analysis](https://discourse.suttacentral.net/t/empty-spans-are-taking-up-space-when-there-is-pali-and-no-english/42691/11?u=agilgur5), it turns out that, in this case, there was a whole block of repeated verse omitted in the translation
    - and verse happens to have a `margin`, causing the omitted spans to be non-empty and taking up space
      - so write some specific CSS to remove the `margin` in cases of empty verse translations

## Verification

Tested locally, screenshots:
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="865" height="516" alt="Screenshot 2026-07-21 at 1 08 38 PM" src="https://github.com/user-attachments/assets/090167f8-b074-4d72-ba63-1947a9e2080a" />
    </td>
    <td>
<img width="861" height="517" alt="Screenshot 2026-07-21 at 1 01 27 PM" src="https://github.com/user-attachments/assets/f4d78b74-a3fc-43ac-81e8-b2f64098a4e7" />
    </td>
  </tr>
</table>

Also made sure that views with Pali still displayed correctly, screenshots:
<table>
  <tr>
    <th>Line-by-line</th>
    <th>Side-by-side</th>
  </tr>
  <tr>
    <td>
<img width="858" height="520" alt="Screenshot 2026-07-21 at 1 02 29 PM" src="https://github.com/user-attachments/assets/cf2cbd2d-68e9-4cbb-9ed7-613d82c5faa1" />
    </td>
    <td>
<img width="858" height="514" alt="Screenshot 2026-07-21 at 1 02 59 PM" src="https://github.com/user-attachments/assets/6e80ec1d-42c3-4f88-a167-7aa6244989c2" />
    </td>
  </tr>
</table>