### PR TITLE
fix(pali): use `overflow-wrap: anywhere` instead of `break-word`

### DIFF
--- a/client/elements/styles/sc-typography-i18n-styles.js
+++ b/client/elements/styles/sc-typography-i18n-styles.js
@@ -136,13 +136,10 @@ export const typographyI18nStyles = css`
     font-family: var(--sc-traditional-chinese-font);
   }
 
-  /* don't let Pali/sanskrit words go too long, probably won't work but oh well */
-
+  /* don't let Pali/sanskrit words go too long */
   [lang='pli'],
   [lang='san'] {
-    word-wrap: break-word;
-
-    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
   }
 
   [lang='ko'] * {


### PR DESCRIPTION
## Summary

For `lang=['pli']`, switch to [`overflow-wrap: anywhere`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overflow-wrap)

## Details

- in some instances, it seemed that `break-word` was insufficient
  - for instance, per [forum bug report](https://discourse.suttacentral.net/t/suttacentral-bug-reports/27763/64?u=agilgur5), [DN29 with Pali + sidenotes](https://suttacentral.net/dn29/en/sujato?layout=linebyline&notes=sidenotes) on a small screen did not word wrap
    - DN29 has some long Pali compound words like "asammā­s­ambud­dha­­p­pa­ve­d­ite­", "dhammā­nu­dhamma­p­paṭipanno", and similar
  - **EDIT**: this [other forum thread](https://discourse.suttacentral.net/t/some-suttas-dont-fit-on-smaller-width-devices/41234?u=agilgur5) has several similar reports [collated](https://discourse.suttacentral.net/t/some-suttas-dont-fit-on-smaller-width-devices/41234/9?u=agilgur5), as well as several words
    - MN21, MN22, MN23, DN16, AN3.70 all have this due to words like "cīvarapiṇḍapātasenāsanagilānappaccayabhesajjaparikkhārahetu", "aniccucchādanaparimaddanabhedanaviddhaṁsanadhammassa", "naccagītavāditavisūkadassanamālāgandhavilepanadhāraṇamaṇḍanavibhūsanaṭṭhānā", etc

## References

Similar fix as #3686 
Related to #3004 and others

## Verification

Tested locally, screenshots:
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="268" height="538" alt="Screenshot 2026-07-21 at 5 30 40 PM" src="https://github.com/user-attachments/assets/162f6cbf-8980-4325-8bad-266022effb8a" />
    </td>
    <td>
<img width="265" height="540" alt="Screenshot 2026-07-21 at 5 31 08 PM" src="https://github.com/user-attachments/assets/4177f0b6-3cee-489e-9ffc-5f7ff4d9d800" />
    </td>
  </tr>
</table>

## Notes to Reviewers

I'm still not entirely sure _why_ `overflow-wrap: break-word` wasn't working. After [a review](https://discourse.suttacentral.net/t/some-suttas-dont-fit-on-smaller-width-devices-due-to-long-pali-words/41234/26?u=agilgur5) of past issues, my suspicion is a browser issue/bug