### PR TITLE
refactor(test): standardize using `@open-wc/testing` package

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -35,7 +35,6 @@
         "@babel/eslint-plugin": "7.23.5",
         "@babel/plugin-transform-runtime": "7.22.5",
         "@babel/preset-env": "7.23.6",
-        "@esm-bundle/chai": "4.3.4",
         "@open-wc/testing": "4.0.0",
         "@rollup/plugin-babel": "^6.0.3",
         "@web/dev-server-legacy": "2.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -55,7 +55,6 @@
     "@babel/eslint-plugin": "7.23.5",
     "@babel/plugin-transform-runtime": "7.22.5",
     "@babel/preset-env": "7.23.6",
-    "@esm-bundle/chai": "4.3.4",
     "@open-wc/testing": "4.0.0",
     "@rollup/plugin-babel": "^6.0.3",
     "@web/dev-server-legacy": "2.1.0",

--- a/client/test/controllers/sc-search-controller.test.js
+++ b/client/test/controllers/sc-search-controller.test.js
@@ -1,6 +1,6 @@
-import {RequestChecker, RequestData, SCSearchController} from "../../elements/sc-search-controller";
+import { assert } from '@open-wc/testing';
 
-import {assert} from '@esm-bundle/chai';
+import { RequestChecker, RequestData, SCSearchController } from '../../elements/sc-search-controller';
 
 function makeResponses() {
   let responses = [];

--- a/client/test/learn-lit-lifecycle.test.js
+++ b/client/test/learn-lit-lifecycle.test.js
@@ -1,8 +1,7 @@
 // These tests are for learning only and do not test any SuttaCentral code.
 
-import {html, LitElement} from "lit";
-import {elementUpdated, fixture} from '@open-wc/testing';
-import {assert} from '@esm-bundle/chai';
+import { LitElement } from 'lit';
+import { assert, elementUpdated, fixture, html } from '@open-wc/testing';
 
 class LifecycleElement extends LitElement {
   static properties = {

--- a/client/test/sc-page-search.test.js
+++ b/client/test/sc-page-search.test.js
@@ -1,10 +1,8 @@
-import { SCPageSearch } from '../elements/sc-page-search.js';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 
-import {html, LitElement} from "lit";
-import {elementUpdated, fixture} from '@open-wc/testing';
-import { expect } from '@esm-bundle/chai';
-import {store} from "../redux-store";
-import {SCSearchController} from "../elements/sc-search-controller";
+import { store } from '../redux-store';
+import { SCPageSearch } from '../elements/sc-page-search.js';
+import { SCSearchController } from '../elements/sc-search-controller';
 
 const GENERAL_SEARCH_RESPONSE = {
   "hits": [

--- a/client/test/text/sc-text-bilara.test.js
+++ b/client/test/text/sc-text-bilara.test.js
@@ -1,6 +1,7 @@
+import { expect } from '@open-wc/testing';
+import sinon from 'sinon';
+
 import { SCTextBilara } from '../../elements/text/sc-text-bilara.js';
-import { expect } from '@esm-bundle/chai';
-import sinon from '../../node_modules/sinon/pkg/sinon-esm.js';
 
 describe('SCTextBilara', () => {
   let instance;


### PR DESCRIPTION
## Summary

Switch direct usage of `@esm-bundle/chai` et al to use of wrapper `@open-wc/testing`

## Details

- should use that wrapper instead of `@esm-bundle/chai` directly or `lit` directly
  - c.f. [its docs](https://github.com/open-wc/open-wc/blob/8a89d51ac5db27f09e3a006d2771af8ba7e492c3/docs/docs/testing/testing-package.md#testing-helpers)
  - (otherwise could use directly and no need for wrapper, but choose one and stick with it)


- while at it:
  - remove unused `LitElement` import
  - shorten `sinon` import
  - fix some formatting of imports:
    - external imports before internal ones
    - single quotes as per [`prettier` config](https://github.com/suttacentral/suttacentral/blob/ac30f9c7dc07da9bafd2bf67027c5cbd33c5ee81/client/package.json#L26)
    - space between braces

## Reference

#3572 and future PRs will automate the formatting
  
## Verification

- `npm test` still passes