### PR TITLE
ci: disable non-security dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: uv
+    directory: /server
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0 # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit-
+
+  - package-ecosystem: npm
+    directory: /client
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0 # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit-
+
+  - package-ecosystem: github-actions
+    directory: /.github/workflows
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0 # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit-
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0 # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit-
+
+  - package-ecosystem: docker-compose
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0 # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit-


### PR DESCRIPTION
## Summary

Disable unneeded dependabot updates

## Details

- most of the automated updates from dependabot cause noise and use up CI time too
- we do not have good test coverage everywhere to ensure all of them are safe to merge
  - HongDa also currently [closes most of them](https://github.com/suttacentral/suttacentral/pulls?q=is%3Aclosed+is%3Apr+author%3Adependabot%5Bbot%5D+is%3Aunmerged) too, so we should disable the auto-updates instead of manually closing them all
- we can instead update dependencies when we need to, and check them periodically for updates, such as on a 6 month schedule

### re: security
- this _does not_ affect security updates, which will still happen automatically if there is a CVE in a dep
  - from the [dependabot docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit):
    > This option has no impact on security updates, which have a separate, internal limit of ten open pull requests.
  - we will still need to ensure security updates are properly tested
  
 ## Verification & Prior Art
 
GitHub does not have a way of testing this, but I've used this same configuration in multiple other repos before: https://github.com/argoproj/argo-workflows/pull/12487, [TSDX](https://github.com/jaredpalmer/tsdx/blob/2d7981b00b2bf7363a3eeff44ff5ff698ba58c8c/.github/dependabot.yml#L53)