### PR TITLE
fix: configure log rotation in prod

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,6 +9,13 @@ services:
       - ./client/:/opt/sc/frontend
     ports:
       - '5001:5000'
+    # configure log rotation
+    logging:
+      driver: json-file # the default
+      options:
+        max-file: 10
+        max-size: 500m
+        compress: "true"
 
   sc-nginx:
     restart: always
@@ -17,6 +24,13 @@ services:
     command: bash entry-point.prod.sh
     environment:
       - NODE_ENV='production'
+    # configure log rotation
+    logging:
+      driver: json-file # the default
+      options:
+        max-file: 10
+        max-size: 1g
+        compress: "true"
 
   sc-arangodb:
     restart: always
@@ -24,6 +38,13 @@ services:
       - server/env/.prod.env
     ports:
       - '8529:8529'
+    # configure log rotation
+    logging:
+      driver: json-file # the default
+      options:
+        max-file: 10
+        max-size: 100m
+        compress: "true"
 
   sc-swagger:
     restart: always
@@ -31,6 +52,13 @@ services:
       - '8080:8080'
     environment:
       - "API_URL=https://suttacentral.net/api/spec"
+    # configure log rotation
+    logging:
+      driver: json-file # the default
+      options:
+        max-file: 10
+        max-size: 10m
+        compress: "true"
 
   sc-frontend:
     command: npm run build


### PR DESCRIPTION
## Summary

Add settings for log rotation in `docker-compose.prod.yml`

## Details

- previously the server's disk space filled up due to logs and HongDa had [manually cleared it](https://discourse.suttacentral.net/t/suttacentral-not-loading-properly/43595/13?u=agilgur5)
  - and then no logs were available as the log file [was deleted](https://discourse.suttacentral.net/chat/c/-/12/12373) instead of [truncated](https://stackoverflow.com/a/43570083/3431180)

- instead of manually truncating the logs, [configure log rotation](https://docs.docker.com/engine/logging/drivers/json-file/#options) [in Compose](https://docs.docker.com/reference/compose-file/services/#logging) to automatically handle this
  - [according to HongDa](https://discourse.suttacentral.net/chat/c/-/12/t/372/12448), there is 25GB of free space on the server, so ensure the log limits are less than that
    - based on the services that would have the most useful logs, as initial numbers, I set:
       - 10 x 500mb for Flask, 10 x 1gb for NGINX, 10 x 100mb for ArangoDB, 10 x 10mb for Swagger, and nothing for the front-end as it only runs build a single time in prod
      - so around ~16gb total, leaving some space to spare intentionally
        - I also enabled compression, but the docs don't say how much that shrinks the files by
      - we can adjust these as needed, these are just some estimates to start with
      
## Verification

- I tested this config locally, and it runs at least, but I couldn't confirm if it rotated for large sizes, but I did try smaller below
- I tested a smaller config of 1kb locally, and `docker compose logs sc-flask` would (correctly) show only 2 lines of logs
  - with Podman, the log file in `/var/lib/containers/storage/overlay-containers` did rotate prior to reaching 1kb
  - I couldn't test multiple files though as Podman apparently doesn't yet support `max-file` according to [the docs](https://docs.podman.io/en/latest/markdown/podman-run.1.html#log-opt-name-value) and some issues: https://github.com/podman-container-tools/podman/discussions/20985, https://github.com/podman-container-tools/podman/issues/21361