### PR TITLE
refactor: use `dispatchCustomEvent` helper consistently

### DIFF
--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -8,6 +8,7 @@ import { scriptIdentifiers, paliScriptsStyles } from './sc-aksharamukha-converte
 import { store } from '../../redux-store';
 import { LitLocalized } from './sc-localization-mixin';
 import { API_ROOT } from '../../constants';
+import { dispatchCustomEvent } from '../../utils/customEvent';
 import { ignorableKeydownEvent } from '../sc-keyboard-shortcuts';
 import { reduxActions } from './sc-redux-actions';
 
@@ -837,16 +838,10 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
   }
 
   _showToast(inputMessage) {
-    this.dispatchEvent(
-      new CustomEvent('show-sc-toast', {
-        detail: {
-          toastType: 'info',
-          message: inputMessage,
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    dispatchCustomEvent(this, 'show-sc-toast', {
+      toastType: 'info',
+      message: inputMessage,
+    });
   }
 
   get actions() {

--- a/client/elements/menus/sc-menu-language-base.js
+++ b/client/elements/menus/sc-menu-language-base.js
@@ -84,13 +84,10 @@ export class SCMenuLanguageBase extends LitLocalized(LitElement) {
       const chosenLanguage = this.languageListResponse[this.selectedLanguageNum];
       // If it's not a main language change menu (but a clone), dispatch an event
       if (this.cloneName) {
-        dispatchEvent(
-          new CustomEvent(`${this.cloneName}-language-changed`, {
-            detail: { isoCode: chosenLanguage.iso_code, name: chosenLanguage.name },
-            composed: true,
-            bubbles: true,
-          })
-        );
+        dispatchCustomEvent(document, `${this.cloneName}-language-changed`, {
+          isoCode: chosenLanguage.iso_code,
+          name: chosenLanguage.name,
+        });
       } else {
         this.actions.changeLanguage(chosenLanguage.iso_code, chosenLanguage.name);
       }

--- a/client/elements/menus/sc-menu-suttaplex-share.js
+++ b/client/elements/menus/sc-menu-suttaplex-share.js
@@ -3,6 +3,7 @@ import { css, html, LitElement, render } from 'lit';
 import { LitLocalized } from '../addons/sc-localization-mixin';
 import { API_ROOT } from '../../constants';
 import copyToClipboard from '../../utils/copy';
+import { dispatchCustomEvent } from '../../utils/customEvent';
 import { formatVolPages } from '../../utils/suttaplex';
 import { icon } from '../../img/sc-icon';
 
@@ -115,13 +116,7 @@ export class SCMenuSuttaplexShare extends LitLocalized(LitElement) {
   }
 
   #notifyCopy(message, success) {
-    this.dispatchEvent(
-      new CustomEvent('par-menu-copied', {
-        detail: { message, success },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    dispatchCustomEvent(this, 'par-menu-copied', { message, success });
   }
 
   // copy the parallels-table in html-string

--- a/client/elements/navigation/sc-navigation.js
+++ b/client/elements/navigation/sc-navigation.js
@@ -289,15 +289,11 @@ export class SCNavigation extends LitLocalized(LitElement) {
       return;
     }
     const description = this.localize('interface:metaDescriptionText');
-    document.dispatchEvent(
-      new CustomEvent('metadata', {
-        detail: {
-          pageTitle: `${this._getTitle()}—${this.localize('interface:navigationTitle')}`,
-          title: `${this._getTitle()}—${this.localize('interface:navigationTitle')}`,
-          description,
-        },
-      })
-    );
+    dispatchCustomEvent(document, 'metadata', {
+      pageTitle: `${this._getTitle()}—${this.localize('interface:navigationTitle')}`,
+      title: `${this._getTitle()}—${this.localize('interface:navigationTitle')}`,
+      description,
+    });
   }
 
   _isPatimokkha(uid) {

--- a/client/elements/publication/sc-publication-edition.js
+++ b/client/elements/publication/sc-publication-edition.js
@@ -9,6 +9,7 @@ import { typographyStaticStyles } from '../styles/sc-typography-static-styles';
 import { reduxActions } from '../addons/sc-redux-actions';
 import { store } from '../../redux-store';
 import { API_ROOT } from '../../constants';
+import { dispatchCustomEvent } from '../../utils/customEvent';
 import { setNavigation } from '../navigation/sc-navigation-common';
 import {
   coverImage,
@@ -268,15 +269,11 @@ export class SCPublicationEdition extends LitLocalized(LitElement) {
 
   _createMetaData() {
     const description = `${this.editionDetail[0].root_name} — ${this.editionInfo.publication?.creator_name}`;
-    document.dispatchEvent(
-      new CustomEvent('metadata', {
-        detail: {
-          pageTitle: description,
-          title: description,
-          description,
-        },
-      })
-    );
+    dispatchCustomEvent(document, 'metadata', {
+      pageTitle: description,
+      title: description,
+      description,
+    });
   }
 
   async getGitHubDirectory(repoUrl, path = '', branch = 'main') {

--- a/client/elements/sc-page-dictionary.js
+++ b/client/elements/sc-page-dictionary.js
@@ -7,6 +7,7 @@ import { SCUtilityStyles } from './styles/sc-utility-styles';
 import { LitLocalized } from './addons/sc-localization-mixin';
 import { dictionarySimpleItemToHtml } from './sc-dictionary-common';
 import { store } from '../redux-store';
+import { dispatchCustomEvent } from '../utils/customEvent.js';
 
 import(
   /* webpackMode: "lazy" */
@@ -334,7 +335,7 @@ export class SCPageDictionary extends LitLocalized(LitElement) {
       await this._fetchAdjacent();
       await this._fetchSimilar();
     }
-    
+
     this._fetchDictionary();
   }
 
@@ -447,17 +448,11 @@ export class SCPageDictionary extends LitLocalized(LitElement) {
     const dictionaryResultsText = this.localize('dictionary:dictionaryResultsText');
     const defineFor = this.localize('dictionary:definitionsFor');
 
-    document.dispatchEvent(
-      new CustomEvent('metadata', {
-        detail: {
-          pageTitle: `${defineFor}: ${this.dictionaryWord}`,
-          title: `${dictionaryResultsText} ${this.dictionaryWord}`,
-          description,
-          bubbles: true,
-          composed: true,
-        },
-      })
-    );
+    dispatchCustomEvent(document, 'metadata', {
+      pageTitle: `${defineFor}: ${this.dictionaryWord}`,
+      title: `${dictionaryResultsText} ${this.dictionaryWord}`,
+      description,
+    });
   }
 
   _containsChineseCharacters(str) {

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -1250,17 +1250,11 @@ export class SCPageSearch extends LitLocalized(LitElement) {
     const pageTitle = `${countResultsFor} ${this.searchQuery}`;
     const toolbarTitle = `${countResultsFor} <strong class="highlightTitle">${this.searchQuery}</strong>`;
 
-    document.dispatchEvent(
-      new CustomEvent('metadata', {
-        detail: {
-          pageTitle,
-          title: `${searchResultsText} ${this.searchQuery}`,
-          description,
-          bubbles: true,
-          composed: true,
-        },
-      })
-    );
+    dispatchCustomEvent(document, 'metadata', {
+      pageTitle,
+      title: `${searchResultsText} ${this.searchQuery}`,
+      description,
+    });
     reduxActions.changeToolbarTitle(toolbarTitle);
     this.#updateNav();
   }

--- a/client/elements/static/sc-static-offline.js
+++ b/client/elements/static/sc-static-offline.js
@@ -476,16 +476,10 @@ export class SCStaticOffline extends LitLocalized(LitElement) {
   }
 
   _showToast(type, inputMessage) {
-    this.dispatchEvent(
-      new CustomEvent('show-sc-toast', {
-        detail: {
-          toastType: type,
-          message: inputMessage,
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    dispatchCustomEvent(this, 'show-sc-toast', {
+      toastType: type,
+      message: inputMessage,
+    });
   }
 
   static styles = [

--- a/client/elements/static/sc-static-search-options.js
+++ b/client/elements/static/sc-static-search-options.js
@@ -5,6 +5,7 @@ import '@material/web/checkbox/checkbox';
 import { typographyCommonStyles } from '../styles/sc-typography-common-styles';
 import { store } from '../../redux-store';
 import { API_ROOT } from '../../constants';
+import { dispatchCustomEvent } from '../../utils/customEvent';
 import { reduxActions } from '../addons/sc-redux-actions';
 
 import { getBrowserLanguages, shouldAutoCheckLanguage } from '../addons/sc-search-utils';
@@ -233,17 +234,11 @@ export class SCStaticSearchOptions extends SCStaticPage {
   #createMetaData() {
     const pageTitle = `${this.localize('search:searchOptions')}`;
 
-    document.dispatchEvent(
-      new CustomEvent('metadata', {
-        detail: {
-          pageTitle,
-          title: pageTitle,
-          description: pageTitle,
-          bubbles: true,
-          composed: true,
-        },
-      })
-    );
+    dispatchCustomEvent(document, 'metadata', {
+      pageTitle,
+      title: pageTitle,
+      description: pageTitle,
+    });
     reduxActions.changeToolbarTitle(pageTitle);
   }
 

--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -242,17 +242,11 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
       }
 
       const pageTitle = `${title || original_title || acronym}—${this.localize('interface:parallelsTitle')}`;
-      document.dispatchEvent(
-        new CustomEvent('metadata', {
-          detail: {
-            pageTitle,
-            title: pageTitle,
-            description,
-            bubbles: true,
-            composed: true,
-          },
-        })
-      );
+      dispatchCustomEvent(document, 'metadata', {
+        pageTitle,
+        title: pageTitle,
+        description,
+      });
     }
   }
 

--- a/client/elements/text/sc-text-illustration.js
+++ b/client/elements/text/sc-text-illustration.js
@@ -1,6 +1,8 @@
 import { LitElement, html, css } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
+import { dispatchCustomEvent } from '../../utils/customEvent';
+
 export class SCTextIllustration extends LitElement {
   static properties = {
     filename: { type: String },
@@ -296,23 +298,19 @@ export class SCTextIllustration extends LitElement {
     this._imageLoaded = true;
     this.isLoading = false;
     this.hasError = false;
-    this.dispatchEvent(new CustomEvent('illustration-loaded', {
-      detail: { illustrationId: this.segmentedId },
-      bubbles: true
-    }));
+    dispatchCustomEvent(this, 'illustration-loaded', {
+      illustrationId: this.segmentedId,
+    });
   }
 
   _onImageError() {
     this.hasError = true;
     this.isLoading = false;
     this.errorMessage = 'Failed to load image';
-    this.dispatchEvent(new CustomEvent('illustration-error', {
-      detail: {
-        illustrationId: this.segmentedId,
-        error: 'Image load failed'
-      },
-      bubbles: true
-    }));
+    dispatchCustomEvent(this, 'illustration-error', {
+      illustrationId: this.segmentedId,
+      error: 'Image load failed',
+    });
   }
 }
 

--- a/client/elements/text/sc-text-legacy.js
+++ b/client/elements/text/sc-text-legacy.js
@@ -13,6 +13,7 @@ import '../addons/sc-bottom-sheet.js';
 import { store } from '../../redux-store';
 import { icon } from '../../img/sc-icon';
 import { API_ROOT } from '../../constants';
+import { dispatchCustomEvent } from '../../utils/customEvent.js';
 import { getURLParam, isChinese } from '../addons/sc-functions-miscellaneous';
 import { reduxActions } from '../addons/sc-redux-actions';
 import * as OpenCC from 'opencc-js';
@@ -407,13 +408,11 @@ export class SCTextLegacy extends SCTextCommon {
       item.classList.add('image-book-link');
       item.classList.add('textual-info-paragraph');
       item.addEventListener('click', () => {
-        this.dispatchEvent(
-          new CustomEvent('show-image', {
-            detail: { vol, division: divisionId, pageNumber },
-            bubbles: true,
-            composed: true,
-          })
-        );
+        dispatchCustomEvent(this, 'show-image', {
+          vol,
+          division: divisionId,
+          pageNumber
+        });
       });
     }, 500);
   }

--- a/client/elements/text/sc-text-page-selector.js
+++ b/client/elements/text/sc-text-page-selector.js
@@ -612,18 +612,12 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
       pageTitle = `${title}${author ? `—${author}` : ''}`;
     }
 
-    document.dispatchEvent(
-      new CustomEvent('metadata', {
-        detail: {
-          pageTitle,
-          title: `${title}${author ? `—${author}` : ''}`,
-          description,
-          openGraphType: 'article', // To conform to the twitter cards and pinterest specification, "og:type" must be equal to ‘article’
-          bubbles: true,
-          composed: true,
-        },
-      })
-    );
+    dispatchCustomEvent(document, 'metadata', {
+      pageTitle,
+      title: `${title}${author ? `—${author}` : ''}`,
+      description,
+      openGraphType: 'article', // To conform to the twitter cards and pinterest specification, "og:type" must be equal to ‘article’
+    });
 
     if (!title) {
       title = this._transformId(this.suttaId, this.expansionReturns);
@@ -664,16 +658,10 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
   }
 
   _showLanguagePromptToast() {
-    this.dispatchEvent(
-      new CustomEvent('show-sc-toast', {
-        detail: {
-          toastType: 'info',
-          message: this.localize('text:languagePromptMessage'),
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    dispatchCustomEvent(this, 'show-sc-toast', {
+      toastType: 'info',
+      message: this.localize('text:languagePromptMessage'),
+    });
   }
 
   #redirectWhenSuttaIsFallenLeaf() {

--- a/client/utils/customEvent.js
+++ b/client/utils/customEvent.js
@@ -1,4 +1,4 @@
-export const dispatchCustomEvent = (from, name, payload) => {
+export function dispatchCustomEvent(from, name, payload) {
   from.dispatchEvent(
     new CustomEvent(name, {
       detail: payload,


### PR DESCRIPTION
## Summary

Always use `dispatchCustomEvent` instead of `dispatchEvent` + `new CustomEvent`

## Details

- `dispatchCustomEvent` was used in a majority of places, but `dispatchEvent` + `new CustomEvent` was still used in quite a few places
  - standardize to use the helper
  - this also makes sure `bubbles` and `composed` are always properly set via the helper
    - sometimes they weren't set (seemingly not intentionally?) and sometimes they were accidentally put inside of the `details` object

- also refactor `dispatchCustomEvent` to be a named function, not a `const` variable assigned to an anonymous function
  - the syntaxes are not identical and named functions have [better tracing](https://stackoverflow.com/a/3435763/3431180)