### PR TITLE
clean: remove duplicate `getGitHubDirectory` function

### DIFF
--- a/client/elements/publication/sc-publication-edition.js
+++ b/client/elements/publication/sc-publication-edition.js
@@ -279,17 +279,6 @@ export class SCPublicationEdition extends LitLocalized(LitElement) {
     );
   }
 
-  async getGitHubDirectory(repoUrl, path = '', branch = 'main') {
-    try {
-      const response = await fetch(`/api/github-directory?repo_url=${encodeURIComponent(repoUrl)}&path=${encodeURIComponent(path)}&branch=${branch}`);
-      const result = await response.json();
-      return result;
-    } catch (error) {
-      console.error('Error fetching GitHub directory:', error);
-      return null;
-    }
-  }
-
   createRenderRoot() {
     return this;
   }


### PR DESCRIPTION
## Summary

Removed duplicate code in `PublicationEdition` component

## Details

- there's two identical `getGitHubDirectory` functions in this component, one [on line 282](https://github.com/suttacentral/suttacentral/blob/b2cb0f91eed45e42c234e39ce17cdb87a2965167/client/elements/publication/sc-publication-edition.js#L282) and one [on line 182](https://github.com/suttacentral/suttacentral/blob/b2cb0f91eed45e42c234e39ce17cdb87a2965167/client/elements/publication/sc-publication-edition.js#L182)
  - this code appears to have been duplicated in eaa97910918a5bae2fa3071bd3ddbc49c1135cc4 (https://github.com/suttacentral/suttacentral/pull/3505#pullrequestreview-4891683883)