### PR TITLE
clean: remove unused `actions` methods in search components

### DIFF
--- a/client/elements/addons/sc-top-sheet-search-options.js
+++ b/client/elements/addons/sc-top-sheet-search-options.js
@@ -103,17 +103,6 @@ export class SCTopSheetSearchOptions extends SCTopSheetCommon {
     `,
   ];
 
-  get actions() {
-    return {
-      changeDisplaySettingMenuState(display) {
-        store.dispatch({
-          type: 'CHANGE_DISPLAY_SETTING_MENU_STATE',
-          displaySettingMenu: display,
-        });
-      },
-    };
-  }
-
   constructor() {
     super();
     this.displayedLanguages = store.getState().searchOptions.displayedLanguages;

--- a/client/elements/static/sc-static-search-options.js
+++ b/client/elements/static/sc-static-search-options.js
@@ -103,17 +103,6 @@ export class SCStaticSearchOptions extends SCStaticPage {
     `,
   ];
 
-  get actions() {
-    return {
-      changeDisplaySettingMenuState(display) {
-        store.dispatch({
-          type: 'CHANGE_DISPLAY_SETTING_MENU_STATE',
-          displaySettingMenu: display,
-        });
-      },
-    };
-  }
-
   constructor() {
     super();
     this.localizedStringsPath = '/localization/elements/search';


### PR DESCRIPTION
## Summary

Remove unused `actions` methods in `TopSheetSearchOptions` and `StaticSearchOptions` components

## Details

- `reduxActions` is used instead and contains similar code
  - unused `actions` code appears to have been written during a7d0a44c0177f55aa4ae284f650f8e433dd5b3f5 (https://github.com/suttacentral/suttacentral/pull/2596#pullrequestreview-4891703571) and 436776d845e0fd191f2286fbca87b818c8f2cd3d (https://github.com/suttacentral/suttacentral/pull/2963#discussion_r3744293958)
  - `changeDisplaySettingMenuState` also [already exists in `reduxActions`](https://github.com/suttacentral/suttacentral/blob/b2cb0f91eed45e42c234e39ce17cdb87a2965167/client/elements/addons/sc-redux-actions.js#L159)