### PR TITLE
refactor: use `reduxActions` instead of `this.actions` methods

### DIFF
--- a/client/elements/addons/sc-redux-actions.js
+++ b/client/elements/addons/sc-redux-actions.js
@@ -8,7 +8,7 @@ export class reduxActions {
     });
   }
 
-  static setReferenceDisplayType(displayedReferences) {
+  static setDisplayedReferences(displayedReferences) {
     store.dispatch({
       type: 'SET_REFERENCE_DISPLAY_TYPE_ARRAY',
       displayedReferences,

--- a/client/elements/addons/sc-redux-actions.js
+++ b/client/elements/addons/sc-redux-actions.js
@@ -235,4 +235,25 @@ export class reduxActions {
       showIllustrations,
     });
   }
+
+  static changeSuttaMetaText(metaText) {
+    store.dispatch({
+      type: 'CHANGE_SUTTA_META_TEXT',
+      metaText,
+    });
+  }
+
+  static changeSuttaPublicationInfo(publicationInfo) {
+    store.dispatch({
+      type: 'CHANGE_SUTTA_PUBLICATION_INFO',
+      suttaPublicationInfo: publicationInfo,
+    });
+  }
+
+  static setStaticPagesToolbarDisplayState(toolbarDisplayState) {
+    store.dispatch({
+      type: 'CHANGE_STATIC_PAGES_TOOLBAR_DISPLAY_STATE',
+      staticPagesToolbarDisplayState: toolbarDisplayState,
+    });
+  }
 }

--- a/client/elements/addons/sc-top-sheet-publication-bilara.js
+++ b/client/elements/addons/sc-top-sheet-publication-bilara.js
@@ -2,6 +2,7 @@ import { LitElement, html, css } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { API_ROOT } from '../../constants';
 import { typographyCommonStyles } from '../styles/sc-typography-common-styles';
+import { reduxActions } from './sc-redux-actions';
 import SCTopSheetCommon from './sc-top-sheet-common';
 import { store } from '../../redux-store';
 
@@ -147,20 +148,9 @@ export class SCTopSheetPublicationBilara extends SCTopSheetCommon {
     }
   }
 
-  get actions() {
-    return {
-      changeSuttaPublicationInfo(publicationInfo) {
-        store.dispatch({
-          type: 'CHANGE_SUTTA_PUBLICATION_INFO',
-          suttaPublicationInfo: publicationInfo,
-        });
-      },
-    };
-  }
-
   fetchPublications() {
     if (!this.textUID || !this.lang || !this.authorUID) {
-      this.actions.changeSuttaPublicationInfo(null);
+      reduxActions.changeSuttaPublicationInfo(null);
       return;
     }
     fetch(`${API_ROOT}/publication_info/${this.textUID}/${this.lang}/${this.authorUID}`)

--- a/client/elements/addons/sc-top-sheet-toc.js
+++ b/client/elements/addons/sc-top-sheet-toc.js
@@ -1,8 +1,9 @@
 import { html, css } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+
+import { reduxActions } from './sc-redux-actions';
 import SCTopSheetCommon from './sc-top-sheet-common';
 import { typographyCommonStyles } from '../styles/sc-typography-common-styles';
-import { store } from '../../redux-store';
 
 export class SCTopSheetToC extends SCTopSheetCommon {
   static styles = [
@@ -34,23 +35,6 @@ figcaption
     items: { type: Object },
     disableToCListStyle: { type: Boolean },
   };
-
-  get actions() {
-    return {
-      changeDisplaySettingMenuState(display) {
-        store.dispatch({
-          type: 'CHANGE_DISPLAY_SETTING_MENU_STATE',
-          displaySettingMenu: display,
-        });
-      },
-      changeDisplaySuttaToCState(displayState) {
-        store.dispatch({
-          type: 'CHANGE_DISPLAY_SUTTA_TOC_STATE',
-          displaySuttaToC: displayState,
-        });
-      },
-    };
-  }
 
   constructor() {
     super();
@@ -94,8 +78,8 @@ figcaption
     const scActionItems = document.querySelector('sc-site-layout').querySelector('#action_items');
     scActionItems?.hideTopSheets();
 
-    this.actions.changeDisplaySettingMenuState(false);
-    this.actions.changeDisplaySuttaToCState(false);
+    reduxActions.changeDisplaySettingMenuState(false);
+    reduxActions.changeDisplaySuttaToCState(false);
   }
 }
 

--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -515,7 +515,7 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
 
   _changeTextView(newTextView) {
     this.selectedTextView = newTextView;
-    this.actions.chooseSegmentedSuttaTextView(newTextView);
+    reduxActions.chooseSegmentedSuttaTextView(newTextView);
     const newType = this.textViewArray.find(item => item.textView === newTextView).textViewLabel;
     this._showToast(
       this.localizeEx(
@@ -678,7 +678,7 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
     const scTopsheetViews = document.querySelector('sc-site-layout').querySelector('#setting_menu');
     const selectedScript = scriptIdentifiers[e.currentTarget.selectedIndex].script;
     const selectedLanguage = scriptIdentifiers[e.currentTarget.selectedIndex].language;
-    scTopsheetViews.actions.choosePaliTextScript(selectedScript);
+    reduxActions.choosePaliTextScript(selectedScript);
     const scriptChangeMessage = scTopsheetViews.localizeEx(
       'viewoption:scriptChanged',
       'paliScript',
@@ -797,7 +797,7 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
   }
 
   _onShowHighlightingChanged(e) {
-    this.actions.setShowHighlighting(e.target.checked);
+    reduxActions.setShowHighlighting(e.target.checked);
     const msg = e.target.checked ? 'showHighlightingEnabled' : 'showHighlightingDisabled';
     this._showToast(this.localize(`viewoption:${msg}`));
   }
@@ -814,7 +814,7 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
 
   changeNoteDisplayType(selectedNoteDisplayType) {
     this.selectedNoteDisplayType = selectedNoteDisplayType;
-    this.actions.setNoteDisplayType(this.selectedNoteDisplayType);
+    reduxActions.setNoteDisplayType(this.selectedNoteDisplayType);
     this._showToast(this.localize('viewoption:noteDisplayTypeToast' +
       this.selectedNoteDisplayType.charAt(0).toUpperCase() + this.selectedNoteDisplayType.slice(1)
     ));
@@ -863,18 +863,6 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
           descriptions: data,
         });
       },
-      chooseSegmentedSuttaTextView(view) {
-        store.dispatch({
-          type: 'CHOOSE_SEGMENTED_SUTTA_TEXT_VIEW',
-          view,
-        });
-      },
-      choosePaliTextScript(script) {
-        store.dispatch({
-          type: 'CHOOSE_PALI_TEXT_SCRIPT',
-          script,
-        });
-      },
       activatePaliLookup(activated, targetLanguage, targetDictRepr) {
         store.dispatch({
           type: 'ACTIVATE_PALI_LOOKUP',
@@ -895,18 +883,6 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
         store.dispatch({
           type: 'SET_REFERENCE_DISPLAY_TYPE',
           referenceDisplayType: displayType,
-        });
-      },
-      setNoteDisplayType(displayType) {
-        store.dispatch({
-          type: 'SET_NOTE_DISPLAY_TYPE',
-          noteDisplayType: displayType,
-        });
-      },
-      setShowHighlighting(showHighlighting) {
-        store.dispatch({
-          type: 'SET_SHOW_HIGHLIGHTING',
-          showHighlighting,
         });
       },
       setRootTextFirst(rootTextFirst) {

--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -851,18 +851,6 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
 
   get actions() {
     return {
-      toggleTextualInfo(enabled) {
-        store.dispatch({
-          type: 'TOGGLE_TEXTUAL_INFORMATION_ENABLED',
-          enabled,
-        });
-      },
-      downloadParagraphs(data) {
-        store.dispatch({
-          type: 'DOWNLOAD_PARAGRAPH_DESCRIPTIONS',
-          descriptions: data,
-        });
-      },
       activatePaliLookup(activated, targetLanguage, targetDictRepr) {
         store.dispatch({
           type: 'ACTIVATE_PALI_LOOKUP',
@@ -877,12 +865,6 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
           chineseLookupTargetLanguage: targetLanguage,
           chineseLookupActivated: activated,
           chineseLookupTargetDictRepr: targetDictRepr,
-        });
-      },
-      setReferenceDisplayType(displayType) {
-        store.dispatch({
-          type: 'SET_REFERENCE_DISPLAY_TYPE',
-          referenceDisplayType: displayType,
         });
       },
       setRootTextFirst(rootTextFirst) {

--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -438,7 +438,7 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
           defaultDisplayedReference.checked = true;
         }
 
-        this.actions.setDisplayedReferences(
+        reduxActions.setDisplayedReferences(
           this.references.filter(({ checked }) => checked).map(({ edition_set }) => edition_set)
         );
       })
@@ -726,7 +726,7 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
     this.references.find(reference => reference.edition_set === 'none').checked = true;
     this.requestUpdate();
     this._showToast(this.localize('viewoption:allRefsDisabled'));
-    this.actions.setDisplayedReferences(['none']);
+    reduxActions.setDisplayedReferences(['none']);
   }
 
   enableAllReferences() {
@@ -734,7 +734,7 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
     this.references.find(reference => reference.edition_set === 'none').checked = false;
     this.requestUpdate();
     this._showToast(this.localize('viewoption:allRefsEnabled'));
-    this.actions.setDisplayedReferences(this.references.filter(({ checked }) => checked).map(({ edition_set }) => edition_set));
+    reduxActions.setDisplayedReferences(this.references.filter(({ checked }) => checked).map(({ edition_set }) => edition_set));
   }
 
   _onReferenceDisplayTypeChanged({ target: { checked, value: selectedReferenceDisplayType } }) {
@@ -773,7 +773,7 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
         this._showToast(this.localize('viewoption:ptsRefsDisabled'));
       }
     }
-    this.actions.setDisplayedReferences(references);
+    reduxActions.setDisplayedReferences(references);
   }
 
   get showHighlightingTemplate() {
@@ -871,12 +871,6 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
         store.dispatch({
           type: 'SET_ROOT_TEXT_FIRST',
           rootTextFirst,
-        });
-      },
-      setDisplayedReferences(displayedReferences) {
-        store.dispatch({
-          type: 'SET_REFERENCE_DISPLAY_TYPE_ARRAY',
-          displayedReferences,
         });
       },
     };

--- a/client/elements/menus/sc-menu-language-base.js
+++ b/client/elements/menus/sc-menu-language-base.js
@@ -4,8 +4,8 @@ import '@material/web/menu/menu-item';
 import '@material/web/iconbutton/icon-button';
 
 import { API_ROOT } from '../../constants';
-import { store } from '../../redux-store';
 import { LitLocalized } from '../addons/sc-localization-mixin';
+import { reduxActions } from '../addons/sc-redux-actions';
 import { languageBaseMenuCss } from './sc-menu-language-base-css';
 import { icon } from '../../img/sc-icon';
 import { dispatchCustomEvent } from '../../utils/customEvent';
@@ -19,24 +19,6 @@ export class SCMenuLanguageBase extends LitLocalized(LitElement) {
     noRoot: { type: Boolean }, // If true, no root languages will be displayed.
     disabled: { type: Boolean },
   };
-
-  get actions() {
-    return {
-      changeLanguage(language, fullName) {
-        store.dispatch({
-          type: 'CHANGE_SITE_LANGUAGE',
-          language,
-          fullName,
-        });
-      },
-      changeLanguageMenuVisibility(visibility) {
-        store.dispatch({
-          type: 'CHANGE_LANGUAGE_MENU_VISIBILITY_STATE',
-          languageMenuVisibility: visibility,
-        });
-      },
-    };
-  }
 
   get apiUrl() {
     return `${API_ROOT}/languages?all=true`;
@@ -55,7 +37,7 @@ export class SCMenuLanguageBase extends LitLocalized(LitElement) {
   }
 
   _showMoreMenu() {
-    this.actions.changeLanguageMenuVisibility(false);
+    reduxActions.changeLanguageMenuVisibility(false);
   }
 
   languageTemplate(language) {
@@ -92,7 +74,7 @@ export class SCMenuLanguageBase extends LitLocalized(LitElement) {
           })
         );
       } else {
-        this.actions.changeLanguage(chosenLanguage.iso_code, chosenLanguage.name);
+        reduxActions.changeLanguage(chosenLanguage.iso_code, chosenLanguage.name);
       }
     } catch (e) {
       console.error(e);

--- a/client/elements/menus/sc-menu-more.js
+++ b/client/elements/menus/sc-menu-more.js
@@ -203,12 +203,6 @@ export class SCMenuMore extends LitLocalized(LitElement) {
           alwaysShowUniversalToolbar: state,
         });
       },
-      changeLanguageMenuVisibility(visibility) {
-        store.dispatch({
-          type: 'CHANGE_LANGUAGE_MENU_VISIBILITY_STATE',
-          languageMenuVisibility: visibility,
-        });
-      },
     };
   }
 
@@ -283,7 +277,7 @@ export class SCMenuMore extends LitLocalized(LitElement) {
   }
 
   _showLanguageMenu() {
-    this.actions.changeLanguageMenuVisibility(true);
+    reduxActions.changeLanguageMenuVisibility(true);
   }
 
   _displayCurrentSiteLanguage() {

--- a/client/elements/menus/sc-menu-static-pages-nav.js
+++ b/client/elements/menus/sc-menu-static-pages-nav.js
@@ -1,6 +1,7 @@
 import { LitElement, html } from 'lit';
 import { LitLocalized } from '../addons/sc-localization-mixin';
 import { store } from '../../redux-store';
+import { reduxActions } from '../addons/sc-redux-actions';
 import { SCMenuStaticPagesNavStyles } from '../styles/sc-menu-static-pages-nav-styles';
 import { API_ROOT } from '../../constants';
 
@@ -34,7 +35,7 @@ export class SCMenuStaticPagesNav extends LitLocalized(LitElement) {
   }
 
   _initStaticPagesToolbarDisplayState() {
-    this.actions.setStaticPagesToolbarDisplayState({
+    reduxActions.setStaticPagesToolbarDisplayState({
       displayFirstToolbar: true,
       displaySecondToolbar: false,
       displayTipitakaToolbar: false,
@@ -43,17 +44,6 @@ export class SCMenuStaticPagesNav extends LitLocalized(LitElement) {
       displayGuidesToolbar: false,
       displayPublicationToolbar: false,
     });
-  }
-
-  get actions() {
-    return {
-      setStaticPagesToolbarDisplayState(toolbarDisplayState) {
-        store.dispatch({
-          type: 'CHANGE_STATIC_PAGES_TOOLBAR_DISPLAY_STATE',
-          staticPagesToolbarDisplayState: toolbarDisplayState,
-        });
-      },
-    };
   }
 
   stateChanged(state) {

--- a/client/elements/navigation/sc-navigation-linden-leaves.js
+++ b/client/elements/navigation/sc-navigation-linden-leaves.js
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { store } from '../../redux-store';
 import { LitLocalized } from '../addons/sc-localization-mixin';
+import { reduxActions } from '../addons/sc-redux-actions';
 import '../menus/sc-action-items-universal';
 import { icon } from '../../img/sc-icon';
 import { dispatchCustomEvent } from '../../utils/customEvent';
@@ -204,23 +205,6 @@ export class SCNavigationLindenLeaves extends LitLocalized(LitElement) {
     this.localizedStringsPath = '/localization/elements/interface';
   }
 
-  get actions() {
-    return {
-      setNavigation(navArray) {
-        store.dispatch({
-          type: 'SET_NAVIGATION',
-          navigationArray: navArray,
-        });
-      },
-      changeToolbarTitle(title) {
-        store.dispatch({
-          type: 'CHANGE_TOOLBAR_TITLE',
-          title,
-        });
-      },
-    };
-  }
-
   stateChanged(state) {
     super.stateChanged(state);
     this.requestUpdate();
@@ -299,14 +283,14 @@ export class SCNavigationLindenLeaves extends LitLocalized(LitElement) {
     this._hideTopSheetsAndMenu();
     if (nav.type === 'home') {
       this.navArray.length = 1;
-      this.actions.setNavigation(this.navArray);
+      reduxActions.setNavigation(this.navArray);
       dispatchCustomEvent(this, 'sc-navigate', { pathname: nav.url });
     }
 
     const routePath = store.getState().currentRoute.path;
-    this.actions.changeToolbarTitle(nav.title);
+    reduxActions.changeToolbarTitle(nav.title);
     this.navArray.length = nav.index + 1 || 1;
-    this.actions.setNavigation(this.navArray);
+    reduxActions.setNavigation(this.navArray);
     this.requestUpdate();
 
     if (this._getPathParamNumber(routePath, 1) !== 'pitaka') {

--- a/client/elements/navigation/sc-navigation.js
+++ b/client/elements/navigation/sc-navigation.js
@@ -273,7 +273,7 @@ export class SCNavigation extends LitLocalized(LitElement) {
     if (!this.currentMenuData || this.currentMenuData.length === 0) {
       return;
     }
-    this.actions.changeToolbarTitle(this._getTitle());
+    reduxActions.changeToolbarTitle(this._getTitle());
   }
 
   _getTitle() {
@@ -309,17 +309,6 @@ export class SCNavigation extends LitLocalized(LitElement) {
       return '';
     }
     return `${API_ROOT}/menu/${uid}?language=${this.siteLanguage || 'en'}`;
-  }
-
-  get actions() {
-    return {
-      changeToolbarTitle(title) {
-        store.dispatch({
-          type: 'CHANGE_TOOLBAR_TITLE',
-          title,
-        });
-      },
-    };
   }
 
   stateChanged(state) {

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -339,22 +339,10 @@ export class SCPageSelector extends LitLocalized(LitElement) {
           payload: { name, params, path },
         });
       },
-      setNavigation(navArray) {
-        store.dispatch({
-          type: 'SET_NAVIGATION',
-          navigationArray: navArray,
-        });
-      },
       setStaticPagesToolbarDisplayState(toolbarDisplayState) {
         store.dispatch({
           type: 'CHANGE_STATIC_PAGES_TOOLBAR_DISPLAY_STATE',
           staticPagesToolbarDisplayState: toolbarDisplayState,
-        });
-      },
-      changeToolbarTitle(title) {
-        store.dispatch({
-          type: 'CHANGE_TOOLBAR_TITLE',
-          title,
         });
       },
       changeDisplayToolButtonState(display) {
@@ -717,7 +705,7 @@ export class SCPageSelector extends LitLocalized(LitElement) {
         }
     }
 
-    this.actions.changeToolbarTitle(title);
+    reduxActions.changeToolbarTitle(title);
 }
 
   _updateNav() {
@@ -738,7 +726,7 @@ export class SCPageSelector extends LitLocalized(LitElement) {
           url: currentPath,
           type: 'staticPage',
         });
-        this.actions.setNavigation(navArray);
+        reduxActions.setNavigation(navArray);
       }
     }
   }

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -339,12 +339,6 @@ export class SCPageSelector extends LitLocalized(LitElement) {
           payload: { name, params, path },
         });
       },
-      setStaticPagesToolbarDisplayState(toolbarDisplayState) {
-        store.dispatch({
-          type: 'CHANGE_STATIC_PAGES_TOOLBAR_DISPLAY_STATE',
-          staticPagesToolbarDisplayState: toolbarDisplayState,
-        });
-      },
       changeDisplayToolButtonState(display) {
         store.dispatch({
           type: 'CHANGE_DISPLAY_TOOL_BUTTON_STATE',
@@ -670,7 +664,7 @@ export class SCPageSelector extends LitLocalized(LitElement) {
       'publicationEditionIntroduction',
     ].includes(this.currentRoute.name);
 
-    this.actions.setStaticPagesToolbarDisplayState({
+    reduxActions.setStaticPagesToolbarDisplayState({
       displayFirstToolbar: isToolbarSelected,
       displaySecondToolbar: this.shouldShowSecondToolbar,
       displayTipitakaToolbar: this.shouldShowTipitakaToolbar,

--- a/client/elements/static/sc-static-languages.js
+++ b/client/elements/static/sc-static-languages.js
@@ -4,6 +4,7 @@ import { layoutSimpleStyles } from '../styles/sc-layout-simple-styles';
 import { typographyCommonStyles } from '../styles/sc-typography-common-styles';
 import { typographyStaticStyles } from '../styles/sc-typography-static-styles';
 import { SCUtilityStyles } from '../styles/sc-utility-styles';
+import { reduxActions } from '../addons/sc-redux-actions';
 import { SCStaticPage } from '../addons/sc-static-page';
 import { API_ROOT } from '../../constants';
 import '../addons/sc-pie-chart';
@@ -56,18 +57,7 @@ export class SCStaticLanguages extends SCStaticPage {
       type: 'LanguageDetailPage',
     };
     setNavigation(navArray);
-    this.actions.changeToolbarTitle(this.localize('languages:languagesOnSuttaCentral'));
-  }
-
-  get actions() {
-    return {
-      changeToolbarTitle(title) {
-        store.dispatch({
-          type: 'CHANGE_TOOLBAR_TITLE',
-          title,
-        });
-      },
-    };
+    reduxActions.changeToolbarTitle(this.localize('languages:languagesOnSuttaCentral'));
   }
 
   findLanguage(code) {

--- a/client/elements/suttaplex/card/sc-parallel-list.js
+++ b/client/elements/suttaplex/card/sc-parallel-list.js
@@ -3,8 +3,8 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { API_ROOT } from '../../../constants';
 import { getParagraphRange, transformId } from '../../../utils/suttaplex';
 import { LitLocalized } from '../../addons/sc-localization-mixin';
+import { reduxActions } from '../../addons/sc-redux-actions';
 import { icon } from '../../../img/sc-icon';
-import { store } from '../../../redux-store';
 
 import './sc-parallel-item';
 import { parallelsListCss } from './sc-suttaplex-css';
@@ -115,17 +115,6 @@ export class SCParallels extends LitLocalized(LitElement) {
     }
   }
 
-  get actions() {
-    return {
-      changeLinearProgressActiveState(active) {
-        store.dispatch({
-          type: 'CHANGE_LINEAR_PROGRESS_ACTIVE_STATE',
-          linearProgressActive: active,
-        });
-      },
-    };
-  }
-
   static styles = [parallelsListCss];
 
   render() {
@@ -200,11 +189,11 @@ export class SCParallels extends LitLocalized(LitElement) {
 
   async _loadData() {
     this.loadingResults = true;
-    this.actions.changeLinearProgressActiveState(this.loadingResults);
+    reduxActions.changeLinearProgressActiveState(this.loadingResults);
     this.responseData = await (await fetch(this._getAPIEndpoint(this.itemUid))).json();
     await this._didRespond();
     this.loadingResults = false;
-    this.actions.changeLinearProgressActiveState(this.loadingResults);
+    reduxActions.changeLinearProgressActiveState(this.loadingResults);
   }
 
   _didRespond() {

--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -28,35 +28,6 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
     expansionData: { type: Array },
   };
 
-  get actions() {
-    return {
-      changeToolbarTitle(title) {
-        store.dispatch({
-          type: 'CHANGE_TOOLBAR_TITLE',
-          title,
-        });
-      },
-      changeLinearProgressActiveState(active) {
-        store.dispatch({
-          type: 'CHANGE_LINEAR_PROGRESS_ACTIVE_STATE',
-          linearProgressActive: active,
-        });
-      },
-      changeDisplayParallelTableViewState(displayState) {
-        store.dispatch({
-          type: 'CHANGE_DISPLAY_PARALLEL_TABLE_VIEW_STATE',
-          displayParallelTableView: displayState,
-        });
-      },
-      toggleSuttaplexDisplay(suttaplexdisplay) {
-        store.dispatch({
-          type: 'SUTTPLEX_LIST_DISPLAY',
-          suttaplexdisplay,
-        });
-      },
-    };
-  }
-
   get apiUrl() {
     return `${API_ROOT}/suttaplex/${this.categoryId}?language=${this.language}`;
   }
@@ -186,7 +157,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
 
   async _fetchCategory() {
     this.suttaplexLoading = true;
-    this.actions.changeLinearProgressActiveState(this.suttaplexLoading);
+    reduxActions.changeLinearProgressActiveState(this.suttaplexLoading);
     this.networkError = null;
 
     try {
@@ -212,7 +183,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
     }
 
     this.suttaplexLoading = false;
-    this.actions.changeLinearProgressActiveState(this.suttaplexLoading);
+    reduxActions.changeLinearProgressActiveState(this.suttaplexLoading);
   }
 
   _updateMetaData() {
@@ -226,10 +197,10 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
 
       if (!isSuttaInRangeSutta) {
         RefreshNavNew(categoryId);
-        this.actions.changeToolbarTitle(original_title);
+        reduxActions.changeToolbarTitle(original_title);
       } else {
         RefreshNavNew(rangeCategoryId);
-        this.actions.changeToolbarTitle(title);
+        reduxActions.changeToolbarTitle(title);
 
         setTimeout(() => {
           const currentNav = store.getState().navigationArray;
@@ -396,18 +367,18 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
       if (view === 'normal') {
         this.displayParallelTableView = false;
         this.suttaplexListDisplay = false;
-        this.actions.changeDisplayParallelTableViewState(false);
-        this.actions.toggleSuttaplexDisplay(false);
+        reduxActions.changeDisplayParallelTableViewState(false);
+        reduxActions.toggleSuttaplexDisplay(false);
       }
       if (view === 'dense') {
         this.displayParallelTableView = false;
         this.suttaplexListDisplay = true;
-        this.actions.changeDisplayParallelTableViewState(false);
-        this.actions.toggleSuttaplexDisplay(true);
+        reduxActions.changeDisplayParallelTableViewState(false);
+        reduxActions.toggleSuttaplexDisplay(true);
       }
       if (view === 'table') {
         this.displayParallelTableView = true;
-        this.actions.changeDisplayParallelTableViewState(true);
+        reduxActions.changeDisplayParallelTableViewState(true);
       }
     }
   }

--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -913,17 +913,6 @@ export class SCTextBilara extends SCTextCommon {
     return name.replace(/^\d+\./, '').trim();
   }
 
-  get actions() {
-    return {
-      chooseSegmentedSuttaTextView(viewNumber) {
-        store.dispatch({
-          type: 'CHOOSE_SEGMENTED_SUTTA_TEXT_VIEW',
-          view: viewNumber,
-        });
-      },
-    };
-  }
-
   _addRootText() {
     if (!this.bilaraRootSutta || this._articleElement().length === 0) {
       return;

--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -293,9 +293,9 @@ export class SCTextBilara extends SCTextCommon {
         this._updateTextViewStylesBasedOnState();
       }, 0);
 
-      this.actions.changeSuttaMetaText('');
+      reduxActions.changeSuttaMetaText('');
       if (!this.isRangeSutta) {
-        this.actions.changeSuttaPublicationInfo({
+        reduxActions.changeSuttaPublicationInfo({
           uid: this.suttaId,
           lang: this.translatedSutta?.lang || 'en',
           authorUid: this.translatedSutta?.author_uid,
@@ -443,7 +443,7 @@ export class SCTextBilara extends SCTextCommon {
         }
       }, 100);
 
-      this.actions.changeSuttaPublicationInfo({
+      reduxActions.changeSuttaPublicationInfo({
         uid: this.range_uid,
         lang: this.translatedSutta?.lang || 'en',
         authorUid: this.translatedSutta?.author_uid,
@@ -915,18 +915,6 @@ export class SCTextBilara extends SCTextCommon {
 
   get actions() {
     return {
-      changeSuttaMetaText(metaText) {
-        store.dispatch({
-          type: 'CHANGE_SUTTA_META_TEXT',
-          metaText,
-        });
-      },
-      changeSuttaPublicationInfo(publicationInfo) {
-        store.dispatch({
-          type: 'CHANGE_SUTTA_PUBLICATION_INFO',
-          suttaPublicationInfo: publicationInfo,
-        });
-      },
       chooseSegmentedSuttaTextView(viewNumber) {
         store.dispatch({
           type: 'CHOOSE_SEGMENTED_SUTTA_TEXT_VIEW',

--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -93,7 +93,7 @@ export class SCTextBilara extends SCTextCommon {
     };
 
     this._onClickHandler = () => {
-      this.actions.changeDisplaySettingMenuState(false);
+      reduxActions.changeDisplaySettingMenuState(false);
     };
 
     // Return the corresponding style sheet according to different combinations of text viewing options.
@@ -449,7 +449,7 @@ export class SCTextBilara extends SCTextCommon {
         authorUid: this.translatedSutta?.author_uid,
       });
 
-      this.actions.showToc([]);
+      reduxActions.showToc([]);
 
       this.scActionItems.range_uid = this.range_uid;
     } else {
@@ -893,7 +893,7 @@ export class SCTextBilara extends SCTextCommon {
   _prepareNavigation() {
     const sutta = this.bilaraTranslatedSutta || this.bilaraRootSutta;
     if (!sutta) {
-      this.actions.showToc([]);
+      reduxActions.showToc([]);
       return;
     }
     const dummyElement = document.createElement('template');
@@ -906,7 +906,7 @@ export class SCTextBilara extends SCTextCommon {
     });
     arrayTOC = arrayTOC.filter(Boolean);
 
-    this.actions.showToc(arrayTOC);
+    reduxActions.showToc(arrayTOC);
   }
 
   _stripLeadingOrdering(name) {
@@ -931,21 +931,6 @@ export class SCTextBilara extends SCTextCommon {
         store.dispatch({
           type: 'CHOOSE_SEGMENTED_SUTTA_TEXT_VIEW',
           view: viewNumber,
-        });
-      },
-      showToc(tableOfContents) {
-        store.dispatch({
-          type: 'CHANGE_DISPLAY_TOC_BUTTON_STATE',
-          payload: {
-            tableOfContents,
-            disableToCListStyle: false,
-          },
-        });
-      },
-      changeDisplaySettingMenuState(display) {
-        store.dispatch({
-          type: 'CHANGE_DISPLAY_SETTING_MENU_STATE',
-          displaySettingMenu: display,
         });
       },
     };

--- a/client/elements/text/sc-text-legacy.js
+++ b/client/elements/text/sc-text-legacy.js
@@ -116,17 +116,6 @@ export class SCTextLegacy extends SCTextCommon {
     `;
   }
 
-  get actions() {
-    return {
-      changeSuttaMetaText(metaText) {
-        store.dispatch({
-          type: 'CHANGE_SUTTA_META_TEXT',
-          metaText,
-        });
-      },
-    };
-  }
-
   connectedCallback() {
     super.connectedCallback();
     window.addEventListener('hashchange', this._hashChangeHandler);
@@ -226,7 +215,7 @@ export class SCTextLegacy extends SCTextCommon {
     this._setAttributes();
     this.spansForWordsGenerated = false;
     this.spansForGraphsGenerated = false;
-    this.actions.changeSuttaMetaText(this._computeMeta());
+    reduxActions.changeSuttaMetaText(this._computeMeta());
     this._loadingChanged();
     this._showHighlightingChanged();
     this._referenceDisplayTypeChanged();

--- a/client/elements/text/sc-text-legacy.js
+++ b/client/elements/text/sc-text-legacy.js
@@ -692,7 +692,7 @@ export class SCTextLegacy extends SCTextCommon {
           // eslint-disable-next-line promise/always-return
           if (paramReference.length > 0) {
             this.chosenReferenceDisplayType = paramReference;
-            reduxActions.setReferenceDisplayType(paramReference);
+            reduxActions.setDisplayedReferences(paramReference);
           }
         })
         .catch(e => console.error(e));

--- a/client/elements/text/sc-text-legacy.js
+++ b/client/elements/text/sc-text-legacy.js
@@ -124,21 +124,6 @@ export class SCTextLegacy extends SCTextCommon {
           metaText,
         });
       },
-      changeDisplaySettingMenuState(display) {
-        store.dispatch({
-          type: 'CHANGE_DISPLAY_SETTING_MENU_STATE',
-          displaySettingMenu: display,
-        });
-      },
-      showToc(tableOfContents) {
-        store.dispatch({
-          type: 'CHANGE_DISPLAY_TOC_BUTTON_STATE',
-          payload: {
-            tableOfContents,
-            disableToCListStyle: true,
-          },
-        });
-      },
     };
   }
 
@@ -146,7 +131,7 @@ export class SCTextLegacy extends SCTextCommon {
     super.connectedCallback();
     window.addEventListener('hashchange', this._hashChangeHandler);
     this.addEventListener('click', () => {
-      this.actions.changeDisplaySettingMenuState(false);
+      reduxActions.changeDisplaySettingMenuState(false);
     });
     this.inputElement = this.querySelector('#simple_text_content');
     this._extractSuttaText();
@@ -255,7 +240,7 @@ export class SCTextLegacy extends SCTextCommon {
   _prepareNavigation() {
     const sutta = this.sutta?.text;
     if (!sutta) {
-      this.actions.showToc([]);
+      reduxActions.showToc([]);
       return;
     }
     const dummyElement = document.createElement('template');
@@ -265,7 +250,7 @@ export class SCTextLegacy extends SCTextCommon {
       return { link: id, name: elem.innerText };
     });
     arrayTOC = arrayTOC.filter(Boolean);
-    this.actions.showToc(arrayTOC);
+    reduxActions.showToc(arrayTOC);
   }
 
   _setAttributes() {

--- a/client/elements/text/sc-text-page-selector.js
+++ b/client/elements/text/sc-text-page-selector.js
@@ -8,6 +8,7 @@ import '../addons/sc-error-icon';
 
 import { store } from '../../redux-store';
 import { LitLocalized } from '../addons/sc-localization-mixin';
+import { reduxActions } from '../addons/sc-redux-actions';
 import { API_ROOT } from '../../constants';
 import { isFallenLeaf } from '../../utils/sc-structure';
 
@@ -54,7 +55,7 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
     this.showedLanguagePrompt = store.getState().showedLanguagePrompt;
     this.siteLanguage = store.getState().siteLanguage;
     this.isLoading = false;
-    this.actions.changeLinearProgressActiveState(false);
+    reduxActions.changeLinearProgressActiveState(false);
     this.langIsoCode = store.getState().currentRoute.params.langIsoCode;
     this.authorUid = store.getState().currentRoute.params.authorUid;
     this.suttaId = store.getState().currentRoute.params?.suttaId;
@@ -169,28 +170,10 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
 
   get actions() {
     return {
-      changeToolbarTitle(title) {
-        store.dispatch({
-          type: 'CHANGE_TOOLBAR_TITLE',
-          title,
-        });
-      },
       setShowedLanguagePrompt() {
         store.dispatch({
           type: 'SET_SHOWED_LANGUAGE_PROMPT',
           showedLanguagePrompt: true,
-        });
-      },
-      setNavigation(navArray) {
-        store.dispatch({
-          type: 'SET_NAVIGATION',
-          navigationArray: navArray,
-        });
-      },
-      changeLinearProgressActiveState(active) {
-        store.dispatch({
-          type: 'CHANGE_LINEAR_PROGRESS_ACTIVE_STATE',
-          linearProgressActive: active,
         });
       },
     };
@@ -235,7 +218,7 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
       index: 99,
     });
 
-    this.actions.setNavigation(this.navArray);
+    reduxActions.setNavigation(this.navArray);
   }
 
   updated(changedProps) {
@@ -482,14 +465,14 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
 
   async _fetchSuttaText() {
     this.isLoading = true;
-    this.actions.changeLinearProgressActiveState(true);
+    reduxActions.changeLinearProgressActiveState(true);
     try {
       this.responseData = await (await fetch(this._getSuttaTextUrl())).json();
     } catch (error) {
       this.lastError = error;
     }
     this.isLoading = false;
-    this.actions.changeLinearProgressActiveState(false);
+    reduxActions.changeLinearProgressActiveState(false);
   }
 
   async _fetchBilaraText() {
@@ -497,7 +480,7 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
       return;
     }
     this.isLoading = true;
-    this.actions.changeLinearProgressActiveState(true);
+    reduxActions.changeLinearProgressActiveState(true);
     try {
       const bilaraData = await (await fetch(this._getBilaraTextUrl())).json();
       this.bilaraRootSutta = bilaraData.root_text;
@@ -512,7 +495,7 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
       this.lastError = error;
     }
     this.isLoading = false;
-    this.actions.changeLinearProgressActiveState(false);
+    reduxActions.changeLinearProgressActiveState(false);
   }
 
   _getBilaraText() {
@@ -550,13 +533,13 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
   }
 
   async _fetchExpansion() {
-    this.actions.changeLinearProgressActiveState(true);
+    reduxActions.changeLinearProgressActiveState(true);
     try {
       this.expansionReturns = await (await fetch(this._getExpansionUrl())).json();
     } catch (error) {
       this.lastError = error;
     }
-    this.actions.changeLinearProgressActiveState(false);
+    reduxActions.changeLinearProgressActiveState(false);
   }
 
   _paramChanged() {
@@ -628,7 +611,7 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
     if (!title) {
       title = this._transformId(this.suttaId, this.expansionReturns);
     }
-    this.actions.changeToolbarTitle(`${title}${author ? `—${author}` : ''}`);
+    reduxActions.changeToolbarTitle(`${title}${author ? `—${author}` : ''}`);
   }
 
   _transformId(rootId, expansionReturns) {


### PR DESCRIPTION
## Summary

In several files, delete `actions` method and replace it with existing code in `reduxActions`

## Details

The actions are static methods that don't depend on the instance, so can be shared across all components
  - the store is global too, so semantically, it doesn't make sense to have them as instance methods
  - it is also fairly common Redux pattern to have shared ["action creators"](https://redux.js.org/tutorials/fundamentals/part-7-standard-patterns#action-creators)
  
**refactor: move duplicate actions to `reduxActions`**

- `changeSuttaMetaText`, `changeSuttaPublicationInfo`, and `setStaticPagesToolbarDisplayState` are used in multiple components
  - so remove duplicate instance `actions` and move them to shared `reduxActions`
  
**clean: remove leftover unused actions**

- `TopSheetViews` has two `actions` that were created but never used: `toggleTextualInfo` and `downloadParagraphs`
  - they originate from https://github.com/suttacentral/suttacentral/commit/a67510135d0b81a37b0139309b0f87ce35203a94 (https://github.com/suttacentral/suttacentral/pull/1634#discussion_r3754125836), which created the component with unused functions
    - these seemed to have been copy+pasted from an older `SettingsMenu` component (which was removed in https://github.com/suttacentral/suttacentral/commit/68c4ebfd8e0b2cf410b4b3397dde74d3e8fb7ed7), but that one actually used these functions, while this component does not

- `TopSheetViews` also has an action that was replaced but never removed: `setReferenceDisplayType`
  - this was replaced by `setDisplayedReferences` in https://github.com/suttacentral/suttacentral/commit/f925cf3f7a2fb0a8d0bc6ea99a48f54bc197110e (https://github.com/suttacentral/suttacentral/pull/1983#discussion_r3754158674), but `setReferenceDisplayType` was not removed despite being no longer used

- `TextBilara` has an action that was created but not used as well: `chooseSegmentedSuttaTextView`
  - it was created in https://github.com/suttacentral/suttacentral/commit/f35516de7c97c48840fec01c30ed87c0d2060a6a (https://github.com/suttacentral/suttacentral/pull/1583#discussion_r3754135369), where it is not used
    
**refactor: rename setReferenceDisplayType to setDisplayedReferences**

- `setReferenceDisplayType` was the old name before there were multiple references, afaict, while `setDisplayedReferences` is the new name for the array type
  - it wasn't renamed everywhere though, so we ended up with a duplicate action that had two different names
  - remove the instance-local one in `TopSheetViews` and use the shared one in `reduxActions`
    - the instance-local one was added in https://github.com/suttacentral/suttacentral/commit/f925cf3f7a2fb0a8d0bc6ea99a48f54bc197110e, while the global one was added in https://github.com/suttacentral/suttacentral/commit/b2ac9b2959aaff8c6d9a5e27cf2365cd90d8b70f
    
## Notes to Reviewers

- If you search `actions()`, there's a few more instance methods left. I left those for now as the actions either operate on a single component or one other component, and so perhaps should be instance-local, [plus stored with `localStorage`](https://github.com/suttacentral/suttacentral/blob/b2cb0f91eed45e42c234e39ce17cdb87a2965167/client/redux-store.js#L304)
  - Some existing global actions should perhaps be converted to instance-local storage too
- #3713 cleans up some other unused actions