### PR TITLE
clean: remove unused imports in localization scripts

### DIFF
--- a/client/localization/common.py
+++ b/client/localization/common.py
@@ -1,5 +1,4 @@
 import re
-import logging
 from pathlib import Path
 
 static_elements_dir = Path('../elements/static/')
@@ -13,8 +12,7 @@ def get_locale_data_file(element_file: Path) -> Path:
     m = re.search(r"this\.localizedStringsPath = '/localization/elements/(.*?)'", string)
     if not m:
         raise ValueError(f'Could not find localizedStringPath in {element_file}')
-    
+
     name = m[1]
     filename = f'{name}_en.json'
     return name, localization_data_dir / filename
-    

--- a/client/localization/make_static_templates.py
+++ b/client/localization/make_static_templates.py
@@ -4,11 +4,12 @@ import re
 import json
 import logging
 from textwrap import TextWrapper
-from common import static_elements_dir, localization_data_dir, templates_dir, get_locale_data_file
+
+from common import static_elements_dir, templates_dir, get_locale_data_file
 
 template_regex = re.compile(r"^(.*?)(\$\{(?:unsafeHTML\()?this.localize\('(.+?:(?:\d+))'\)\)?\})", re.MULTILINE)
 
-wrapper = TextWrapper(break_long_words=False, break_on_hyphens=False, drop_whitespace=True, width=100) 
+wrapper = TextWrapper(break_long_words=False, break_on_hyphens=False, drop_whitespace=True, width=100)
 
 def main():
     for file in static_elements_dir.glob('*.js'):
@@ -19,7 +20,7 @@ def main():
 
         with locale_file.open('r', encoding='utf8') as f:
             locale_data = json.load(f)
-        
+
         with file.open('r', encoding='utf8') as f:
             string = f.read()
 
@@ -36,7 +37,7 @@ def main():
             if len(segment) <= 80 or depth > 40:
                 result = f'{prefix}${{t`{segment}`}}'
             else:
-                
+
                 wrapper.initial_indent = ' ' * depth
                 wrapper.subsequent_indent = ' ' * depth
                 parts = wrapper.wrap(segment)
@@ -45,7 +46,7 @@ def main():
                 result = f'{prefix}${{t`{segment}`}}'
 
             return result
-        
+
         new_string = template_regex.sub(sub_fn, string)
 
         with (templates_dir / file.name).open('w', encoding='utf8') as f:
@@ -53,6 +54,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-        
-
-

--- a/client/localization/unmake_static_templates.py
+++ b/client/localization/unmake_static_templates.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 
-from os import stat
 import re
 import json
 import logging
-from common import static_elements_dir, localization_data_dir, templates_dir, get_locale_data_file
 
+from common import static_elements_dir, templates_dir, get_locale_data_file
 
 
 generic_template_regex = re.compile(r'(\$\{t`)([^`]+?)(`\})')
@@ -13,7 +12,7 @@ generic_template_regex = re.compile(r'(\$\{t`)([^`]+?)(`\})')
 for file in sorted(templates_dir.glob('*.js')):
     with file.open(encoding='utf8') as f:
         string = f.read()
-    
+
     locale_name, locale_data_file = get_locale_data_file(file)
     if locale_name == 'interface':
         logging.warning(f'Not to be used with interface! {file.name}')
@@ -43,15 +42,13 @@ for file in sorted(templates_dir.glob('*.js')):
 
     with locale_data_file.open('r', encoding='utf8') as f:
         old_locale_data = json.load(f)
-    
+
     for k,v in old_locale_data.items():
         if not k.split(':')[1].isdigit():
             locale_data[k] = v
 
     with locale_data_file.open('w', encoding='utf8') as f:
         json.dump(locale_data, f, ensure_ascii=False, indent=2)
-    
+
     with (static_elements_dir / file.name).open('w', encoding='utf8') as f:
         f.write(new_string)
-
-    


### PR DESCRIPTION
## Summary

Fix some lint issues in Python scripts in `client/localization/`
- these were incidental findings from when I accidentally ran `ruff` (#3656) in the top-level directory instead of in `server/`

## Details

- the linter found some unused imports, which originate from when these scripts were created in c6e7a08fda1ea3e3aed859c5b4bb30b67de66c48 (https://github.com/suttacentral/suttacentral/pull/2309#pullrequestreview-4909251928)
  - and I fixed some whitespace issues while I was at it as well (trailing whitespace mostly)