### PR TITLE
refactor: `#updateMetaData` instead of `_createMetaData`

### DIFF
--- a/client/elements/navigation/sc-navigation.js
+++ b/client/elements/navigation/sc-navigation.js
@@ -89,7 +89,7 @@ export class SCNavigation extends LitLocalized(LitElement) {
       return;
     }
     this._setToolbarTitle();
-    this._createMetaData();
+    this.#updateMetaData();
     RefreshNavNew(this.currentUid);
   }
 
@@ -238,7 +238,7 @@ export class SCNavigation extends LitLocalized(LitElement) {
         this._updateLastSelectedItemRootLangISO(this.currentMenuData[0].root_lang_iso);
         if (params.dispatchState) {
           this._setToolbarTitle();
-          this._createMetaData();
+          this.#updateMetaData();
           if (!this._menuHasChildren() || this._isPatimokkha(this.currentMenuData[0]?.uid)) {
             dispatchCustomEvent(this, 'sc-navigate', {
               pathname: `/${params.childId}`,
@@ -284,7 +284,7 @@ export class SCNavigation extends LitLocalized(LitElement) {
     );
   }
 
-  _createMetaData() {
+  #updateMetaData() {
     if (!this.currentMenuData || this.currentMenuData.length === 0) {
       return;
     }

--- a/client/elements/sc-page-dictionary.js
+++ b/client/elements/sc-page-dictionary.js
@@ -258,7 +258,7 @@ export class SCPageDictionary extends LitLocalized(LitElement) {
           </div>
         </main>
       </div>
-      ${this._createMetaData()}
+      ${this.#updateMetaData()}
     `;
   }
 
@@ -334,7 +334,7 @@ export class SCPageDictionary extends LitLocalized(LitElement) {
       await this._fetchAdjacent();
       await this._fetchSimilar();
     }
-    
+
     this._fetchDictionary();
   }
 
@@ -439,7 +439,7 @@ export class SCPageDictionary extends LitLocalized(LitElement) {
     }
   }
 
-  _createMetaData() {
+  #updateMetaData() {
     if (!this.localize) {
       return;
     }

--- a/client/elements/sc-page-search.js
+++ b/client/elements/sc-page-search.js
@@ -1034,7 +1034,7 @@ export class SCPageSearch extends LitLocalized(LitElement) {
     super.updated(changedProps);
     if (changedProps.has('lastSearchResults')) {
       this.requestUpdate();
-      this.#createMetaData();
+      this.#updateMetaData();
     }
     const searchInput = this.shadowRoot.querySelector('#search_input');
     if (searchInput?.value === '') {
@@ -1241,7 +1241,7 @@ export class SCPageSearch extends LitLocalized(LitElement) {
     return `${API_ROOT}/expansion`;
   }
 
-  #createMetaData() {
+  #updateMetaData() {
     const description = this.localize('search:metaDescriptionText');
     const searchResultsText = this.localize('search:searchResultsText');
     const resultsFor = this.localize('search:resultsFor');

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -362,7 +362,7 @@ export class SCPageSelector extends LitLocalized(LitElement) {
 
   connectedCallback() {
     super.connectedCallback();
-    this._createMetaData();
+    this.#updateMetaData();
 
     this._changeRoute(this.router.location);
     this._stopListening = this.router.listen(({ location }) => {
@@ -449,7 +449,7 @@ export class SCPageSelector extends LitLocalized(LitElement) {
 
   updated() {
     if (this.currentRoute.name?.toUpperCase() !== 'SUTTA') {
-      this._createMetaData();
+      this.#updateMetaData();
     }
     this._updateNav();
     this._setVisibleToolbar();
@@ -593,7 +593,7 @@ export class SCPageSelector extends LitLocalized(LitElement) {
     });
   }
 
-  _createMetaData() {
+  #updateMetaData() {
     const description = this.localize('interface:metaDescriptionText');
 
     let pageName = this.tryLocalize(

--- a/client/elements/static/sc-static-search-options.js
+++ b/client/elements/static/sc-static-search-options.js
@@ -219,7 +219,7 @@ export class SCStaticSearchOptions extends SCStaticPage {
     `;
   }
 
-  #createMetaData() {
+  #updateMetaData() {
     const pageTitle = `${this.localize('search:searchOptions')}`;
 
     document.dispatchEvent(
@@ -237,7 +237,7 @@ export class SCStaticSearchOptions extends SCStaticPage {
   }
 
   firstUpdated() {
-    this.#createMetaData();
+    this.#updateMetaData();
   }
 }
 

--- a/client/elements/suttaplex/sc-suttaplex-list.js
+++ b/client/elements/suttaplex/sc-suttaplex-list.js
@@ -176,7 +176,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
         part => (this.suttaplexData = [...this.suttaplexData, ...part]),
         15,
         100
-      ).then(() => this._updateMetaData());
+      ).then(() => this.#updateMetaData());
       this.initTableView();
     } catch (e) {
       this.networkError = e;
@@ -186,7 +186,7 @@ class SCSuttaplexList extends LitLocalized(LitElement) {
     reduxActions.changeLinearProgressActiveState(this.suttaplexLoading);
   }
 
-  _updateMetaData() {
+  #updateMetaData() {
     const { suttaplexData, isSuttaInRangeSutta, categoryId, rangeCategoryId } = this;
     if (this.suttaplexData?.length) {
       const { title, original_title, blurb, acronym } = suttaplexData[0];

--- a/client/elements/text/sc-text-page-selector.js
+++ b/client/elements/text/sc-text-page-selector.js
@@ -95,7 +95,7 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
       </div>
       ${this.displayStepper}
       <sc-text-image id="sc_text_image"></sc-text-image>
-      ${this._createMetaData(this.responseData, this.expansionReturns)}
+      ${this.#updateMetaData(this.responseData, this.expansionReturns)}
     `;
   }
 
@@ -567,7 +567,7 @@ export class SCTextPageSelector extends LitLocalized(LitElement) {
     return this.lastError;
   }
 
-  _createMetaData(responseData, expansionReturns) {
+  #updateMetaData(responseData, expansionReturns) {
     if (!responseData?.translation) {
       return;
     }


### PR DESCRIPTION
## Summary

Be consistent with naming of method for updating metadata tags

## Details

- use newer private method syntax with the hash (`#`)
  - (vs. the underscore (`_`) is just an older convention with no syntactic effect)
  - some newer methods [already had](https://github.com/suttacentral/suttacentral/blob/585f9dea6258d43325b20da3a34d52e62586f262/client/elements/static/sc-static-search-options.js#L222) this - make it consistent everywhere
- "update" is more correct semantically, as the metadata tags already exist, they're just being updated
  - `SuttaplexList` [already had](https://github.com/suttacentral/suttacentral/blob/585f9dea6258d43325b20da3a34d52e62586f262/client/elements/suttaplex/sc-suttaplex-list.js#L189) this naming - make it consistent everywhere
  
## Notes to Reviewers

This doesn't include one component, `PublicationEdition`, as I have another PR (#3729) that will change that and will merge conflict otherwise