### PR TITLE
clean: remove unused `volumesMenu` variable

### DIFF
--- a/client/elements/publication/sc-publication-edition.js
+++ b/client/elements/publication/sc-publication-edition.js
@@ -54,17 +54,8 @@ export class SCPublicationEdition extends LitLocalized(LitElement) {
 
   updated(changedProps) {
     super.updated(changedProps);
-
-    this.volumesMenu = this.querySelector('#volumes-menu');
-    if (this.volumesMenu) {
-      this.volumesMenu.anchor = this.querySelector('#volumes-menu-button');
-    }
-
     if (changedProps.has('editionId') && this.editionId) {
       this.#initializeEditionData();
-    }
-    if (changedProps.has('volumesInfoForDownloadMenu')) {
-      this.requestUpdate();
     }
     this.#updateNav();
   }


### PR DESCRIPTION
## Summary

`PublicationEdition` had an unused `this.volumesMenu` variable, as well as unused logic for `volumesInfoForDownloadMenu`

## Details

- `volumesMenu` is [not used anywhere](https://github.com/search?q=repo%3Asuttacentral%2Fsuttacentral+volumesMenu&type=code)
- `volumesInfoForDownloadMenu` is similarly [never used](https://github.com/search?q=repo%3Asuttacentral%2Fsuttacentral+volumesInfo&type=code)