### PR TITLE
clean: remove unused `editionHomeInfo.root_title`

### DIFF
--- a/client/elements/menus/sc-menu-static-pages-nav.js
+++ b/client/elements/menus/sc-menu-static-pages-nav.js
@@ -9,7 +9,7 @@ export class SCMenuStaticPagesNav extends LitLocalized(LitElement) {
   static properties = {
     staticPagesToolbarDisplayState: { type: Object },
     changedRoute: { type: Object },
-    editionHome: { type: Object },
+    editionHomeInfo: { type: Object },
     editionMatters: { type: Array },
   };
 

--- a/client/elements/publication/sc-publication-edition-matter.js
+++ b/client/elements/publication/sc-publication-edition-matter.js
@@ -66,7 +66,6 @@ export class SCPublicationEditionMatter extends LitLocalized(LitElement) {
         reduxActions.changeCurrentEditionHomeInfo({
           title: this.editionDetail[0]?.translated_name?.replace('Collection', ''),
           url: `/edition/${this.editionUid}/${this.currentRoute.params.langIsoCode}/${this.currentRoute.params.authorUid}`,
-          root_title: this.editionDetail[0].root_name,
         });
       }
     } catch (error) {

--- a/client/elements/publication/sc-publication-edition.js
+++ b/client/elements/publication/sc-publication-edition.js
@@ -118,7 +118,6 @@ export class SCPublicationEdition extends LitLocalized(LitElement) {
 
   #fetchAllEditions() {
     setTimeout(() => {
-      this.allEditions = allEditions;
       this.editionId = allEditions.find(
         x => x.uid === this.editionUid && x.edition_id?.includes('web')
       )?.edition_id;
@@ -158,7 +157,6 @@ export class SCPublicationEdition extends LitLocalized(LitElement) {
         reduxActions.changeCurrentEditionHomeInfo({
           title: this.editionDetail[0]?.translated_name?.replace('Collection', ''),
           url: `/edition/${this.editionUid}/${this.currentRoute.params.langIsoCode}/${this.currentRoute.params.authorUid}`,
-          root_title: this.editionDetail[0].root_name,
         });
       }
     } catch (error) {

--- a/client/redux-store.js
+++ b/client/redux-store.js
@@ -95,7 +95,6 @@ const initialState = {
   currentEditionHomeInfo: {
     title: '',
     url: '',
-    root_title: '',
   },
   instantSearch: {
     lastUpdatedDate: '2023-09-22T00:00:00.000Z',


### PR DESCRIPTION
## Summary

The Redux store's `editionHomeInfo.root_title` property is not used, so remove it

## Details

- the `root_title` property of `editionHomeInfo` is not used
  - so remove the few times it's set and its initial state in the Redux store
  - only the [`title` and `url` are used](https://github.com/suttacentral/suttacentral/blob/585f9dea6258d43325b20da3a34d52e62586f262/client/elements/menus/sc-menu-static-pages-nav.js#L285) in the `MenuStaticPagesNav` component (c.f. https://github.com/suttacentral/suttacentral/pull/2447#pullrequestreview-4996135497)

- and fix an erroneously named property `editionHome`
  - `editionHome` is unused, while `editionHomeInfo` is used, so this seems like a typo

- also remove an unused `allEditions` variable
  - only used on that one line