### PR TITLE
security(api): only allow `suttacentral/editions` repo to be fetched

### DIFF
--- a/server/src/api/views/views.py
+++ b/server/src/api/views/views.py
@@ -1850,6 +1850,8 @@ class GitHubDirectoryListing(Resource):
                 return {'error': 'Invalid GitHub repository URL'}, 422
 
             owner, repo = repo_info
+            if owner != 'suttacentral' or repo != 'editions':
+                return {'error': 'Disallowed GitHub repository URL'}, 403
 
             api_url = f"https://api.github.com/repos/{owner}/{repo}/contents"
             if path:


### PR DESCRIPTION
## Summary

Allowlist `suttacentral/editions` repo in the `GitHubDirectoryListing` API

## Details

- without this, anyone could hit this _unauthenticated_ API and retrieve the contents of any repo
  - and if a key were provided (such as in the server's env variables to increase rate limits), that could include any private repos (if the key is not properly scoped)
  - this makes it ripe for being used by bots to hide their tracks, IPs, etc

## Future Work

- [ ] honestly, this entire API is far too broad and unnecessary
  - for its original purpose from eaa97910918a5bae2fa3071bd3ddbc49c1135cc4 (c.f. https://github.com/suttacentral/suttacentral/pull/3505#discussion_r3813256875 + original [forum thread](https://discourse.suttacentral.net/t/editions-pdf-links-not-working/34034/36?u=agilgur5)), to not need to hardcode edition dates in the front-end, one could instead:
    1. use a symlink
    2. fetch the [`last_run_date` file](https://github.com/suttacentral/editions/blob/0d8b363343771ce51767caca91b2780d99edde41/last_run_date) and parse the date from there (similar to, but more complete than https://github.com/suttacentral/suttacentral/pull/2582)
    3. pull from the short-hand `latest` release (i.e. https://github.com/suttacentral/editions/releases/latest)
    - then no need for an API at all, can be dynamically done in the front-end (similar to what Ven. @khemarato suggested [in the thread](https://discourse.suttacentral.net/t/editions-pdf-links-not-working/34034/26?u=agilgur5))
