### PR TITLE
fix: don't `fetchMatter` on every route change

### DIFF
--- a/client/elements/menus/sc-menu-static-pages-nav.js
+++ b/client/elements/menus/sc-menu-static-pages-nav.js
@@ -53,8 +53,6 @@ export class SCMenuStaticPagesNav extends LitLocalized(LitElement) {
     }
     if (this.changedRoute !== state.currentRoute) {
       this.changedRoute = state.currentRoute;
-      this._fetchMatter();
-      this.requestUpdate();
     }
     if (this.editionHomeInfo !== state.currentEditionHomeInfo) {
       this.editionHomeInfo = state.currentEditionHomeInfo;


### PR DESCRIPTION
## Summary

The `MenuStaticPagesNav` component was incorrectly fetching Edition files on _every page load_
  - meanwhile it only needs this for a few menus inside Edition pages (and some of those persist between route changes too)
  
## Details
- remove the incorrect fetch
- directly below this removed conditional, it already fetches [when `editionHomeInfo` changes](https://github.com/suttacentral/suttacentral/blob/585f9dea6258d43325b20da3a34d52e62586f262/client/elements/menus/sc-menu-static-pages-nav.js#L61)
  - which only happens on Edition pages; no need to do this twice nor on other pages

- the `requestUpdate()` is also unnecessary as `changedRoute` is a [reactive property](https://lit.dev/docs/components/properties/), so any change to it will already trigger an update

## History

This seems to originate from https://github.com/suttacentral/suttacentral/pull/2447#discussion_r3826679603, which has both the correct and incorrect code in it, so perhaps due to incorrect clean-up and checks after iteration

## Verification

Testing locally with DevTools's Network Tab open, I no longer get a `files` API endpoint request on every page load
- and I still get the correct menus on Edition pages

## Future Work
- [ ] this should probably be further optimized to only `fetchMatter` once across components, i.e. this one and `PublicationEditionMatter` of #3725 
  - currently the same data is fetched by both components during the same page load (i.e. duplicate network requests in the component tree)