### PR TITLE
fix: only `fetchMatter` once in `EditionMatter` component

### DIFF
--- a/client/elements/publication/sc-publication-edition-matter.js
+++ b/client/elements/publication/sc-publication-edition-matter.js
@@ -13,7 +13,7 @@ import { allEditions } from './sc-publication-common';
 export class SCPublicationEditionMatter extends LitLocalized(LitElement) {
   static properties = {
     matter: { type: String },
-    matterContent: { type: Object },
+    editionFiles: { type: Object },
   };
 
   static styles = [
@@ -78,19 +78,15 @@ export class SCPublicationEditionMatter extends LitLocalized(LitElement) {
     await this.#fetchMatter();
     await this.#fetchEditionDetails();
     await this.#fetchEditionInfo();
-    this.requestUpdate();
   }
 
   stateChanged(state) {
     super.stateChanged(state);
-    if (this.changedRoute !== state.currentRoute) {
-      this.changedRoute = state.currentRoute;
-      this.matter = store.getState().currentRoute.params.matter;
-      if (!this.matter) {
-        return;
-      }
-      this.#fetchMatter();
+    const matter = state.currentRoute.params.matter;
+    if (!matter || matter === this.matter) {
+      return;
     }
+    this.matter = matter;
   }
 
   #updateNav() {
@@ -118,14 +114,20 @@ export class SCPublicationEditionMatter extends LitLocalized(LitElement) {
       this.editionFiles = await (
         await fetch(`${API_ROOT}/publication/edition/${this.editionId}/files`)
       ).json();
-      for (const key in this.editionFiles) {
-        if (Object.hasOwn(this.editionFiles, key) && key.includes(this.matter.toLowerCase())) {
-          this.matterContent = this.editionFiles[key];
-        }
-      }
-      this.requestUpdate();
     } catch (error) {
       console.error(error);
+    }
+  }
+
+  #renderMatter() {
+    if (!this.matter || !this.editionFiles) {
+      return;
+    }
+
+    for (const key in this.editionFiles) {
+      if (Object.hasOwn(this.editionFiles, key) && key.includes(this.matter.toLowerCase())) {
+        return this.editionFiles[key];
+      }
     }
   }
 
@@ -134,7 +136,8 @@ export class SCPublicationEditionMatter extends LitLocalized(LitElement) {
   }
 
   render() {
-    if (!this.matterContent) {
+    const matterContent = this.#renderMatter();
+    if (!matterContent) {
       return html``;
     }
     return html`
@@ -143,7 +146,7 @@ export class SCPublicationEditionMatter extends LitLocalized(LitElement) {
         ${typographyStaticStyles}
         ${SCPublicationStyles}
       </style>
-      <main>${unsafeHTML(this.matterContent)}</main>
+      <main>${unsafeHTML(matterContent)}</main>
     `;
   }
 }


### PR DESCRIPTION
## Summary

The `PublicationEditionMatter` component was fetching Edition files _every_ time the `matter` changed, even though the files already contain _all_ the front matter.
- Similar to #3724, but for a different component and a bit different routing 

## Details

- the `files` API route returns _all_ front matter files for an Edition
  - so there's no need to re-fetch when the specific file changes in the route
- split out the rendering / derivation of the specific file from the fetching as well
  - so can re-render the content without re-fetching
  - also change the properties a bit so `editionFiles` is reactive, while `matterContent` is purely derived
    - (IMO, this is more intuitive with tooling that has computed/derived observables, [like Signals](https://lit.dev/docs/data/signals/))
- no need to `requestUpdate` as `this.matter` etc are [reactive properties](https://lit.dev/docs/components/properties/)

## Verification

Testing locally with DevTools's Network Tab open, I no longer get a `files` API endpoint request whenever the `matter` changes
- and I still get the correct content for Edition front matter pages

## Future Work
- [x] testing these pages a bunch led me to discover another bug with the toolbar title being set to blank, c.f. https://github.com/suttacentral/suttacentral/pull/3023#discussion_r3834867169
   - ✅ Fixed in #3726
- [ ] this should be further optimized to only `fetchMatter` once across components, i.e. this one and `MenuStaticPagesNav` of #3724 
  - currently the same data is fetched by both components during the same page load (i.e. duplicate network requests in the component tree)
- [ ] Signals are a lot more ergonomic, so I'd honestly recommend replacing both Redux and local state with them
  - the main difference between local and shared state in Signals is whether the signal is exported -- pretty straightforward/intuitive IMO