### PR TITLE
fix: don't set the toolbar title to `''` for `EditionMatter` pages

### DIFF
--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -676,6 +676,11 @@ export class SCPageSelector extends LitLocalized(LitElement) {
   }
 
   _changeToolbarTitle() {
+    // the `PublicationEditionMatter` component changes its own title
+    if (this.currentRoute.name === 'publicationEditionMatter') {
+      return;
+    }
+
     const titleMap = {
         'search': this.localize('interface:searchResults'),
         'define': this.localize('interface:dictionaryResults'),
@@ -683,7 +688,6 @@ export class SCPageSelector extends LitLocalized(LitElement) {
         'navigation': '',
         'suttaplex': '',
         'sutta': '',
-        'publicationEditionMatter': '',
         'palitipitaka': 'Pāḷi Tipiṭaka',
         'searchFilter': 'Search Filter',
         'pirivena-project': 'SuttaCentral Translations For Pirivenas',

--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -676,8 +676,8 @@ export class SCPageSelector extends LitLocalized(LitElement) {
   }
 
   _changeToolbarTitle() {
-    // the `PublicationEditionMatter` component changes its own title
-    if (this.currentRoute.name === 'publicationEditionMatter') {
+    // these components change their own titles
+    if (['navigation', 'suttaplex', 'sutta', 'publicationEditionMatter'].includes(this.currentRoute.name)) {
       return;
     }
 
@@ -685,9 +685,6 @@ export class SCPageSelector extends LitLocalized(LitElement) {
         'search': this.localize('interface:searchResults'),
         'define': this.localize('interface:dictionaryResults'),
         'home': 'SuttaCentral',
-        'navigation': '',
-        'suttaplex': '',
-        'sutta': '',
         'palitipitaka': 'Pāḷi Tipiṭaka',
         'searchFilter': 'Search Filter',
         'pirivena-project': 'SuttaCentral Translations For Pirivenas',


### PR DESCRIPTION
## Summary

The `PageSelector` component was erroneously changing the toolbar title to blank on certain pages which already set their own title, causing subtle bugs for the `PublicationEditionMatter` pages and others

## Details 

- the `PublicationEditionMatter` pages only need to set the title once, as it is the same for each front matter file rendered, but `PageSelector` was resetting it to `''` whenever the route changed
- and they [already set their title](https://github.com/suttacentral/suttacentral/blob/585f9dea6258d43325b20da3a34d52e62586f262/client/elements/publication/sc-publication-edition-matter.js#L62), no need for it to be set in this component too
- the logic was correct in the original Editions UI code (#2447), but erroneously changed later in https://github.com/suttacentral/suttacentral/commit/da0a2914742a0fddd0e6eebe84ecffaeebace779 (see https://github.com/suttacentral/suttacentral/pull/3023#discussion_r3834867169)

### Further Changes

Followed up and fixed this for a few other components that similarly set their own titles: [`Navigation`](https://github.com/suttacentral/suttacentral/blob/585f9dea6258d43325b20da3a34d52e62586f262/client/elements/navigation/sc-navigation.js#L276), [`SuttaplexList`](https://github.com/suttacentral/suttacentral/blob/585f9dea6258d43325b20da3a34d52e62586f262/client/elements/suttaplex/sc-suttaplex-list.js#L203), and [`TextPageSelector`](https://github.com/suttacentral/suttacentral/blob/585f9dea6258d43325b20da3a34d52e62586f262/client/elements/text/sc-text-page-selector.js#L614)
- These did not have visible errors as they always overwrote the blank title from `PageSelector`, but this was still a subtle bug that could pop up in the future, so might as well fix it while I'm modifying this code already

## Verification

Tested locally, screenshots:
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img width="557" height="448" alt="Screenshot 2026-08-21 at 11 15 07 PM" src="https://github.com/user-attachments/assets/89cbb530-2d41-496c-9096-e77a5704c620" />
    </td>
    <td>
      <img width="555" height="448" alt="Screenshot 2026-08-21 at 11 15 16 PM" src="https://github.com/user-attachments/assets/91eb7774-0999-471b-95e0-511be765a117" />
    </td>
  </tr>
</table>
