### PR TITLE
clean: remove unused imports in `publication-common`

### DIFF
--- a/client/elements/publication/sc-publication-common.js
+++ b/client/elements/publication/sc-publication-common.js
@@ -1,6 +1,4 @@
 import { API_ROOT } from '../../constants';
-import { reduxActions } from '../addons/sc-redux-actions';
-import { store } from '../../redux-store';
 
 export const coverImage = new Map([
   ['dn', 'dn-book.jpg'],


### PR DESCRIPTION
## Summary

`reduxActions` and `store` are unused imports within the `publication-common.js` file

## Details

- they were added in 457658359d9663c452fbf3f386cb48ce0fa20c0b, but the code that used it moved outside of it in 1cba1691af43be7f966b211cdba0908e4ecd5b15
  - and these imports were never cleaned up
  - these two commits were part of the same PR, c.f. https://github.com/suttacentral/suttacentral/pull/2556#discussion_r3837229208