### PR TITLE
refactor: don't use `__resources` directly

### DIFF
--- a/client/elements/sc-page-selector.js
+++ b/client/elements/sc-page-selector.js
@@ -692,11 +692,7 @@ export class SCPageSelector extends LitLocalized(LitElement) {
     let title = titleMap[this.currentRoute.name];
     if (title === undefined) {
         const key = `interface:${this.currentRoute.name}Title`;
-        if (this.__resources[key]) {
-            title = this.localize(key);
-        } else {
-            title = '';
-        }
+        title = this.tryLocalize(key, '');
     }
 
     reduxActions.changeToolbarTitle(title);


### PR DESCRIPTION
## Summary

Use `this.tryLocalize` instead of `this.__resources` in the `PageSelector`
- this is the only place other than the localization mixin itself that used `__resources`

## Details

- per the naming convention, `__resources` is supposed to be private and only used within the `LitLocalized` mixin
- use `tryLocalize` instead, which encapsulates this logic

## History
- this logic originates from b7ba39c7d3bfb8041b32b950cf17364834718b74, which was ~8 months before the `tryLocalize` function was created in 242e81e9057d6c5e082bc79d32efcf0fb5fc4bed