### PR TITLE
fix: improve metadata of Edition pages

### DIFF
--- a/client/elements/publication/sc-publication-edition-matter.js
+++ b/client/elements/publication/sc-publication-edition-matter.js
@@ -132,10 +132,12 @@ export class SCPublicationEditionMatter extends LitLocalized(LitElement) {
   }
 
   #updateMetaData() {
-    const description = `${this.editionDetail?.[0].root_name} — ${this.editionInfo?.publication?.creator_name} - ${this.matter}`;
+    const title = `${this.editionDetail?.[0].root_name} — ${this.editionInfo?.publication?.creator_name} - ${this.matter}`;
+    const doc = new DOMParser().parseFromString(this.matterContent, 'text/html');
+    const description = doc.querySelector('h1').textContent;
     dispatchCustomEvent(document, 'metadata', {
-      pageTitle: description,
-      title: description,
+      pageTitle: title,
+      title,
       description,
     });
   }

--- a/client/elements/publication/sc-publication-edition-matter.js
+++ b/client/elements/publication/sc-publication-edition-matter.js
@@ -8,6 +8,7 @@ import { SCPublicationStyles } from '../styles/sc-publication-styles';
 import { typographyCommonStyles } from '../styles/sc-typography-common-styles';
 import { typographyStaticStyles } from '../styles/sc-typography-static-styles';
 import { store } from '../../redux-store';
+import { dispatchCustomEvent } from '../../utils/customEvent';
 import { allEditions } from './sc-publication-common';
 
 export class SCPublicationEditionMatter extends LitLocalized(LitElement) {
@@ -130,6 +131,15 @@ export class SCPublicationEditionMatter extends LitLocalized(LitElement) {
     }
   }
 
+  #updateMetaData() {
+    const description = `${this.editionDetail?.[0].root_name} — ${this.editionInfo?.publication?.creator_name} - ${this.matter}`;
+    dispatchCustomEvent(document, 'metadata', {
+      pageTitle: description,
+      title: description,
+      description,
+    });
+  }
+
   createRenderRoot() {
     return this;
   }
@@ -146,6 +156,7 @@ export class SCPublicationEditionMatter extends LitLocalized(LitElement) {
         ${SCPublicationStyles}
       </style>
       <main>${unsafeHTML(matterContent)}</main>
+      ${this.#updateMetaData()}
     `;
   }
 }

--- a/client/elements/publication/sc-publication-edition.js
+++ b/client/elements/publication/sc-publication-edition.js
@@ -256,12 +256,12 @@ export class SCPublicationEdition extends LitLocalized(LitElement) {
     return this.publicationDownloadUrls[type];
   }
 
-  _createMetaData() {
-    const description = `${this.editionDetail[0].root_name} — ${this.editionInfo.publication?.creator_name}`;
+  #updateMetaData() {
+    const title = `${this.editionDetail[0].root_name} — ${this.editionInfo.publication?.creator_name}`;
     dispatchCustomEvent(document, 'metadata', {
-      pageTitle: description,
-      title: description,
-      description,
+      pageTitle: title,
+      title,
+      description: this.editionDetail[0].blurb,
     });
   }
 
@@ -518,7 +518,7 @@ export class SCPublicationEdition extends LitLocalized(LitElement) {
           <section>${this.#publicationDetailTemplate()}</section>
         </article>
       </main>
-      ${this._createMetaData()}
+      ${this.#updateMetaData()}
     `;
   }
 }


### PR DESCRIPTION
## Summary

Ensure `Edition` and `EditionMatter` pages have a unique title and description

## Details

#### fix: `EditionMatter` pages should have proper metadata

- per my own [forum bug report](https://discourse.suttacentral.net/t/suttacentral-bug-reports/27763/340?u=agilgur5), these pages had a title of `publicationEditionMatter—SuttaCentral` and the site-wide default `meta` `description`
  - this generic metadata originates from [the `PageSelector` component](https://github.com/suttacentral/suttacentral/blob/585f9dea6258d43325b20da3a34d52e62586f262/client/elements/sc-page-selector.js#L608)
  - they should have their own metadata, similar to the fix for a prior bug report: https://github.com/suttacentral/suttacentral/commit/a685b5d3e6959016ade235203ba70536720f5951 (#3492)
    - this is nearly the same metadata as the `Edition` page, but with ` - ${this.matter}` following it to differentiate and define the page

- use `#updateMetaData` to be properly private and more semantically correct than `create`, [following `SuttaplexList`](https://github.com/suttacentral/suttacentral/blob/585f9dea6258d43325b20da3a34d52e62586f262/client/elements/suttaplex/sc-suttaplex-list.js#L189) and a recent PR of mine (#3718)
      
#### fix: use the Edition `blurb` for `description` metadata

- Editions have blurbs, so that can be used for the metadata to give a unique description
  - instead of duplicating the title into the description

- also use `#updateMetaData` instead of `_createMetaData` per previous commit and my other PR

#### fix: use the `EditionMatter` `h1` for `description` metadata

- pull out the text of the `h1` (that [each Edition front matter file has](https://github.com/suttacentral/bilara-data/blob/548765d7eb515e3dc47eb92f3f0057ef3c0456b4/_publication/en/brahmali/editions/vinaya/pli-tv-vi/matter/foreword.html#L2)) to use as a unique description
  - instead of duplicating the title in the description
  
## Verification

Tested locally and made sure the `title` and `meta` `description` updated properly for the Vinaya main page and front matter pages

## Future Work
- [ ] `${this.matter}` is an abbreviation/path/ID, so not ideal, but a good first start IMO
- [ ] the `EditionMatter` description could be longer, potentially pulling from the first `p` instead, but that is a lot less consistent than the heading
  - for now, I think this the approach in this PR is a good bit better than before