### PR TITLE
fix: do not generate `<span>` tags when the variant is blank.

### DIFF
--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -1081,7 +1081,7 @@ export class SCTextBilara extends SCTextCommon {
     }
     Object.entries(this.suttaVariant).forEach(([key, value]) => {
       const rootSpan = this.querySelector(`#${CSS.escape(key)} .root`);
-      if (rootSpan) {
+      if (rootSpan && value) {
         rootSpan.appendChild(this._addVariantSpan(value));
       }
     });


### PR DESCRIPTION
This issue was caused by the recent addition of aligned segment IDs to some JSON files.