### PR TITLE
fix: correctly set initial state of references in `TextLegacy`

### DIFF
--- a/client/elements/text/sc-text-bilara.js
+++ b/client/elements/text/sc-text-bilara.js
@@ -884,9 +884,9 @@ export class SCTextBilara extends SCTextCommon {
     }
   }
 
-  buildReferences(referenceDisplayTypeArray) {
-    return Array.isArray(referenceDisplayTypeArray)
-      ? referenceDisplayTypeArray.reduce((acc, edition_set) => acc + edition_set, '')
+  buildReferences(displayedReferences) {
+    return Array.isArray(displayedReferences)
+      ? displayedReferences.reduce((acc, edition_set) => acc + edition_set, '')
       : '';
   }
 

--- a/client/elements/text/sc-text-legacy.js
+++ b/client/elements/text/sc-text-legacy.js
@@ -38,7 +38,7 @@ export class SCTextLegacy extends SCTextCommon {
     localizedStringsPath: { type: String },
     inputElement: { type: Object },
     showHighlighting: { type: Boolean },
-    chosenReferenceDisplayType: { type: String },
+    chosenReferenceDisplayType: { type: Array },
     navItems: { type: Array },
   };
 
@@ -56,7 +56,7 @@ export class SCTextLegacy extends SCTextCommon {
     this.spansForGraphsGenerated = false;
     this.isChineseLookupEnabled = textOptionsState.chineseLookupActivated;
     this.showHighlighting = textOptionsState.showHighlighting;
-    this.chosenReferenceDisplayType = textOptionsState.referenceDisplayType;
+    this.chosenReferenceDisplayType = textOptionsState.displayedReferences;
     this.textualInfoClassTitles = {
       gloss: 'Definition of term.',
       add: 'Text added by the editor or translator for clarification',
@@ -664,13 +664,10 @@ export class SCTextLegacy extends SCTextCommon {
   _setTextViewState() {
     const highlight = getURLParam('highlight');
     const reference = getURLParam('reference');
-    const { textOptions } = store.getState();
 
     if (highlight && ['true', 'false'].includes(highlight.toLowerCase())) {
       this.showHighlighting = highlight === 'true';
       reduxActions.setShowHighlighting(highlight === 'true');
-    } else {
-      this.showHighlighting = textOptions.showHighlighting;
     }
 
     if (reference) {
@@ -695,8 +692,6 @@ export class SCTextLegacy extends SCTextCommon {
           }
         })
         .catch(e => console.error(e));
-    } else {
-      this.chosenReferenceDisplayType = textOptions.displayedReferences;
     }
   }
 }

--- a/client/elements/text/sc-text-legacy.js
+++ b/client/elements/text/sc-text-legacy.js
@@ -38,7 +38,7 @@ export class SCTextLegacy extends SCTextCommon {
     localizedStringsPath: { type: String },
     inputElement: { type: Object },
     showHighlighting: { type: Boolean },
-    chosenReferenceDisplayType: { type: Array },
+    displayedReferences: { type: Array },
     navItems: { type: Array },
   };
 
@@ -56,7 +56,7 @@ export class SCTextLegacy extends SCTextCommon {
     this.spansForGraphsGenerated = false;
     this.isChineseLookupEnabled = textOptionsState.chineseLookupActivated;
     this.showHighlighting = textOptionsState.showHighlighting;
-    this.chosenReferenceDisplayType = textOptionsState.displayedReferences;
+    this.displayedReferences = textOptionsState.displayedReferences;
     this.textualInfoClassTitles = {
       gloss: 'Definition of term.',
       add: 'Text added by the editor or translator for clarification',
@@ -157,8 +157,8 @@ export class SCTextLegacy extends SCTextCommon {
       this._showHighlightingChanged();
       this._updateURLSearchParams();
     }
-    if (changedProps.has('chosenReferenceDisplayType')) {
-      this._referenceDisplayTypeChanged();
+    if (changedProps.has('displayedReferences')) {
+      this._displayedReferencesChanged();
       this._updateURLSearchParams();
     }
   }
@@ -183,8 +183,8 @@ export class SCTextLegacy extends SCTextCommon {
     }
   }
 
-  _referenceDisplayTypeChanged() {
-    if (this.chosenReferenceDisplayType.includes('main')) {
+  _displayedReferencesChanged() {
+    if (this.displayedReferences.includes('main')) {
       this._articleElement().forEach(article => {
         article.classList.add('legacy-reference');
       });
@@ -207,8 +207,8 @@ export class SCTextLegacy extends SCTextCommon {
     if (this.showHighlighting !== textOptionsState.showHighlighting) {
       this.showHighlighting = textOptionsState.showHighlighting;
     }
-    if (this.chosenReferenceDisplayType !== textOptionsState.displayedReferences) {
-      this.chosenReferenceDisplayType = textOptionsState.displayedReferences;
+    if (this.displayedReferences !== textOptionsState.displayedReferences) {
+      this.displayedReferences = textOptionsState.displayedReferences;
     }
   }
 
@@ -219,7 +219,7 @@ export class SCTextLegacy extends SCTextCommon {
     reduxActions.changeSuttaMetaText(this._computeMeta());
     this._loadingChanged();
     this._showHighlightingChanged();
-    this._referenceDisplayTypeChanged();
+    this._displayedReferencesChanged();
     this._chineseLookupStateChanged();
     this.navItems = this._prepareNavigation();
     setTimeout(() => {
@@ -687,7 +687,7 @@ export class SCTextLegacy extends SCTextCommon {
           }
           // eslint-disable-next-line promise/always-return
           if (paramReference.length > 0) {
-            this.chosenReferenceDisplayType = paramReference;
+            this.displayedReferences = paramReference;
             reduxActions.setDisplayedReferences(paramReference);
           }
         })


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/suttacentral/suttacentral/commit/e8115b054e23b9bdc4f83d6fffa4abeff42ba0b0 (part of #3714), where I updated the old name of singular `referenceDisplayType` to plural `displayedReferences` in actions
- this updates other places where the old name was used as a property

## Details

**fix: correctly set initial state of references in `TextLegacy`**
- ensure the constructor correctly sets the initial state and remove the now duplicative override [in `_setTextViewState`](https://github.com/suttacentral/suttacentral/blob/59e3cef3a87644e9f162c815d29d2a35461d04cc/client/elements/text/sc-text-legacy.js#L699)
  - the `showHighlighting` `else` is also not necessary as it is already set that way in the constructor
- also correctly set the property `type` to `Array`

**refactor: rename `chosenReferenceDisplayType` to `displayedReferences` in `TextLegacy`**
- make it clear that this is currently a plural, array type, and no longer a singular string type
- match the name of the state for consistency
- match `TextBilara`
  - also update the one spot where `TextBilara` had a different name
  
## Notes to Reviewers

This does not change [`referenceDisplayType` in `TopSheetViews`](https://github.com/suttacentral/suttacentral/blob/59e3cef3a87644e9f162c815d29d2a35461d04cc/client/elements/addons/sc-top-sheet-views.js#L413) as that one is used differently -- either singular for a single checkbox or to fetch all _available_ display types (vs. the _state_ of checked display types)