### PR TITLE
clean: auto-remove unused imports in new tests with `ruff`

### DIFF
--- a/server/tests/common/test_arangodb.py
+++ b/server/tests/common/test_arangodb.py
@@ -1,13 +1,11 @@
 from typing import Generator
 
 import pytest
-from arango import ArangoClient, DocumentInsertError, Response
+from arango import ArangoClient, DocumentInsertError
 from arango.collection import StandardCollection
 from arango.database import Database, StandardDatabase
-from arango.request import Request
 
 from common import arangodb
-from common.arangodb import explain_error
 from common.utils import app_context
 
 

--- a/server/tests/data_loader/test_changetracker.py
+++ b/server/tests/data_loader/test_changetracker.py
@@ -1,5 +1,4 @@
 import pytest
-from arango.database import Database
 
 import common.utils
 from common import arangodb


### PR DESCRIPTION
## Summary

The new `ruff check` lint in CI [detected](https://github.com/suttacentral/suttacentral/actions/runs/33345650270/job/99349130606) these in some older PRs that were recently merged (i.e. those PRs' original branches hadn't yet run `ruff`)

## Details

- from https://github.com/suttacentral/suttacentral/commit/3e78847a584dce96623b1be4fa1872351865d32c (https://github.com/suttacentral/suttacentral/pull/3623#pullrequestreview-5103777195):
    ```
    F401 [*] `arango.Response` imported but unused
    --> tests/common/test_arangodb.py:4:55
      |
    3 | import pytest
    4 | from arango import ArangoClient, DocumentInsertError, Response
      |                                                       ^^^^^^^^
    5 | from arango.collection import StandardCollection
    6 | from arango.database import Database, StandardDatabase
      |
    help: Remove unused import: `arango.Response`

    F401 [*] `arango.request.Request` imported but unused
    --> tests/common/test_arangodb.py:7:28
      |
    5 | from arango.collection import StandardCollection
    6 | from arango.database import Database, StandardDatabase
    7 | from arango.request import Request
      |                            ^^^^^^^
    8 |
    9 | from common import arangodb
      |
    help: Remove unused import: `arango.request.Request`

    F401 [*] `common.arangodb.explain_error` imported but unused
      --> tests/common/test_arangodb.py:10:29
      |
    9 | from common import arangodb
    10 | from common.arangodb import explain_error
      |                             ^^^^^^^^^^^^^
    11 | from common.utils import app_context
      |
    help: Remove unused import: `common.arangodb.explain_error`
    ```
    
- from https://github.com/suttacentral/suttacentral/commit/59e3cef3a87644e9f162c815d29d2a35461d04cc (https://github.com/suttacentral/suttacentral/pull/3619#discussion_r3926064251):
    ```
    F401 [*] `arango.database.Database` imported but unused
    --> tests/data_loader/test_changetracker.py:2:29
      |
    1 | import pytest
    2 | from arango.database import Database
      |                             ^^^^^^^^
    3 |
    4 | import common.utils
      |
    help: Remove unused import: `arango.database.Database`
    ```
 
- remove all 4 unused imports

## Verification

`lint` has no errors and passes now


<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/suttacentral/suttacentral/pull/3735?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->

<!-- gk-ai-analysis-start:b5798cd12708f33edb2c4e59d2d5c277b64dd259 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiUmVtb3ZlIHVudXNlZCBpbXBvcnRzIGluIHRlc3QgZmlsZXMgdG8gcmVzb2x2ZSBSdWZmIGxpbnRlciBlcnJvcnMuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiUmVtb3ZlZCB1bnVzZWQgaW1wb3J0cyBpbiBjb21tb24gdGVzdHMiLCJkZXNjcmlwdGlvbiI6IlJlbW92ZWQgYFJlc3BvbnNlYCwgYFJlcXVlc3RgLCBhbmQgYGV4cGxhaW5fZXJyb3JgIGltcG9ydHMgd2hpY2ggd2VyZSBub3QgdXNlZCBpbiBgdGVzdF9hcmFuZ29kYi5weWAuIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6InNlcnZlci90ZXN0cy9jb21tb24vdGVzdF9hcmFuZ29kYi5weSIsImxpbmVTdGFydCI6NH0seyJ0aXRsZSI6IlJlbW92ZWQgdW51c2VkIGltcG9ydCBpbiBjaGFuZ2UgdHJhY2tlciB0ZXN0cyIsImRlc2NyaXB0aW9uIjoiUmVtb3ZlZCB0aGUgdW51c2VkIGBEYXRhYmFzZWAgaW1wb3J0IGZyb20gYHRlc3RfY2hhbmdldHJhY2tlci5weWAuIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6InNlcnZlci90ZXN0cy9kYXRhX2xvYWRlci90ZXN0X2NoYW5nZXRyYWNrZXIucHkiLCJsaW5lU3RhcnQiOjF9XSwiaXNzdWVzIjpbXSwic3VnZ2VzdGlvbnMiOltdLCJzZWN1cml0eSI6W119 -->
<!-- gk-ai-analysis-end:b5798cd12708f33edb2c4e59d2d5c277b64dd259 -->