### PR TITLE
clean(docs): remove outdated `Polymer` reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,15 +199,13 @@ class InitialMigration(Migration):
 
 - Use [ES6 fat arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
 
-- Use [ES6 classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) (`class MyElement extends Polymer.Element`) instead of the old `Polymer({...})` syntax when declaring an element inside your \<script> tags.
-
 - Use `const`/`let` instead of `var` when declaring a variable.
 
 - Use `===` and `!==` instead of `==` and `!=` when comparing values to avoid [type coercion](http://webreflection.blogspot.com/2010/10/javascript-coercion-demystified.html).
 
 - Comments explaining a function's purpose should be written on the line directly above the function declaration.
 
-- Internal HTML imports should come after external ones (from bower_components) and be separated by a newline.
+- Internal imports should come after external ones (from `node_modules`) and be separated by a newline.
 
 - When commenting Components at the top-level (above `<dom-module>`), keep HTML comment tags (`\<!--` & `-->`) on their own separate lines.
 


### PR DESCRIPTION
## Summary

The `README` had an outdated reference to Polymer that was no longer necessary

## Details

- Polymer was superseded by Lit years ago, so this line is no longer relevant
- also update the line about imports to be current:
  - `node_modules` instead of `bower_components` and imports in JS, not HTML

- See also e13cfba45da9eb507b754ae11fef84512cca25a7 (part of #1285), 5fde1bb1cca809ad310a39053e1c4436e997618b (#1973), etc

## Future Work

- [ ] The rest of this Style Guide should be replaced with automatic linting and formatting with ESLint (#3572), Prettier, et al