### PR TITLE
clean: remove unused `paliScripts` property

### DIFF
--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -33,7 +33,6 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
     paliLookupLanguage: { type: String },
     chineseLookupArray: { type: Array },
     chineseLookupLanguage: { type: String },
-    paliScripts: { type: Array },
     paliScript: { type: String },
     textualInfoToggleEnabled: { type: Boolean },
     textualInfoResponse: { type: Object },


### PR DESCRIPTION
## Summary

Remove an unused property from the `TopSheetViews` component

## Details

In 531ba0a817ffc1daa48ab894c829650d0208c1ba (https://github.com/suttacentral/suttacentral/pull/1878#discussion_r3936737102), it was replaced with the `scriptIdentifiers` constant and no longer used since then