### PR TITLE
refactor: use declarative style for Pali script selection

### DIFF
--- a/client/elements/addons/sc-top-sheet-views.js
+++ b/client/elements/addons/sc-top-sheet-views.js
@@ -296,7 +296,6 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
     }
     if (this.paliScript !== state.textOptions.script) {
       this.paliScript = state.textOptions.script;
-      this.#setPaliScriptSelected();
     }
     const currentReferences = this.buildReferences(this.displayedReferences);
     const incomingReferences = this.buildReferences(state.textOptions.displayedReferences);
@@ -660,10 +659,10 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
               <p>${this.localize('viewoption:changePaliScriptDescription')}</p>
             </details>
             <div class="form-controls">
-              <select id="selPaliScripts">
+              <select id="selPaliScripts" @change=${this._onPaliScriptChanged}>
                 ${scriptIdentifiers.map(
                   script => html`
-                    <option value=${script.script}>
+                    <option value=${script.script} ?selected=${script.script === this.paliScript}>
                       ${script.language}
                     </option>
                   `
@@ -872,10 +871,6 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
   }
 
   firstUpdated() {
-    this.shadowRoot
-      .querySelector('#selPaliScripts')
-      .addEventListener('change', this._onPaliScriptChanged);
-    this.#setPaliScriptSelected();
     this._keydownHandlers = {
       'm': this._handleMKeydown.bind(this),
       'M': this._handleMKeydown.bind(this),
@@ -889,19 +884,6 @@ export class SCTopSheetViews extends LitLocalized(LitElement) {
       'V': this._handleVKeydown.bind(this),
     };
     document.addEventListener('keydown', this._handleKeydown.bind(this));
-  }
-
-  #setPaliScriptSelected() {
-    const paliScriptSelect = this.shadowRoot.querySelector('#selPaliScripts');
-    if (!paliScriptSelect) {
-      return;
-    }
-    for (const option of paliScriptSelect.options) {
-      if (option.value === this.paliScript) {
-        option.selected = true;
-        break;
-      }
-    }
   }
 
   _onRootOrderChanged(e) {


### PR DESCRIPTION
## Summary

Use declarative style for the `TopSheetViews`'s component's Pali script selector dropdown


## Details
- the `select` dropdown was using an imperative style with substantially more code instead of following the declarative component style
  - this was done as part of e42d0f978062a9f01193ccfcfb0fbb4996465089 (#1878), but there is no commit message or PR description
    - I assume this may have been due to a problem with native HTML state, such as with `select`s, as described in [this SO answer](https://stackoverflow.com/a/55888908/3431180) and [this old Lit issue](https://github.com/lit/lit-element/issues/805#issuecomment-605554546), but this seems to no longer be necessary as the declarative code works fine for me when testing
    
## Verification
Re-tested the dropdown locally and it updated the script correctly every time I changed it

<!-- gk-ai-analysis-start:f37b0fbe101a9cfda2e22d2dbcf4cc37be540b76 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiUmVmYWN0b3JzIHRoZSBQYWxpIHNjcmlwdCBzZWxlY3RvciBpbiBgc2MtdG9wLXNoZWV0LXZpZXdzYCB0byB1c2UgTGl0J3MgZGVjbGFyYXRpdmUgZXZlbnQgYmluZGluZ3MgYW5kIHByb3BlcnR5IHJlbmRlcmluZyBpbnN0ZWFkIG9mIGltcGVyYXRpdmUgRE9NIG1hbmlwdWxhdGlvbi4iLCJrZXlJbnNpZ2h0cyI6W3sidGl0bGUiOiJEZWNsYXJhdGl2ZSBldmVudCBiaW5kaW5nIGFuZCBwcm9wZXJ0eSBhc3NpZ25tZW50IiwiZGVzY3JpcHRpb24iOiJUaGUgUGFsaSBzY3JpcHQgYDxzZWxlY3Q+YCBub3cgdXNlcyBgQGNoYW5nZWAgZm9yIGV2ZW50IGJpbmRpbmcgYW5kIGA/c2VsZWN0ZWRgIGZvciBzZXR0aW5nIHRoZSBzZWxlY3RlZCBvcHRpb24gZGlyZWN0bHkgd2l0aGluIHRoZSBMaXQgdGVtcGxhdGUsIHJlcGxhY2luZyBtYW51YWwgYGFkZEV2ZW50TGlzdGVuZXJgIGFuZCBpbXBlcmF0aXZlIERPTSB1cGRhdGVzLiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJjbGllbnQvZWxlbWVudHMvYWRkb25zL3NjLXRvcC1zaGVldC12aWV3cy5qcyIsImxpbmVTdGFydCI6NjYyfSx7InRpdGxlIjoiUmVtb3ZhbCBvZiBpbXBlcmF0aXZlIHN0YXRlIHN5bmMiLCJkZXNjcmlwdGlvbiI6IlJlbW92ZWQgYCNzZXRQYWxpU2NyaXB0U2VsZWN0ZWQoKWAgYW5kIG1hbnVhbCBzZXR1cCBpbiBgZmlyc3RVcGRhdGVkYCwgc2ltcGxpZnlpbmcgdGhlIGxpZmVjeWNsZSBhbmQgcmVkdWNpbmcgY29kZSBvdmVyaGVhZC4iLCJzZXZlcml0eSI6ImxvdyIsImZpbGVQYXRoIjoiY2xpZW50L2VsZW1lbnRzL2FkZG9ucy9zYy10b3Atc2hlZXQtdmlld3MuanMiLCJsaW5lU3RhcnQiOjg4OX1dLCJpc3N1ZXMiOltdLCJzdWdnZXN0aW9ucyI6W10sInNlY3VyaXR5IjpbXX0= -->
<!-- gk-ai-analysis-end:f37b0fbe101a9cfda2e22d2dbcf4cc37be540b76 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/suttacentral/suttacentral/pull/3739?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->